### PR TITLE
GitHub routes with multi-repo support

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ const routes = {};
 require('./lib/routes/status').register(routes, config);
 require('./lib/routes/journal').register(routes, config);
 require('./lib/routes/events').register(routes, config);
+require('./lib/routes/github').register(routes, config);
 
 // Build HTML page (cached — config doesn't change at runtime)
 let cachedHTML;

--- a/lib/routes/github.js
+++ b/lib/routes/github.js
@@ -1,0 +1,89 @@
+// routes/github.js — /api/github/issues, /api/github/prs
+// Supports 0, 1, or N repos via config.features.github.repos array
+// Uses `gh` CLI with 60-second response cache
+
+const { execSync } = require('child_process');
+const { sendJSON } = require('../helpers');
+
+// Simple in-memory cache with 60s TTL
+const cache = {};
+function cachedExec(key, cmd) {
+  const now = Date.now();
+  if (cache[key] && (now - cache[key].ts) < 60000) {
+    return cache[key].data;
+  }
+  try {
+    const raw = execSync(cmd, { encoding: 'utf-8', timeout: 15000 });
+    const data = JSON.parse(raw);
+    cache[key] = { ts: now, data };
+    return data;
+  } catch (e) {
+    return { _error: e.message, items: [] };
+  }
+}
+
+function register(routes, config) {
+  const github = config.features && config.features.github;
+  if (!github || !Array.isArray(github.repos) || github.repos.length === 0) {
+    // No GitHub repos configured — register stub routes that return empty data
+    routes['GET /api/github/issues'] = (req, res) => {
+      sendJSON(res, 200, { items: [], repos: [] });
+    };
+    routes['GET /api/github/prs'] = (req, res) => {
+      sendJSON(res, 200, { items: [], repos: [] });
+    };
+    return;
+  }
+
+  const repos = github.repos;
+
+  routes['GET /api/github/issues'] = (req, res) => {
+    const allItems = [];
+    const errors = [];
+    for (const repo of repos) {
+      const result = cachedExec(
+        `issues:${repo}`,
+        `gh issue list --repo ${repo} --state open --json number,title,labels,createdAt,updatedAt,url --limit 50`
+      );
+      if (result._error) {
+        errors.push({ repo, error: result._error });
+      } else if (Array.isArray(result)) {
+        for (const item of result) {
+          item.repo = repo;
+          allItems.push(item);
+        }
+      }
+    }
+    // Sort by createdAt descending (newest first)
+    allItems.sort((a, b) => (b.createdAt || '').localeCompare(a.createdAt || ''));
+    const response = { items: allItems, repos };
+    if (errors.length > 0) response.errors = errors;
+    sendJSON(res, 200, response);
+  };
+
+  routes['GET /api/github/prs'] = (req, res) => {
+    const allItems = [];
+    const errors = [];
+    for (const repo of repos) {
+      const result = cachedExec(
+        `prs:${repo}`,
+        `gh pr list --repo ${repo} --state all --json number,title,state,createdAt,mergedAt,url --limit 20`
+      );
+      if (result._error) {
+        errors.push({ repo, error: result._error });
+      } else if (Array.isArray(result)) {
+        for (const item of result) {
+          item.repo = repo;
+          allItems.push(item);
+        }
+      }
+    }
+    // Sort by createdAt descending (newest first)
+    allItems.sort((a, b) => (b.createdAt || '').localeCompare(a.createdAt || ''));
+    const response = { items: allItems, repos };
+    if (errors.length > 0) response.errors = errors;
+    sendJSON(res, 200, response);
+  };
+}
+
+module.exports = { register };

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -401,6 +401,7 @@ async function loadGitHub() {
     if (issues.length === 0) {
       html += '<div style="color:#999;font-size:14px;padding:12px 0">No open issues' + (issuesData.error ? ' (error: ' + escapeHtml(issuesData.error) + ')' : '') + '</div>';
     } else {
+      const multiRepo = issuesData.repos && issuesData.repos.length > 1;
       issues.forEach(function(issue) {
         const labels = (issue.labels || []).map(function(l) {
           const lname = typeof l === 'string' ? l : (l.name || '');
@@ -408,9 +409,11 @@ async function loadGitHub() {
           return '<span class="gh-label" style="background:#' + escapeHtml(color) + '22;color:#' + escapeHtml(color) + '">' + escapeHtml(lname) + '</span>';
         }).join('');
         const url = issue.url || '#';
+        const repoLabel = multiRepo && issue.repo ? '<span class="gh-label" style="background:#e3f2fd;color:#1565c0">' + escapeHtml(issue.repo.split('/').pop()) + '</span>' : '';
         html += '<div class="gh-item">'
           + '<span class="number">#' + issue.number + '</span>'
           + '<a href="' + escapeHtml(url) + '" target="_blank" rel="noopener">' + escapeHtml(issue.title) + '</a>'
+          + repoLabel
           + labels
           + '<span class="date">' + formatShortDate(issue.createdAt) + '</span>'
           + '</div>';
@@ -424,6 +427,7 @@ async function loadGitHub() {
     if (prs.length === 0) {
       html += '<div style="color:#999;font-size:14px;padding:12px 0">No PRs' + (prsData.error ? ' (error: ' + escapeHtml(prsData.error) + ')' : '') + '</div>';
     } else {
+      const multiRepoPr = prsData.repos && prsData.repos.length > 1;
       prs.forEach(function(pr) {
         let stateClass = 'state-open';
         let stateLabel = 'open';
@@ -431,9 +435,11 @@ async function loadGitHub() {
         else if (pr.state === 'CLOSED') { stateClass = 'state-closed'; stateLabel = 'closed'; }
         const prUrl = pr.url || '#';
         const dateStr = pr.mergedAt ? formatShortDate(pr.mergedAt) : formatShortDate(pr.createdAt);
+        const prRepoLabel = multiRepoPr && pr.repo ? '<span class="gh-label" style="background:#e3f2fd;color:#1565c0">' + escapeHtml(pr.repo.split('/').pop()) + '</span>' : '';
         html += '<div class="gh-item">'
           + '<span class="number">#' + pr.number + '</span>'
           + '<a href="' + escapeHtml(prUrl) + '" target="_blank" rel="noopener">' + escapeHtml(pr.title) + '</a>'
+          + prRepoLabel
           + '<span class="state-badge ' + stateClass + '">' + stateLabel + '</span>'
           + '<span class="date">' + dateStr + '</span>'
           + '</div>';

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -25,6 +25,7 @@ function createTestServer(configOverrides = {}) {
   require('../lib/routes/status').register(routes, config);
   require('../lib/routes/journal').register(routes, config);
   require('../lib/routes/events').register(routes, config);
+  require('../lib/routes/github').register(routes, config);
 
   return { server: createServer(config, { routes, getHTML: () => '<html>test</html>' }), config };
 }
@@ -236,5 +237,32 @@ describe('GET /api/wins', () => {
     assert.ok(Array.isArray(data));
     // Fixture win is from 2026-02-01 which may or may not be within 30 days
     // depending on when tests run — just verify it's an array
+  });
+});
+
+describe('GET /api/github/* (no repos configured)', () => {
+  let server, port;
+
+  before(async () => {
+    const result = createTestServer(); // features: {} means no github
+    server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    port = server.address().port;
+  });
+
+  after(() => server.close());
+
+  it('returns empty items for /api/github/issues', async () => {
+    const { status, data } = await fetchJSON(port, '/api/github/issues');
+    assert.equal(status, 200);
+    assert.ok(Array.isArray(data.items));
+    assert.equal(data.items.length, 0);
+  });
+
+  it('returns empty items for /api/github/prs', async () => {
+    const { status, data } = await fetchJSON(port, '/api/github/prs');
+    assert.equal(status, 200);
+    assert.ok(Array.isArray(data.items));
+    assert.equal(data.items.length, 0);
   });
 });


### PR DESCRIPTION
## Summary
- Add `lib/routes/github.js` with `/api/github/issues` and `/api/github/prs` routes
- Support 0, 1, or N repos via `config.features.github.repos` array
- 60-second in-memory cache for gh CLI responses
- Multi-repo: items tagged with `repo` field, frontend shows repo name badges
- Stub routes return empty data when no repos configured
- 2 new integration tests for no-repos-configured case

## Test plan
- [x] All 66 tests pass
- [x] Stub routes return `{ items: [], repos: [] }` when no github configured
- [x] Frontend loadGitHub() checks `PORTAL_CONFIG.hasGitHub` before fetching

Refs #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)