### PR TITLE
Cron toggle + cycle control routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ require('./lib/routes/status').register(routes, config);
 require('./lib/routes/journal').register(routes, config);
 require('./lib/routes/events').register(routes, config);
 require('./lib/routes/github').register(routes, config);
+require('./lib/routes/cycle').register(routes, config);
 
 // Build HTML page (cached — config doesn't change at runtime)
 let cachedHTML;

--- a/lib/routes/cycle.js
+++ b/lib/routes/cycle.js
@@ -1,0 +1,89 @@
+// routes/cycle.js — /api/cron/toggle, /api/cycle/run, /api/cycle/respond
+// Controls cron schedule and triggers wake cycles
+
+const fs = require('fs');
+const path = require('path');
+const { spawn } = require('child_process');
+const { sendJSON } = require('../helpers');
+const { isCycleLocked } = require('../cron');
+
+function register(routes, config) {
+  const cronFile = config.cronFile;
+  const lockFile = config.lockFile;
+  const agentDir = config.agentDir;
+
+  // POST /api/cron/toggle — enable or disable the cron wake schedule
+  routes['POST /api/cron/toggle'] = (req, res) => {
+    if (!cronFile) {
+      return sendJSON(res, 400, { error: 'No cron file configured' });
+    }
+    try {
+      const content = fs.readFileSync(cronFile, 'utf-8');
+      const lines = content.split('\n');
+      const hasActive = lines.some(l => l.includes('wake.sh') && !l.startsWith('#'));
+      const hasCommented = lines.some(l => l.startsWith('#') && l.includes('wake.sh'));
+
+      let newLines;
+      let enabled;
+      if (hasActive) {
+        // Disable: comment out the wake.sh line
+        newLines = lines.map(l => (l.includes('wake.sh') && !l.startsWith('#')) ? '# ' + l : l);
+        enabled = false;
+      } else if (hasCommented) {
+        // Enable: uncomment the wake.sh line
+        newLines = lines.map(l => (l.startsWith('#') && l.includes('wake.sh')) ? l.replace(/^#\s*/, '') : l);
+        enabled = true;
+      } else {
+        return sendJSON(res, 400, { error: 'No wake.sh entry found in cron file' });
+      }
+
+      fs.writeFileSync(cronFile, newLines.join('\n'));
+      return sendJSON(res, 200, { ok: true, enabled });
+    } catch (e) {
+      return sendJSON(res, 500, { error: 'Failed to toggle cron: ' + e.message });
+    }
+  };
+
+  // POST /api/cycle/run — trigger a full wake cycle
+  routes['POST /api/cycle/run'] = (req, res) => {
+    if (isCycleLocked(lockFile)) {
+      return sendJSON(res, 409, { ok: false, error: 'Cycle already running' });
+    }
+    const wakeScript = path.join(agentDir, 'scripts/wake.sh');
+    try {
+      const child = spawn('bash', [wakeScript], {
+        detached: true,
+        stdio: 'ignore',
+        cwd: agentDir,
+      });
+      child.unref();
+      return sendJSON(res, 200, { ok: true });
+    } catch (e) {
+      return sendJSON(res, 500, { error: 'Failed to start cycle: ' + e.message });
+    }
+  };
+
+  // POST /api/cycle/respond — trigger a respond-only cycle (if respond.sh exists)
+  routes['POST /api/cycle/respond'] = (req, res) => {
+    if (isCycleLocked(lockFile)) {
+      return sendJSON(res, 409, { ok: false, error: 'Cycle already running' });
+    }
+    const respondScript = path.join(agentDir, 'scripts/respond.sh');
+    if (!fs.existsSync(respondScript)) {
+      return sendJSON(res, 404, { ok: false, error: 'respond.sh not found' });
+    }
+    try {
+      const child = spawn('bash', [respondScript], {
+        detached: true,
+        stdio: 'ignore',
+        cwd: agentDir,
+      });
+      child.unref();
+      return sendJSON(res, 200, { ok: true });
+    } catch (e) {
+      return sendJSON(res, 500, { error: 'Failed to start respond cycle: ' + e.message });
+    }
+  };
+}
+
+module.exports = { register };

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -162,6 +162,12 @@ ${authorCSS}
     <span id="status-dot" class="status-dot status-red" title="Unknown"></span>
   </div>
   <div id="next-run">Next run: loading...</div>
+  <div id="cron-toggle-wrap" style="padding:4px 16px 8px;display:none"><button id="cron-toggle-btn" class="refresh-btn" style="width:100%" onclick="toggleCron()">Loading...</button></div>
+  <div style="padding:4px 16px 8px;display:flex;gap:6px">
+    <button id="run-cycle-btn" class="refresh-btn" style="flex:1" onclick="runCycle()">Run Cycle</button>
+    <button id="run-respond-btn" class="refresh-btn" style="flex:1" onclick="runRespond()">Respond</button>
+  </div>
+  <div id="cycle-status" style="padding:0 16px 8px;font-size:12px;display:none"><span id="cycle-status-text"></span></div>
   <div id="quick-stats">
     <span id="stat-issues" style="display:none">-- issues open</span>
     <span id="stat-prs" style="display:none">-- PRs open</span>
@@ -223,6 +229,27 @@ async function updateStatusDot() {
       dot.className = 'status-dot status-red';
       dot.title = 'No cycle data';
     }
+
+    // Cycle running indicator
+    const cycleEl = document.getElementById('cycle-status');
+    const cycleText = document.getElementById('cycle-status-text');
+    const cycleBtn = document.getElementById('run-cycle-btn');
+    const respondBtn = document.getElementById('run-respond-btn');
+    if (data.cycleRunning) {
+      cycleEl.style.display = 'block';
+      cycleText.innerHTML = '<span class="status-dot status-green" style="width:8px;height:8px;vertical-align:middle;margin-right:4px"></span>Agent running';
+      cycleText.style.color = '#2e7d32';
+      cycleBtn.disabled = true;
+      respondBtn.disabled = true;
+      cycleBtn.style.opacity = '0.5';
+      respondBtn.style.opacity = '0.5';
+    } else {
+      cycleEl.style.display = 'none';
+      cycleBtn.disabled = false;
+      respondBtn.disabled = false;
+      cycleBtn.style.opacity = '1';
+      respondBtn.style.opacity = '1';
+    }
   } catch {}
 }
 
