### PR TITLE
Roadmap + Health routes and tabs

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,8 @@ require('./lib/routes/journal').register(routes, config);
 require('./lib/routes/events').register(routes, config);
 require('./lib/routes/github').register(routes, config);
 require('./lib/routes/cycle').register(routes, config);
+require('./lib/routes/roadmap').register(routes, config);
+require('./lib/routes/health').register(routes, config);
 
 // Build HTML page (cached — config doesn't change at runtime)
 let cachedHTML;

--- a/lib/routes/health.js
+++ b/lib/routes/health.js
@@ -1,0 +1,22 @@
+// routes/health.js — Serves health check data from health.jsonl
+// Registered when features.health is true
+
+const path = require('path');
+const { sendJSON, readLastLines } = require('../helpers');
+
+function register(routes, config) {
+  if (!config.features || !config.features.health) return;
+
+  const agentDir = config.agentDir || '.';
+
+  routes['GET /api/health'] = (req, res) => {
+    const lines = readLastLines(path.join(agentDir, 'logs', 'health.jsonl'), 50);
+    const entries = [];
+    for (const line of lines) {
+      try { entries.push(JSON.parse(line)); } catch {}
+    }
+    sendJSON(res, 200, entries);
+  };
+}
+
+module.exports = { register };

--- a/lib/routes/roadmap.js
+++ b/lib/routes/roadmap.js
@@ -1,0 +1,24 @@
+// routes/roadmap.js — Serves roadmap.md content
+// Registered when features.roadmap is true
+
+const fs = require('fs');
+const path = require('path');
+const { sendJSON } = require('../helpers');
+
+function register(routes, config) {
+  if (!config.features || !config.features.roadmap) return;
+
+  const agentDir = config.agentDir || '.';
+
+  routes['GET /api/roadmap'] = (req, res) => {
+    const roadmapPath = path.join(agentDir, 'roadmap.md');
+    try {
+      const content = fs.readFileSync(roadmapPath, 'utf-8');
+      sendJSON(res, 200, { content });
+    } catch {
+      sendJSON(res, 200, { content: '*No roadmap.md found.*' });
+    }
+  };
+}
+
+module.exports = { register };

--- a/lib/ui/shell.js
+++ b/lib/ui/shell.js
@@ -4,6 +4,8 @@
 const { getStyles } = require('./styles');
 const { getClientCore } = require('./client-core');
 const { getGitHubTabJS } = require('./tabs/github');
