### PR TITLE
Requests route and tab

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ require('./lib/routes/github').register(routes, config);
 require('./lib/routes/cycle').register(routes, config);
 require('./lib/routes/roadmap').register(routes, config);
 require('./lib/routes/health').register(routes, config);
+require('./lib/routes/requests').register(routes, config);
 
 // Build HTML page (cached — config doesn't change at runtime)
 let cachedHTML;

--- a/lib/routes/requests.js
+++ b/lib/routes/requests.js
@@ -1,0 +1,96 @@
+// routes/requests.js — PM request management
+// GET /api/requests — list request files with metadata
+// POST /api/requests/reply — reply to a request + cross-post to journal
+// Registered when features.requests is true
+
+const fs = require('fs');
+const path = require('path');
+const { sendJSON, readBody } = require('../helpers');
+
+function register(routes, config) {
+  if (!config.features || !config.features.requests) return;
+
+  const agentDir = config.agentDir || '.';
+  const requestsDir = path.join(agentDir, 'requests');
+
+  routes['GET /api/requests'] = (req, res) => {
+    const requests = [];
+    try {
+      const files = fs.readdirSync(requestsDir)
+        .filter(f => f.endsWith('.md') && f !== '_template.md')
+        .sort();
+      for (const file of files) {
+        const content = fs.readFileSync(path.join(requestsDir, file), 'utf-8');
+        const titleMatch = content.match(/^#\s+(.+)/m);
+        const statusMatch = content.match(/\*\*Status:\*\*\s*(\w+)/);
+        const filedMatch = content.match(/\*\*Filed:\*\*\s*(.+)/);
+        requests.push({
+          file,
+          title: titleMatch ? titleMatch[1].replace(/^Request:\s*/i, '') : file.replace(/\.md$/, ''),
+          status: statusMatch ? statusMatch[1] : 'unknown',
+          filed: filedMatch ? filedMatch[1].trim() : null,
+          content,
+        });
+      }
+    } catch {}
+    sendJSON(res, 200, { items: requests });
+  };
+
+  routes['POST /api/requests/reply'] = async (req, res) => {
+    let body;
+    try {
+      body = JSON.parse(await readBody(req));
+    } catch {
+      return sendJSON(res, 400, { error: 'Invalid JSON' });
+    }
+
+    const file = (body.file || '').trim();
+    const comment = (body.comment || '').trim();
+
+    if (!file || !comment) {
+      return sendJSON(res, 400, { error: 'file and comment are required' });
+    }
+
+    // Path traversal protection
+    if (file.includes('/') || file.includes('\\') || file.includes('..')) {
+      return sendJSON(res, 400, { error: 'Invalid filename' });
+    }
+
+    const filePath = path.join(requestsDir, file);
+    if (!fs.existsSync(filePath)) {
+      return sendJSON(res, 404, { error: 'Request file not found' });
+    }
+
+    // Read request file to extract title for journal cross-post
+    let content = fs.readFileSync(filePath, 'utf-8');
+    const titleMatch = content.match(/^#\s+(.+)/m);
+    const title = titleMatch ? titleMatch[1].replace(/^Request:\s*/i, '') : file.replace(/\.md$/, '');
+
+    const now = new Date();
+    const ts = now.toISOString();
+
+    // Append response to request file
+    content += '\n## Response — ' + ts + '\n\n' + comment + '\n';
+    fs.writeFileSync(filePath, content);
+
+    // Cross-post to journal
+    const yyyy = now.getFullYear();
+    const mm = String(now.getMonth() + 1).padStart(2, '0');
+    const filename = `${yyyy}-${mm}.md`;
+    const journalsDir = path.join(agentDir, 'journals');
+    const journalPath = path.join(journalsDir, filename);
+    const journalText = 'Re: ' + title + '\n\n' + comment;
+    const entry = `\n### ${ts} | rob | direction\n${journalText}\n`;
+
+    if (!fs.existsSync(journalPath)) {
+      const header = `# ${config.name || 'Agent'} Journal — ${yyyy}-${mm}\n\n---\n`;
+      fs.writeFileSync(journalPath, header + entry);
+    } else {
+      fs.appendFileSync(journalPath, entry);
+    }
+
+    sendJSON(res, 200, { ok: true, ts });
+  };
+}
+
+module.exports = { register };

--- a/lib/ui/shell.js
+++ b/lib/ui/shell.js
@@ -6,6 +6,7 @@ const { getClientCore } = require('./client-core');
 const { getGitHubTabJS } = require('./tabs/github');
 const { getRoadmapTabJS } = require('./tabs/roadmap');
 const { getHealthTabJS } = require('./tabs/health');
+const { getRequestsTabJS } = require('./tabs/requests');
 
 /**
  * Build the full SPA HTML page string from config.
@@ -52,6 +53,11 @@ function buildHTML(config) {
   if (tabs.includes('health')) {
     tabJS += getHealthTabJS();
     tabLoaderEntries.push(`health: loadHealth`);
+  }
+
+  if (tabs.includes('requests')) {
+    tabJS += getRequestsTabJS();
+    tabLoaderEntries.push(`requests: loadRequests`);
   }
 
   // Build the TAB_LOADERS map

--- a/lib/ui/tabs/requests.js
+++ b/lib/ui/tabs/requests.js
@@ -1,0 +1,76 @@
+// tabs/requests.js — Requests tab client-side JS
+// Renders PM request list with status badges, markdown content, and reply forms
+
+function getRequestsTabJS() {
+  return `
+// --- Requests tab ---
+var _requestFiles = [];
+
+async function loadRequests() {
+  var contentEl = document.getElementById('content');
+  contentEl.innerHTML = '<div class="empty">Loading requests...</div>';
+  try {
+    var res = await fetch('/api/requests');
+    var data = await res.json();
+    var items = data.items || [];
+    _requestFiles = items.map(function(r) { return r.file; });
+    var html = '<div class="status-section"><h2>PM Requests</h2>';
+    if (items.length === 0) {
+      html += '<div style="color:#999;font-size:14px;padding:8px 0">No requests filed yet.</div>';
+    } else {
+      items.forEach(function(req, idx) {
+        var statusClass = 'tag-note';
+        if (req.status === 'pending') statusClass = 'tag-question';
+        else if (req.status === 'approved') statusClass = 'tag-output';
+        else if (req.status === 'rejected') statusClass = 'tag-feedback';
+        else if (req.status === 'completed') statusClass = 'tag-outcome';
+        html += '<div class="journal-entry" style="border-left:3px solid #ff9800">'
+          + '<div class="journal-entry-header">'
+          + '<span style="font-weight:600;font-size:14px">' + escapeHtml(req.title) + '</span>'
+          + '<span class="tag-badge ' + statusClass + '">' + escapeHtml(req.status) + '</span>'
+          + (req.filed ? '<span class="timestamp">Filed ' + escapeHtml(req.filed) + '</span>' : '')
+          + '</div>'
+          + '<div class="journal-entry-body md-content">' + marked.parse(req.content) + '</div>';
+
+        // Reply form
+        html += '<div style="margin-top:12px;padding-top:12px;border-top:1px solid #eee">'
+          + '<div style="display:flex;gap:8px;align-items:flex-start;flex-wrap:wrap">'
+          + '<textarea id="reply-comment-' + idx + '" placeholder="Reply..." style="flex:1;min-width:200px;min-height:48px;border:1px solid #ddd;border-radius:6px;padding:6px 8px;font-size:13px;font-family:inherit;resize:vertical"></textarea>'
+          + '<button onclick="replyToRequest(' + idx + ')" style="padding:6px 16px;background:#1a73e8;color:#fff;border:none;border-radius:6px;font-size:13px;cursor:pointer;white-space:nowrap">Reply</button>'
+          + '</div>'
+          + '</div>';
+
+        html += '</div>';
+      });
+    }
+    html += '</div>';
+    contentEl.innerHTML = html;
+    contentEl.querySelectorAll('.md-content a').forEach(function(a) { a.target = '_blank'; a.rel = 'noopener'; });
+    contentEl.scrollTop = 0;
+  } catch (err) {
+    contentEl.innerHTML = '<div class="empty">Failed to load requests</div>';
+  }
+}
+
+async function replyToRequest(idx) {
+  var file = _requestFiles[idx];
+  if (!file) return;
+  var commentEl = document.getElementById('reply-comment-' + idx);
+  if (!commentEl) return;
+  var comment = commentEl.value.trim();
+  if (!comment) { commentEl.style.borderColor = '#c62828'; return; }
+  try {
+    var res = await fetch('/api/requests/reply', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ file: file, comment: comment })
+    });
+    var data = await res.json();
+    if (!data.ok) { alert('Error: ' + (data.error || 'Unknown')); return; }
+  } catch (e) { alert('Network error'); return; }
+  await loadRequests();
+}
+`;
+}
+
+module.exports = { getRequestsTabJS };

--- a/test/fixtures/requests/add-logging.md
+++ b/test/fixtures/requests/add-logging.md
@@ -1,0 +1,12 @@
+# Request: Add structured logging
+
+**Status:** pending
+**Filed:** 2026-02-20
+
+## Description
+
+Add structured JSON logging to the API endpoints for better observability.
+
+## Rationale
+
+Current logging is ad-hoc console.log statements. Structured logging would make it easier to query and monitor.

--- a/test/fixtures/requests/deploy-automation.md
+++ b/test/fixtures/requests/deploy-automation.md
@@ -1,0 +1,12 @@
+# Request: Automate deployment
+
+**Status:** completed
+**Filed:** 2026-02-10
+
+## Description
+
+Set up automated deployment pipeline for the portal package.
+
+## Response — 2026-02-12T14:00:00.000Z
+
+Done. Added update-portal.sh to each agent repo.

--- a/test/fixtures/requests/improve-tests.md
+++ b/test/fixtures/requests/improve-tests.md
@@ -1,0 +1,12 @@
+# Request: Improve test coverage
+
+**Status:** approved
+**Filed:** 2026-02-15
+
+## Description
+
+Increase test coverage to 90%+ across all modules.
+
+## Response — 2026-02-16T10:00:00.000Z
+
+Approved, go ahead. Focus on edge cases in the cron parser first.

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -34,6 +34,7 @@ function bootPortal(configOverrides = {}) {
   require('../lib/routes/cycle').register(routes, config);
   require('../lib/routes/roadmap').register(routes, config);
   require('../lib/routes/health').register(routes, config);
+  require('../lib/routes/requests').register(routes, config);
 
   const getHTML = () => buildHTML(config);
 

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -29,6 +29,7 @@ function createTestServer(configOverrides = {}) {
   require('../lib/routes/cycle').register(routes, config);
   require('../lib/routes/roadmap').register(routes, config);
   require('../lib/routes/health').register(routes, config);
+  require('../lib/routes/requests').register(routes, config);
 
   return { server: createServer(config, { routes, getHTML: () => '<html>test</html>' }), config };
 }
@@ -448,5 +449,137 @@ describe('GET /api/health', () => {
 
     server.close();
     fs.rmSync(tmpDir, { recursive: true });
+  });
+});
+
+describe('GET /api/requests', () => {
+  it('returns request files with metadata when feature enabled', async () => {
+    const result = createTestServer({ features: { requests: true } });
+    const server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    const port = server.address().port;
+
+    const { status, data } = await fetchJSON(port, '/api/requests');
+    assert.equal(status, 200);
+    assert.ok(Array.isArray(data.items));
+    assert.equal(data.items.length, 3);
+    // Sorted alphabetically by filename
+    assert.equal(data.items[0].file, 'add-logging.md');
+    assert.equal(data.items[0].status, 'pending');
+    assert.ok(data.items[0].title.includes('Add structured logging'));
+    assert.equal(data.items[1].file, 'deploy-automation.md');
+    assert.equal(data.items[1].status, 'completed');
+    assert.equal(data.items[2].file, 'improve-tests.md');
+    assert.equal(data.items[2].status, 'approved');
+
+    server.close();
+  });
+
+  it('returns 404 when feature disabled', async () => {
+    const result = createTestServer({ features: {} });
+    const server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    const port = server.address().port;
+
+    const { status } = await fetchJSON(port, '/api/requests');
+    assert.equal(status, 404);
+
+    server.close();
+  });
+
+  it('returns empty items when requests dir missing', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'portal-requests-'));
+    fs.mkdirSync(path.join(tmpDir, 'journals'));
+    fs.mkdirSync(path.join(tmpDir, 'logs'));
+
+    const result = createTestServer({ agentDir: tmpDir, features: { requests: true } });
+    const server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    const port = server.address().port;
+
+    const { status, data } = await fetchJSON(port, '/api/requests');
+    assert.equal(status, 200);
+    assert.ok(Array.isArray(data.items));
+    assert.equal(data.items.length, 0);
+
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+});
+
+describe('POST /api/requests/reply', () => {
+  let server, port, tmpDir;
+
+  before(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'portal-reply-'));
+    fs.mkdirSync(path.join(tmpDir, 'journals'));
+    fs.mkdirSync(path.join(tmpDir, 'logs'));
+    fs.mkdirSync(path.join(tmpDir, 'requests'));
+    fs.writeFileSync(path.join(tmpDir, 'requests', 'test-request.md'),
+      '# Request: Test feature\n\n**Status:** pending\n**Filed:** 2026-02-20\n\nPlease add test feature.\n');
+
+    const result = createTestServer({ agentDir: tmpDir, features: { requests: true } });
+    server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    port = server.address().port;
+  });
+
+  after(() => {
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('appends reply to request file and cross-posts to journal', async () => {
+    const { status, data } = await fetchJSON(port, '/api/requests/reply', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ file: 'test-request.md', comment: 'Approved, proceed.' }),
+    });
+    assert.equal(status, 200);
+    assert.equal(data.ok, true);
+    assert.ok(data.ts);
+
+    // Verify reply appended to request file
+    const reqContent = fs.readFileSync(path.join(tmpDir, 'requests', 'test-request.md'), 'utf-8');
+    assert.ok(reqContent.includes('## Response'));
+    assert.ok(reqContent.includes('Approved, proceed.'));
+
+    // Verify cross-post to journal
+    const now = new Date();
+    const journalFile = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}.md`;
+    const journalContent = fs.readFileSync(path.join(tmpDir, 'journals', journalFile), 'utf-8');
+    assert.ok(journalContent.includes('rob | direction'));
+    assert.ok(journalContent.includes('Re: Test feature'));
+    assert.ok(journalContent.includes('Approved, proceed.'));
+  });
+
+  it('rejects missing file field', async () => {
+    const { status, data } = await fetchJSON(port, '/api/requests/reply', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ comment: 'Hello' }),
+    });
+    assert.equal(status, 400);
+    assert.ok(data.error.includes('required'));
+  });
+
+  it('rejects path traversal', async () => {
+    const { status, data } = await fetchJSON(port, '/api/requests/reply', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ file: '../../../etc/passwd', comment: 'attack' }),
+    });
+    assert.equal(status, 400);
+    assert.ok(data.error.includes('Invalid filename'));
+  });
+
+  it('returns 404 for nonexistent request file', async () => {
+    const { status, data } = await fetchJSON(port, '/api/requests/reply', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ file: 'nonexistent.md', comment: 'Hello' }),
+    });
+    assert.equal(status, 404);
+    assert.ok(data.error.includes('not found'));
   });
 });

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -165,4 +165,21 @@ describe('buildHTML', () => {
     const html = buildHTML(baseConfig);
     assert.ok(!html.includes('function loadHealth'));
   });
+
+  it('includes requests tab JS when configured', () => {
+    const config = {
+      ...baseConfig,
+      features: { tabs: ['journal', 'requests', 'status'], requests: true },
+    };
+    const html = buildHTML(config);
+    assert.ok(html.includes('data-tab="requests"'));
+    assert.ok(html.includes('function loadRequests'));
+    assert.ok(html.includes('function replyToRequest'));
+    assert.ok(html.includes('requests: loadRequests'));
+  });
+
+  it('excludes requests tab JS when not configured', () => {
+    const html = buildHTML(baseConfig);
+    assert.ok(!html.includes('function loadRequests'));
+  });
 });


### PR DESCRIPTION
## Summary
- Add `GET /api/requests` — lists request `.md` files with parsed title/status/filed metadata
- Add `POST /api/requests/reply` — appends response to request file + cross-posts to journal as `direction` entry
- Requests tab with status badges (pending/approved/rejected/completed), markdown content, inline reply forms
- Path traversal protection on all filename inputs
- 9 new tests, 106 total passing

## Test plan
- [x] All 106 tests pass
- [x] Request list returns sorted files with correct metadata parsing
- [x] Reply appends to request file AND cross-posts to journal
- [x] Path traversal (`../../../etc/passwd`) blocked with 400
- [x] Missing file returns 404
- [x] Routes return 404 when feature flag is disabled
- [x] UI tests verify tab JS included/excluded based on config

Refs #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)