@@ -263,7 +290,64 @@ async function loadNextRun() {
       el.style.color = '#888';
     }
     el.title = 'Cron: ' + (data.cron || 'none');
+
+    // Update toggle button
+    const toggleWrap = document.getElementById('cron-toggle-wrap');
+    const toggleBtn = document.getElementById('cron-toggle-btn');
+    if (data.installed && data.daemonRunning !== false) {
+      toggleWrap.style.display = 'block';
+      if (data.enabled === false) {
+        toggleBtn.textContent = 'Enable Cron';
+        toggleBtn.style.background = '#e8f5e9';
+        toggleBtn.style.color = '#2e7d32';
+      } else {
+        toggleBtn.textContent = 'Disable Cron';
+        toggleBtn.style.background = '#fff';
+        toggleBtn.style.color = '#555';
+      }
+    } else {
+      toggleWrap.style.display = 'none';
+    }
   } catch {}
+}
+
+async function toggleCron() {
+  const btn = document.getElementById('cron-toggle-btn');
+  btn.disabled = true;
+  btn.textContent = 'Toggling...';
+  try {
+    await fetch('/api/cron/toggle', { method: 'POST' });
+  } catch {}
+  btn.disabled = false;
+  await loadNextRun();
+}
+
+async function runCycle() {
+  const btn = document.getElementById('run-cycle-btn');
+  btn.disabled = true;
+  btn.textContent = 'Starting...';
+  try {
+    const res = await fetch('/api/cycle/run', { method: 'POST' });
+    const data = await res.json();
+    if (!data.ok) alert(data.error || 'Failed to start cycle');
+  } catch { alert('Request failed'); }
+  btn.disabled = false;
+  btn.textContent = 'Run Cycle';
+  updateStatusDot();
+}
+
+async function runRespond() {
+  const btn = document.getElementById('run-respond-btn');
+  btn.disabled = true;
+  btn.textContent = 'Starting...';
+  try {
+    const res = await fetch('/api/cycle/respond', { method: 'POST' });
+    const data = await res.json();
+    if (!data.ok) alert(data.error || 'Failed to start respond cycle');
+  } catch { alert('Request failed'); }
+  btn.disabled = false;
+  btn.textContent = 'Respond';
+  updateStatusDot();
 }
 
 // --- Quick stats ---

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -26,6 +26,7 @@ function createTestServer(configOverrides = {}) {
   require('../lib/routes/journal').register(routes, config);
   require('../lib/routes/events').register(routes, config);
   require('../lib/routes/github').register(routes, config);
+  require('../lib/routes/cycle').register(routes, config);
 
   return { server: createServer(config, { routes, getHTML: () => '<html>test</html>' }), config };
 }