+const { getRoadmapTabJS } = require('./tabs/roadmap');
+const { getHealthTabJS } = require('./tabs/health');
 
 /**
  * Build the full SPA HTML page string from config.
@@ -40,6 +42,16 @@ function buildHTML(config) {
   if (tabs.includes('github')) {
     tabJS += getGitHubTabJS();
     tabLoaderEntries.push(`github: loadGitHub`);
+  }
+
+  if (tabs.includes('roadmap')) {
+    tabJS += getRoadmapTabJS();
+    tabLoaderEntries.push(`roadmap: loadRoadmap`);
+  }
+
+  if (tabs.includes('health')) {
+    tabJS += getHealthTabJS();
+    tabLoaderEntries.push(`health: loadHealth`);
   }
 
   // Build the TAB_LOADERS map

--- a/lib/ui/tabs/health.js
+++ b/lib/ui/tabs/health.js
@@ -1,0 +1,42 @@
+// tabs/health.js — Health tab client-side JS
+// Renders health check entries in a reverse-chronological table
+
+function getHealthTabJS() {
+  return `
+// --- Health tab ---
+async function loadHealth() {
+  const contentEl = document.getElementById('content');
+  contentEl.innerHTML = '<div class="empty">Loading health data...</div>';
+  try {
+    const res = await fetch('/api/health');
+    const entries = await res.json();
+    let html = '<div class="status-section"><h2>Health Checks</h2>';
+    if (!Array.isArray(entries) || entries.length === 0) {
+      html += '<div style="color:#999;font-size:14px;padding:8px 0">No health check data yet.</div>';
+    } else {
+      html += '<table class="md-content" style="width:100%;border-collapse:collapse">';
+      html += '<thead><tr><th>Timestamp</th><th>Project</th><th>Endpoint</th><th>Status</th><th>Latency</th><th>OK</th></tr></thead><tbody>';
+      entries.slice().reverse().forEach(function(e) {
+        const okLabel = e.ok ? '\\u2713' : '\\u2717';
+        const okColor = e.ok ? '#2e7d32' : '#c62828';
+        html += '<tr>'
+          + '<td>' + formatTimestamp(e.ts || '') + '</td>'
+          + '<td>' + escapeHtml(e.project || '') + '</td>'
+          + '<td style="font-family:monospace;font-size:12px">' + escapeHtml(e.endpoint || '') + '</td>'
+          + '<td>' + (e.status || '\\u2014') + '</td>'
+          + '<td>' + (e.latency_ms != null ? e.latency_ms + 'ms' : '\\u2014') + '</td>'
+          + '<td style="color:' + okColor + ';font-weight:bold">' + okLabel + '</td>'
+          + '</tr>';
+      });
+      html += '</tbody></table>';
+    }
+    html += '</div>';
+    contentEl.innerHTML = html;
+  } catch (err) {
+    contentEl.innerHTML = '<div class="empty">Failed to load health data</div>';
+  }
+}
+`;
+}
+
+module.exports = { getHealthTabJS };

--- a/lib/ui/tabs/roadmap.js
+++ b/lib/ui/tabs/roadmap.js
@@ -1,0 +1,23 @@
+// tabs/roadmap.js — Roadmap tab client-side JS
+// Renders roadmap.md markdown in a card
+
+function getRoadmapTabJS() {
+  return `
+// --- Roadmap tab ---
+async function loadRoadmap() {
+  const contentEl = document.getElementById('content');
+  contentEl.innerHTML = '<div class="empty">Loading roadmap...</div>';
+  try {
+    const res = await fetch('/api/roadmap');
+    const data = await res.json();
+    contentEl.innerHTML = '<div class="status-section"><div class="status-card"><div class="md-content">' + marked.parse(data.content || '*No roadmap.md*') + '</div></div></div>';
+    contentEl.querySelectorAll('.md-content a').forEach(function(a) { a.target = '_blank'; a.rel = 'noopener'; });
+    contentEl.scrollTop = 0;
+  } catch (err) {
+    contentEl.innerHTML = '<div class="empty">Failed to load roadmap</div>';
+  }
+}
+`;
+}
+
+module.exports = { getRoadmapTabJS };

--- a/test/fixtures/logs/health.jsonl
+++ b/test/fixtures/logs/health.jsonl
@@ -1,0 +1,3 @@
+{"ts":"2026-02-25T10:00:00Z","project":"agentdeals","endpoint":"https://example.com/api/health","status":200,"latency_ms":142,"ok":true}
+{"ts":"2026-02-25T12:00:00Z","project":"agentdeals","endpoint":"https://example.com/api/health","status":200,"latency_ms":98,"ok":true}
+{"ts":"2026-02-26T10:00:00Z","project":"agent-portal","endpoint":"https://example.com/api/status","status":500,"latency_ms":2100,"ok":false}

--- a/test/fixtures/roadmap.md
+++ b/test/fixtures/roadmap.md
@@ -1,0 +1,12 @@
+# Product Roadmap
+
+## Q1 2026
+
+- [x] Launch agent portal
+- [ ] Deploy to all containers
+- [ ] Add health monitoring
+
+## Q2 2026
+
+- [ ] Multi-project support
+- [ ] Telegram notifications

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -32,6 +32,8 @@ function bootPortal(configOverrides = {}) {
   require('../lib/routes/events').register(routes, config);
   require('../lib/routes/github').register(routes, config);
   require('../lib/routes/cycle').register(routes, config);
+  require('../lib/routes/roadmap').register(routes, config);
+  require('../lib/routes/health').register(routes, config);
 
   const getHTML = () => buildHTML(config);
 

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -27,6 +27,8 @@ function createTestServer(configOverrides = {}) {
   require('../lib/routes/events').register(routes, config);
   require('../lib/routes/github').register(routes, config);
   require('../lib/routes/cycle').register(routes, config);
+  require('../lib/routes/roadmap').register(routes, config);
+  require('../lib/routes/health').register(routes, config);
 
   return { server: createServer(config, { routes, getHTML: () => '<html>test</html>' }), config };
 }
@@ -349,5 +351,102 @@ describe('POST /api/cycle/respond', () => {
     });
     assert.equal(status, 404);
     assert.ok(data.error.includes('respond.sh not found'));
+  });
+});
+
+describe('GET /api/roadmap', () => {
+  it('returns roadmap.md content when feature enabled', async () => {
+    const result = createTestServer({ features: { roadmap: true } });
+    const server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    const port = server.address().port;
+
+    const { status, data } = await fetchJSON(port, '/api/roadmap');
+    assert.equal(status, 200);
+    assert.ok(data.content.includes('Product Roadmap'));
+    assert.ok(data.content.includes('Launch agent portal'));
+
+    server.close();
+  });
+
+  it('returns 404 when feature disabled', async () => {
+    const result = createTestServer({ features: {} });
+    const server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    const port = server.address().port;
+
+    const { status } = await fetchJSON(port, '/api/roadmap');
+    assert.equal(status, 404);
+
+    server.close();
+  });
+
+  it('returns fallback content when roadmap.md missing', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'portal-roadmap-'));
+    fs.mkdirSync(path.join(tmpDir, 'journals'));
+    fs.mkdirSync(path.join(tmpDir, 'logs'));
+
+    const result = createTestServer({ agentDir: tmpDir, features: { roadmap: true } });
+    const server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    const port = server.address().port;
+
+    const { status, data } = await fetchJSON(port, '/api/roadmap');
+    assert.equal(status, 200);
+    assert.ok(data.content.includes('No roadmap.md found'));
+
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+});
+
+describe('GET /api/health', () => {
+  it('returns health entries when feature enabled', async () => {
+    const result = createTestServer({ features: { health: true } });
+    const server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    const port = server.address().port;
+
+    const { status, data } = await fetchJSON(port, '/api/health');
+    assert.equal(status, 200);
+    assert.ok(Array.isArray(data));
+    assert.equal(data.length, 3);
+    assert.equal(data[0].project, 'agentdeals');
+    assert.equal(data[0].ok, true);
+    assert.equal(data[2].ok, false);
+    assert.equal(data[2].status, 500);
+
+    server.close();
+  });
+
+  it('returns 404 when feature disabled', async () => {
+    const result = createTestServer({ features: {} });
+    const server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    const port = server.address().port;
+
+    const { status } = await fetchJSON(port, '/api/health');
+    assert.equal(status, 404);
+
+    server.close();
+  });
+
+  it('returns empty array when health.jsonl missing', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'portal-health-'));
+    fs.mkdirSync(path.join(tmpDir, 'journals'));
+    fs.mkdirSync(path.join(tmpDir, 'logs'));
+
+    const result = createTestServer({ agentDir: tmpDir, features: { health: true } });
+    const server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    const port = server.address().port;
+
+    const { status, data } = await fetchJSON(port, '/api/health');
+    assert.equal(status, 200);
+    assert.ok(Array.isArray(data));
+    assert.equal(data.length, 0);
+
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
   });
 });

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -133,4 +133,36 @@ describe('buildHTML', () => {
     assert.ok(html.includes('id="cycle-status"'));
     assert.ok(html.includes('data.cycleRunning'));
   });
+
+  it('includes roadmap tab JS when configured', () => {
+    const config = {
+      ...baseConfig,
+      features: { tabs: ['journal', 'roadmap', 'status'], roadmap: true },
+    };
+    const html = buildHTML(config);
+    assert.ok(html.includes('data-tab="roadmap"'));
+    assert.ok(html.includes('function loadRoadmap'));
+    assert.ok(html.includes('roadmap: loadRoadmap'));
+  });
+
+  it('excludes roadmap tab JS when not configured', () => {
+    const html = buildHTML(baseConfig);
+    assert.ok(!html.includes('function loadRoadmap'));
+  });
+
+  it('includes health tab JS when configured', () => {
+    const config = {
+      ...baseConfig,
+      features: { tabs: ['journal', 'health', 'status'], health: true },
+    };
+    const html = buildHTML(config);
+    assert.ok(html.includes('data-tab="health"'));
+    assert.ok(html.includes('function loadHealth'));
+    assert.ok(html.includes('health: loadHealth'));
+  });
+
+  it('excludes health tab JS when not configured', () => {
+    const html = buildHTML(baseConfig);
+    assert.ok(!html.includes('function loadHealth'));
+  });
 });


### PR DESCRIPTION
## Summary
- Add `GET /api/roadmap` — serves `roadmap.md` content (opt-in via `features.roadmap`)
- Add `GET /api/health` — serves parsed `health.jsonl` entries (opt-in via `features.health`)
- Roadmap tab renders markdown in a card; Health tab renders reverse-chronological table
- Both conditionally included in HTML via TAB_LOADERS
- 10 new tests, 97 total passing

## Test plan
- [x] All 97 tests pass
- [x] Roadmap route serves fixture content, returns fallback when file missing
- [x] Health route parses JSONL correctly, returns empty array when file missing
- [x] Both routes return 404 when feature flags are disabled
- [x] UI tests verify tab JS included/excluded based on config

Refs #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)