@@ -264,5 +265,89 @@ describe('GET /api/github/* (no repos configured)', () => {
     assert.equal(status, 200);
     assert.ok(Array.isArray(data.items));
     assert.equal(data.items.length, 0);
+  });
+});
+
+describe('POST /api/cron/toggle', () => {
+  let server, port, tmpDir;
+
+  before(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'portal-cron-test-'));
+    fs.mkdirSync(path.join(tmpDir, 'journals'));
+    fs.mkdirSync(path.join(tmpDir, 'logs'));
+    const cronFile = path.join(tmpDir, 'test-cron');
+    fs.writeFileSync(cronFile, '# cron test\n0 */2 * * * root bash /root/scripts/wake.sh\n');
+
+    const result = createTestServer({ agentDir: tmpDir, cronFile });
+    server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    port = server.address().port;
+  });
+
+  after(() => {
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('disables cron by commenting wake.sh line', async () => {
+    const { status, data } = await fetchJSON(port, '/api/cron/toggle', {
+      method: 'POST',
+    });
+    assert.equal(status, 200);
+    assert.equal(data.ok, true);
+    assert.equal(data.enabled, false);
+  });
+
+  it('enables cron by uncommenting wake.sh line', async () => {
+    const { status, data } = await fetchJSON(port, '/api/cron/toggle', {
+      method: 'POST',
+    });
+    assert.equal(status, 200);
+    assert.equal(data.ok, true);
+    assert.equal(data.enabled, true);
+  });
+});
+
+describe('POST /api/cycle/run', () => {
+  let server, port;
+
+  before(async () => {
+    // Use a lock file that won't exist (so lock check says "not running")
+    const result = createTestServer({ lockFile: '/tmp/test-portal-lock-nonexistent-cycle' });
+    server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    port = server.address().port;
+  });
+
+  after(() => server.close());
+
+  it('returns 200 when no cycle is running (wake.sh may not exist but spawn succeeds)', async () => {
+    const { status, data } = await fetchJSON(port, '/api/cycle/run', {
+      method: 'POST',
+    });
+    // Should return 200 OK (spawn will succeed even if script doesn't exist)
+    assert.equal(status, 200);
+    assert.equal(data.ok, true);
+  });
+});
+
+describe('POST /api/cycle/respond', () => {
+  let server, port;
+
+  before(async () => {
+    const result = createTestServer({ lockFile: '/tmp/test-portal-lock-nonexistent-respond' });
+    server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    port = server.address().port;
+  });
+
+  after(() => server.close());
+
+  it('returns 404 when respond.sh does not exist', async () => {
+    const { status, data } = await fetchJSON(port, '/api/cycle/respond', {
+      method: 'POST',
+    });
+    assert.equal(status, 404);
+    assert.ok(data.error.includes('respond.sh not found'));
   });
 });

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -107,4 +107,20 @@ describe('buildHTML', () => {
     assert.ok(html.includes('<title>Agent — Agent Portal</title>'));
     assert.ok(html.includes('<h1>Agent</h1>'));
   });
+
+  it('includes cron toggle and cycle control buttons', () => {
+    const html = buildHTML(baseConfig);
+    assert.ok(html.includes('id="cron-toggle-btn"'));
+    assert.ok(html.includes('id="run-cycle-btn"'));
+    assert.ok(html.includes('id="run-respond-btn"'));
+    assert.ok(html.includes('function toggleCron'));
+    assert.ok(html.includes('function runCycle'));
+    assert.ok(html.includes('function runRespond'));
+  });
+
+  it('includes cycle-running status indicator', () => {
+    const html = buildHTML(baseConfig);
+    assert.ok(html.includes('id="cycle-status"'));
+    assert.ok(html.includes('data.cycleRunning'));
+  });
 });


### PR DESCRIPTION
## Summary
- Add `lib/routes/cycle.js` with cron toggle, wake cycle trigger, and respond cycle trigger
- POST /api/cron/toggle: comments/uncomments wake.sh line in cron file
- POST /api/cycle/run: spawns detached wake.sh process (checks lock first)
- POST /api/cycle/respond: spawns detached respond.sh (checks existence + lock)
- Update sidebar UI with cron toggle button, Run Cycle / Respond buttons, running indicator
- 6 new tests (cron enable/disable, cycle run, respond 404)

## Test plan
- [x] All 72 tests pass (`node --test test/*.test.js`)
- [x] Cron toggle test: disables then re-enables cron
- [x] Cycle run returns 200 OK
- [x] Respond returns 404 when script missing
- [x] UI includes all new buttons and JS functions

Refs #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)