### PR TITLE
Project sidebar + per-project journals

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@ require('./lib/routes/cycle').register(routes, config);
 require('./lib/routes/roadmap').register(routes, config);
 require('./lib/routes/health').register(routes, config);
 require('./lib/routes/requests').register(routes, config);
+require('./lib/routes/projects').register(routes, config);
 
 // Build HTML page (cached — config doesn't change at runtime)
 let cachedHTML;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -86,4 +86,26 @@ function getAllJournalEntries(journalsDir) {
   return allEntries;
 }
 
-module.exports = { sendJSON, readBody, readLastLines, parseJournal, getAllJournalEntries };
+/**
+ * Parse YAML frontmatter from a markdown file.
+ * Returns an object of key-value pairs. Bracket-delimited values
+ * (e.g., [tag1, tag2]) are converted to arrays.
+ */
+function parseFrontmatter(content) {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return {};
+  const fm = {};
+  for (const line of match[1].split('\n')) {
+    const kv = line.match(/^(\w[\w_-]*):\s*(.+)$/);
+    if (kv) {
+      let val = kv[2].trim();
+      if (val.startsWith('[') && val.endsWith(']')) {
+        val = val.slice(1, -1).split(',').map(s => s.trim());
+      }
+      fm[kv[1]] = val;
+    }
+  }
+  return fm;
+}
+
+module.exports = { sendJSON, readBody, readLastLines, parseJournal, getAllJournalEntries, parseFrontmatter };

--- a/lib/routes/projects.js
+++ b/lib/routes/projects.js
@@ -1,0 +1,161 @@
+// projects.js — Project listing, per-project journals, project files
+// Registered when sidebar.type === 'projects'
+
+const fs = require('fs');
+const path = require('path');
+const { sendJSON, readBody, parseJournal, parseFrontmatter } = require('../helpers');
+
+function getOutputFiles(agentDir) {
+  const outputDir = path.join(agentDir, 'output');
+  const feedbackDir = path.join(agentDir, 'input', 'feedback');
+  const processedDir = path.join(feedbackDir, 'processed');
+  try {
+    const files = fs.readdirSync(outputDir)
+      .filter(f => f.endsWith('.md') && f !== '.gitkeep');
+    return files.map(f => {
+      const feedbackFile = f.replace('.md', '.feedback.yaml');
+      const feedbackPath = path.join(feedbackDir, feedbackFile);
+      const processedPath = path.join(processedDir, feedbackFile);
+      const reviewed = fs.existsSync(feedbackPath) || fs.existsSync(processedPath);
+      return { filename: f, reviewed };
+    });
+  } catch {
+    return [];
+  }
+}
+
+function getProjects(agentDir, journalsDir, projectsDir) {
+  try {
+    const files = fs.readdirSync(projectsDir)
+      .filter(f => f.endsWith('.md') && !f.startsWith('_'));
+
+    const priorityOrder = { high: 0, medium: 1, low: 2 };
+    const allOutputs = getOutputFiles(agentDir);
+
+    return files.map(f => {
+      const slug = f.replace('.md', '');
+      const content = fs.readFileSync(path.join(projectsDir, f), 'utf-8');
+      const fm = parseFrontmatter(content);
+
+      const titleMatch = content.match(/^# (.+)$/m);
+      const title = titleMatch ? titleMatch[1] : slug;
+
+      const journalPath = path.join(journalsDir, slug + '.md');
+      let entryCount = 0;
+      let lastActivity = null;
+      if (fs.existsSync(journalPath)) {
+        const journalContent = fs.readFileSync(journalPath, 'utf-8');
+        const entries = parseJournal(journalContent);
+        entryCount = entries.length;
+        if (entries.length > 0) {
+          lastActivity = entries[entries.length - 1].ts;
+        }
+      }
+
+      const projectOutputs = allOutputs.filter(o => o.filename.startsWith(slug));
+      const outputCount = projectOutputs.length;
+      const unreviewedCount = projectOutputs.filter(o => !o.reviewed).length;
+
+      return {
+        slug,
+        title,
+        status: fm.status || 'active',
+        priority: fm.priority || 'medium',
+        tags: Array.isArray(fm.tags) ? fm.tags : [],
+        entryCount,
+        lastActivity,
+        outputCount,
+        unreviewedCount,
+      };
+    }).sort((a, b) => {
+      const pa = priorityOrder[a.priority] ?? 3;
+      const pb = priorityOrder[b.priority] ?? 3;
+      return pa - pb;
+    });
+  } catch {
+    return [];
+  }
+}
+
+function register(routes, config) {
+  if (!config.sidebar || config.sidebar.type !== 'projects') return;
+
+  const agentDir = config.agentDir || '.';
+  const journalsDir = path.join(agentDir, 'journals');
+  const projectsDir = path.join(agentDir, config.sidebar.projectsDir || 'projects');
+
+  // GET /api/projects — list all projects with metadata
+  routes['GET /api/projects'] = (req, res) => {
+    sendJSON(res, 200, getProjects(agentDir, journalsDir, projectsDir));
+  };
+
+  // GET /api/projects/:slug/journal — per-project journal entries
+  routes['GET /api/projects/:slug/journal'] = (req, res) => {
+    const slug = req.params.slug;
+    const journalPath = path.join(journalsDir, slug + '.md');
+    if (!journalPath.startsWith(journalsDir)) {
+      return sendJSON(res, 400, { error: 'Invalid slug' });
+    }
+    if (!fs.existsSync(journalPath)) {
+      return sendJSON(res, 200, { slug, entries: [] });
+    }
+    const content = fs.readFileSync(journalPath, 'utf-8');
+    const entries = parseJournal(content);
+    sendJSON(res, 200, { slug, entries });
+  };
+
+  // POST /api/projects/:slug/journal — append to per-project journal
+  routes['POST /api/projects/:slug/journal'] = (req, res) => {
+    const slug = req.params.slug;
+    const journalPath = path.join(journalsDir, slug + '.md');
+    if (!journalPath.startsWith(journalsDir)) {
+      return sendJSON(res, 400, { error: 'Invalid slug' });
+    }
+
+    readBody(req).then(body => {
+      try {
+        const data = JSON.parse(body);
+        const text = (data.text || '').trim();
+        const tag = (data.tag || 'note').trim();
+        if (!text) {
+          return sendJSON(res, 400, { error: 'Text is required' });
+        }
+        const validTags = ['output', 'feedback', 'outcome', 'observation', 'note', 'direction', 'question'];
+        if (!validTags.includes(tag)) {
+          return sendJSON(res, 400, { error: 'Invalid tag. Must be one of: ' + validTags.join(', ') });
+        }
+
+        const ts = new Date().toISOString();
+        const entry = `\n### ${ts} | rob | ${tag}\n${text}\n`;
+
+        if (!fs.existsSync(journalPath)) {
+          const projectTitle = slug.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+          const header = `# ${projectTitle} — Journal\n\nProject: [${slug}](../projects/${slug}.md)\n\n---\n`;
+          fs.writeFileSync(journalPath, header + entry);
+        } else {
+          fs.appendFileSync(journalPath, entry);
+        }
+
+        sendJSON(res, 200, { ok: true, ts, tag });
+      } catch {
+        sendJSON(res, 400, { error: 'Invalid JSON' });
+      }
+    });
+  };
+
+  // GET /api/projects/:slug/file — raw project definition markdown
+  routes['GET /api/projects/:slug/file'] = (req, res) => {
+    const slug = req.params.slug;
+    const filePath = path.join(projectsDir, slug + '.md');
+    if (!filePath.startsWith(projectsDir)) {
+      return sendJSON(res, 400, { error: 'Invalid slug' });
+    }
+    if (!fs.existsSync(filePath)) {
+      return sendJSON(res, 404, { error: 'Project file not found' });
+    }
+    const content = fs.readFileSync(filePath, 'utf-8');
+    sendJSON(res, 200, { slug, content });
+  };
+}
+
+module.exports = { register };

--- a/lib/ui/shell.js
+++ b/lib/ui/shell.js
@@ -7,6 +7,7 @@ const { getGitHubTabJS } = require('./tabs/github');
 const { getRoadmapTabJS } = require('./tabs/roadmap');
 const { getHealthTabJS } = require('./tabs/health');
 const { getRequestsTabJS } = require('./tabs/requests');
+const { getProjectSidebarJS } = require('./sidebar-projects');
 
 /**
  * Build the full SPA HTML page string from config.
@@ -16,10 +17,13 @@ const { getRequestsTabJS } = require('./tabs/requests');
  * - authors: { name: { color, bg } } for author badge styling
  * - features.github: if present, enables GitHub tab
  * - features.tabs: optional array of tab names to show (default: ["journal", "status"])
+ * - sidebar.type: "simple" (default) or "projects" (Bobbo-style project list)
  */
 function buildHTML(config) {
   const name = config.name || 'Agent';
   const authors = config.authors || {};
+  const sidebarType = (config.sidebar && config.sidebar.type) || 'simple';
+  const hasRunningLog = sidebarType === 'projects' && config.sidebar && config.sidebar.runningLog;
 
   // Determine which tabs to show
   const defaultTabs = ['journal', 'status'];
@@ -60,23 +64,35 @@ function buildHTML(config) {
     tabLoaderEntries.push(`requests: loadRequests`);
   }
 
+  // Project sidebar support
+  let projectSidebarJS = '';
+  if (sidebarType === 'projects') {
+    projectSidebarJS = getProjectSidebarJS();
+    // Override journal loader to use per-project journal when project selected
+    tabLoaderEntries[0] = `journal: loadProjectJournal`;
+    // Add project tab loader
+    if (tabs.includes('project')) {
+      tabLoaderEntries.push(`project: loadProjectFile`);
+    }
+  }
+
   // Build the TAB_LOADERS map
   const tabLoadersJS = `const TAB_LOADERS = { ${tabLoaderEntries.join(', ')} };`;
 
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>${name} — Agent Portal</title>
-<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"><\/script>
-<style>
-${getStyles(authors)}
-</style>
-</head>
-<body>
-
-<div id="sidebar">
+  // Build sidebar HTML based on type
+  let sidebarHTML;
+  if (sidebarType === 'projects') {
+    sidebarHTML = `<div id="sidebar">
+  <h1>${name}</h1>
+  <div id="next-run">Next run: loading...</div>
+  ${hasRunningLog ? `<div id="bobbo-log-item" class="project-item active" onclick="selectBobboLog()">
+    <div class="title">Running Log</div>
+    <div class="meta">Cross-project cycle log</div>
+  </div>` : ''}
+  <div id="project-list"></div>
+</div>`;
+  } else {
+    sidebarHTML = `<div id="sidebar">
   <div id="sidebar-header">
     <h1>${name}</h1>
     <span id="status-dot" class="status-dot status-red" title="Unknown"></span>
@@ -92,7 +108,49 @@ ${getStyles(authors)}
     <span id="stat-issues" style="display:none">-- issues open</span>
     <span id="stat-prs" style="display:none">-- PRs open</span>
   </div>
-</div>
+</div>`;
+  }
+
+  // Build init function based on sidebar type
+  let initJS;
+  if (sidebarType === 'projects') {
+    initJS = `async function init() {
+  await loadProjects();
+  await loadNextRun();
+  ${hasRunningLog ? 'await selectBobboLog();' : 'if (projects.length > 0) await selectProject(projects[0].slug);'}
+}`;
+  } else {
+    initJS = `async function init() {
+  await Promise.all([
+    updateStatusDot(),
+    loadNextRun(),
+    loadQuickStats(),
+  ]);
+  switchTab(currentTab);
+}`;
+  }
+
+  const portalConfig = {
+    name,
+    tabs,
+    hasGitHub: !!(config.features && config.features.github),
+    sidebarType,
+  };
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${name} — Agent Portal</title>
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"><\/script>
+<style>
+${getStyles(authors)}
+</style>
+</head>
+<body>
+
+${sidebarHTML}
 
 <div id="main">
   <div id="tabs">
@@ -102,24 +160,18 @@ ${getStyles(authors)}
 </div>
 
 <script>
-const PORTAL_CONFIG = ${JSON.stringify({ name, tabs, hasGitHub: !!(config.features && config.features.github) })};
+const PORTAL_CONFIG = ${JSON.stringify(portalConfig)};
 ${getClientCore()}
+${projectSidebarJS}
 ${tabJS}
 ${tabLoadersJS}
 
 // --- Init ---
-async function init() {
-  await Promise.all([
-    updateStatusDot(),
-    loadNextRun(),
-    loadQuickStats(),
-  ]);
-  switchTab(currentTab);
-}
+${initJS}
 
 init();
 setInterval(loadNextRun, 60000);
-setInterval(updateStatusDot, 10000);
+${sidebarType === 'simple' ? 'setInterval(updateStatusDot, 10000);' : ''}
 <\/script>
 </body>
 </html>`;

--- a/lib/ui/sidebar-projects.js
+++ b/lib/ui/sidebar-projects.js
@@ -1,0 +1,149 @@
+// sidebar-projects.js — Project-centric sidebar variant client JS
+// Used when config.sidebar.type === 'projects'
+
+/**
+ * Get the project sidebar client-side JS string.
+ * Handles project list rendering, selection, running log, and per-project navigation.
+ */
+function getProjectSidebarJS() {
+  return `
+let projects = [];
+let currentSlug = null;
+
+async function loadProjects() {
+  try {
+    const res = await fetch('/api/projects');
+    projects = await res.json();
+    renderSidebar();
+  } catch {}
+}
+
+function renderSidebar() {
+  const list = document.getElementById('project-list');
+  list.innerHTML = projects.map(function(p) {
+    const cls = 'project-item' + (p.slug === currentSlug ? ' active' : '');
+    const badge = '<span class="priority-badge priority-' + p.priority + '">' + p.priority + '</span>';
+    const unreviewedBadge = p.unreviewedCount > 0
+      ? ' <span class="unreviewed-badge">' + p.unreviewedCount + ' to review</span>' : '';
+    const metaParts = [];
+    if (p.outputCount > 0) {
+      metaParts.push(p.outputCount + ' output' + (p.outputCount !== 1 ? 's' : ''));
+    }
+    if (p.entryCount > 0) {
+      metaParts.push(p.entryCount + ' journal');
+    }
+    if (p.lastActivity) {
+      metaParts.push(new Date(p.lastActivity).toLocaleDateString());
+    }
+    const meta = metaParts.join(' \\u00b7 ');
+    return '<div class="' + cls + '" onclick="selectProject(\\'' + p.slug + '\\')">'
+      + '<div class="title">' + escapeHtml(p.title) + ' ' + badge + unreviewedBadge + '</div>'
+      + '<div class="meta">' + meta + '</div>'
+      + '</div>';
+  }).join('');
+}
+
+async function selectProject(slug) {
+  currentSlug = slug;
+  const logItem = document.getElementById('bobbo-log-item');
+  if (logItem) logItem.classList.remove('active');
+  renderSidebar();
+  document.getElementById('tabs').style.display = 'flex';
+  switchTab('journal');
+}
+
+async function selectBobboLog() {
+  currentSlug = null;
+  renderSidebar();
+  const logItem = document.getElementById('bobbo-log-item');
+  if (logItem) logItem.classList.add('active');
+  document.getElementById('tabs').style.display = 'none';
+  // Load cross-project running log (the monthly journal files)
+  const contentEl = document.getElementById('content');
+  contentEl.innerHTML = '<div class="empty">Loading running log...</div>';
+  try {
+    const res = await fetch('/api/journal');
+    const data = await res.json();
+    let html = '<div class="journal-thread"><h2 style="margin-bottom:16px;color:#444">Running Log</h2>';
+    if (!data.entries || data.entries.length === 0) {
+      html += '<div class="empty" style="margin-top:40px">No entries yet.</div>';
+    } else {
+      data.entries.forEach(function(e) {
+        const dateStr = formatTimestamp(e.ts);
+        html += '<div class="journal-entry author-' + escapeHtml(e.author) + '">'
+          + '<div class="journal-entry-header">'
+          + '<span class="author-badge ' + escapeHtml(e.author) + '">' + escapeHtml(e.author) + '</span>'
+          + '<span class="tag-badge tag-' + escapeHtml(e.tag) + '">' + escapeHtml(e.tag) + '</span>'
+          + '<span class="timestamp">' + dateStr + '</span>'
+          + '</div>'
+          + '<div class="journal-entry-body md-content">' + marked.parse(e.content) + '</div>'
+          + '</div>';
+      });
+    }
+    html += '</div>';
+    contentEl.innerHTML = html;
+    contentEl.querySelectorAll('.journal-entry-body a').forEach(function(a) { a.target = '_blank'; a.rel = 'noopener'; });
+    contentEl.scrollTop = contentEl.scrollHeight;
+  } catch {
+    contentEl.innerHTML = '<div class="empty">Failed to load running log</div>';
+  }
+}
+
+// Override loadJournal to load per-project journal when a project is selected
+const _originalLoadJournal = typeof loadJournal === 'function' ? loadJournal : null;
+
+async function loadProjectJournal() {
+  if (!currentSlug) {
+    if (_originalLoadJournal) return _originalLoadJournal();
+    return;
+  }
+  const contentEl = document.getElementById('content');
+  contentEl.innerHTML = '<div class="empty">Loading journal...</div>';
+  try {
+    const res = await fetch('/api/projects/' + encodeURIComponent(currentSlug) + '/journal');
+    const data = await res.json();
+    let html = '<div class="journal-thread">';
+    if (!data.entries || data.entries.length === 0) {
+      html += '<div class="empty" style="margin-top:60px">No journal entries yet.</div>';
+    } else {
+      data.entries.forEach(function(e) {
+        const dateStr = formatTimestamp(e.ts);
+        html += '<div class="journal-entry author-' + escapeHtml(e.author) + '">'
+          + '<div class="journal-entry-header">'
+          + '<span class="author-badge ' + escapeHtml(e.author) + '">' + escapeHtml(e.author) + '</span>'
+          + '<span class="tag-badge tag-' + escapeHtml(e.tag) + '">' + escapeHtml(e.tag) + '</span>'
+          + '<span class="timestamp">' + dateStr + '</span>'
+          + '</div>'
+          + '<div class="journal-entry-body md-content">' + marked.parse(e.content) + '</div>'
+          + '</div>';
+      });
+    }
+    html += '</div>';
+    contentEl.innerHTML = html;
+    contentEl.querySelectorAll('.journal-entry-body a').forEach(function(a) { a.target = '_blank'; a.rel = 'noopener'; });
+    contentEl.scrollTop = contentEl.scrollHeight;
+  } catch {
+    contentEl.innerHTML = '<div class="empty">Failed to load journal</div>';
+  }
+}
+
+async function loadProjectFile() {
+  if (!currentSlug) return;
+  const contentEl = document.getElementById('content');
+  contentEl.innerHTML = '<div class="empty">Loading project...</div>';
+  try {
+    const res = await fetch('/api/projects/' + encodeURIComponent(currentSlug) + '/file');
+    const data = await res.json();
+    contentEl.innerHTML = '<div class="status-section"><div class="status-card"><div class="md-content">'
+      + marked.parse(data.content || '*No project file found.*')
+      + '</div></div></div>';
+    contentEl.querySelectorAll('.md-content a').forEach(function(a) { a.target = '_blank'; a.rel = 'noopener'; });
+    contentEl.scrollTop = 0;
+  } catch {
+    contentEl.innerHTML = '<div class="empty">Failed to load project file</div>';
+  }
+}
+`;
+}
+
+module.exports = { getProjectSidebarJS };

--- a/lib/ui/styles.js
+++ b/lib/ui/styles.js
@@ -109,6 +109,19 @@ ${authorCSS}
   .win-item .win-desc { font-size: 14px; }
   .win-item .win-meta { font-size: 12px; color: #888; margin-top: 4px; }
 
+  /* Project sidebar */
+  .project-item { padding: 12px 16px; border-bottom: 1px solid #f0f0f0; cursor: pointer; transition: background 0.1s; }
+  .project-item:hover { background: #f8f8f8; }
+  .project-item.active { background: #e8f0fe; border-left: 3px solid #1a73e8; }
+  .project-item .title { font-size: 14px; font-weight: 500; display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+  .project-item .meta { font-size: 12px; color: #888; margin-top: 4px; }
+  .priority-badge { display: inline-block; font-size: 10px; font-weight: 600; padding: 1px 6px; border-radius: 8px; text-transform: uppercase; }
+  .priority-high { background: #fce4ec; color: #c62828; }
+  .priority-medium { background: #fff3e0; color: #e65100; }
+  .priority-low { background: #e8f5e9; color: #2e7d32; }
+  .unreviewed-badge { display: inline-block; font-size: 10px; font-weight: 600; padding: 1px 6px; border-radius: 8px; background: #e3f2fd; color: #1565c0; }
+  #project-list { flex: 1; overflow-y: auto; }
+
   /* Markdown styling */
   .md-content h1 { font-size: 24px; margin-bottom: 8px; }
   .md-content h2 { font-size: 20px; margin-top: 24px; margin-bottom: 8px; }

--- a/test/fixtures/journals/alpha-feature.md
+++ b/test/fixtures/journals/alpha-feature.md
@@ -1,0 +1,14 @@
+# Alpha Feature — Journal
+
+Project: [alpha-feature](../projects/alpha-feature.md)
+
+---
+
+### 2026-02-20T10:00:00.000Z | bobbo | output
+Implemented the first API endpoint for alpha feature.
+
+### 2026-02-21T14:30:00.000Z | rob | feedback
+Good progress. Make sure to add validation on the input params.
+
+### 2026-02-22T09:00:00.000Z | bobbo | note
+Added input validation as requested. Moving on to database migrations.

--- a/test/fixtures/journals/beta-cleanup.md
+++ b/test/fixtures/journals/beta-cleanup.md
@@ -1,0 +1,8 @@
+# Beta Cleanup — Journal
+
+Project: [beta-cleanup](../projects/beta-cleanup.md)
+
+---
+
+### 2026-02-19T16:00:00.000Z | bobbo | observation
+Found 3 deprecated methods that can be removed safely.

--- a/test/fixtures/projects/alpha-feature.md
+++ b/test/fixtures/projects/alpha-feature.md
@@ -1,0 +1,15 @@
+---
+status: active
+priority: high
+tags: [backend, api]
+---
+
+# Alpha Feature
+
+Build the alpha feature for the platform.
+
+## Goals
+
+- Implement core API endpoints
+- Add database migrations
+- Write integration tests

--- a/test/fixtures/projects/beta-cleanup.md
+++ b/test/fixtures/projects/beta-cleanup.md
@@ -1,0 +1,14 @@
+---
+status: active
+priority: medium
+tags: [cleanup]
+---
+
+# Beta Cleanup
+
+Clean up the beta module code.
+
+## Tasks
+
+- Remove deprecated methods
+- Update documentation

--- a/test/fixtures/projects/gamma-docs.md
+++ b/test/fixtures/projects/gamma-docs.md
@@ -1,0 +1,9 @@
+---
+status: paused
+priority: low
+tags: [docs]
+---
+
+# Gamma Docs
+
+Write documentation for the gamma module.

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const http = require('http');
-const { sendJSON, readBody, readLastLines, parseJournal, getAllJournalEntries } = require('../lib/helpers');
+const { sendJSON, readBody, readLastLines, parseJournal, getAllJournalEntries, parseFrontmatter } = require('../lib/helpers');
 
 // --- parseJournal ---
 
@@ -123,6 +123,40 @@ describe('getAllJournalEntries', () => {
     } finally {
       fs.rmSync(tmpDir, { recursive: true });
     }
+  });
+});
+
+// --- parseFrontmatter ---
+
+describe('parseFrontmatter', () => {
+  it('parses valid YAML frontmatter', () => {
+    const content = '---\nstatus: active\npriority: high\n---\n\n# Title\n';
+    const fm = parseFrontmatter(content);
+    assert.equal(fm.status, 'active');
+    assert.equal(fm.priority, 'high');
+  });
+
+  it('returns empty object for missing frontmatter', () => {
+    const fm = parseFrontmatter('# Just a title\n\nSome content.\n');
+    assert.deepEqual(fm, {});
+  });
+
+  it('returns empty object for empty content', () => {
+    const fm = parseFrontmatter('');
+    assert.deepEqual(fm, {});
+  });
+
+  it('parses bracket-delimited values as arrays', () => {
+    const content = '---\ntags: [backend, api, testing]\n---\n';
+    const fm = parseFrontmatter(content);
+    assert.ok(Array.isArray(fm.tags));
+    assert.deepEqual(fm.tags, ['backend', 'api', 'testing']);
+  });
+
+  it('handles keys with hyphens', () => {
+    const content = '---\ndue-date: 2026-03-01\n---\n';
+    const fm = parseFrontmatter(content);
+    assert.equal(fm['due-date'], '2026-03-01');
   });
 });
 

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -35,6 +35,7 @@ function bootPortal(configOverrides = {}) {
   require('../lib/routes/roadmap').register(routes, config);
   require('../lib/routes/health').register(routes, config);
   require('../lib/routes/requests').register(routes, config);
+  require('../lib/routes/projects').register(routes, config);
 
   const getHTML = () => buildHTML(config);
 

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -30,6 +30,7 @@ function createTestServer(configOverrides = {}) {
   require('../lib/routes/roadmap').register(routes, config);
   require('../lib/routes/health').register(routes, config);
   require('../lib/routes/requests').register(routes, config);
+  require('../lib/routes/projects').register(routes, config);
 
   return { server: createServer(config, { routes, getHTML: () => '<html>test</html>' }), config };
 }
@@ -579,6 +580,176 @@ describe('POST /api/requests/reply', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ file: 'nonexistent.md', comment: 'Hello' }),
     });
+    assert.equal(status, 404);
+    assert.ok(data.error.includes('not found'));
+  });
+});
+
+// --- Project routes ---
+
+describe('GET /api/projects', () => {
+  it('returns project list sorted by priority when sidebar.type is projects', async () => {
+    const result = createTestServer({
+      sidebar: { type: 'projects', projectsDir: 'projects' },
+    });
+    const server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    const port = server.address().port;
+
+    const { status, data } = await fetchJSON(port, '/api/projects');
+    assert.equal(status, 200);
+    assert.ok(Array.isArray(data));
+    assert.equal(data.length, 3);
+    // Sorted: high, medium, low
+    assert.equal(data[0].priority, 'high');
+    assert.equal(data[0].slug, 'alpha-feature');
+    assert.equal(data[0].title, 'Alpha Feature');
+    assert.equal(data[0].entryCount, 3);
+    assert.ok(data[0].lastActivity);
+    assert.equal(data[1].priority, 'medium');
+    assert.equal(data[1].slug, 'beta-cleanup');
+    assert.equal(data[2].priority, 'low');
+    assert.equal(data[2].slug, 'gamma-docs');
+
+    server.close();
+  });
+
+  it('returns 404 when sidebar.type is not projects', async () => {
+    const result = createTestServer({ features: {} });
+    const server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    const port = server.address().port;
+
+    const { status } = await fetchJSON(port, '/api/projects');
+    assert.equal(status, 404);
+
+    server.close();
+  });
+
+  it('parses frontmatter tags as arrays', async () => {
+    const result = createTestServer({
+      sidebar: { type: 'projects', projectsDir: 'projects' },
+    });
+    const server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    const port = server.address().port;
+
+    const { data } = await fetchJSON(port, '/api/projects');
+    const alpha = data.find(p => p.slug === 'alpha-feature');
+    assert.ok(Array.isArray(alpha.tags));
+    assert.deepEqual(alpha.tags, ['backend', 'api']);
+
+    server.close();
+  });
+});
+
+describe('GET /api/projects/:slug/journal', () => {
+  let server, port;
+
+  before(async () => {
+    const result = createTestServer({
+      sidebar: { type: 'projects', projectsDir: 'projects' },
+    });
+    server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    port = server.address().port;
+  });
+
+  after(() => server.close());
+
+  it('returns per-project journal entries', async () => {
+    const { status, data } = await fetchJSON(port, '/api/projects/alpha-feature/journal');
+    assert.equal(status, 200);
+    assert.equal(data.slug, 'alpha-feature');
+    assert.ok(Array.isArray(data.entries));
+    assert.equal(data.entries.length, 3);
+    assert.equal(data.entries[0].author, 'bobbo');
+    assert.equal(data.entries[0].tag, 'output');
+  });
+
+  it('returns empty entries for project with no journal', async () => {
+    const { status, data } = await fetchJSON(port, '/api/projects/gamma-docs/journal');
+    assert.equal(status, 200);
+    assert.equal(data.slug, 'gamma-docs');
+    assert.deepEqual(data.entries, []);
+  });
+});
+
+describe('POST /api/projects/:slug/journal', () => {
+  let server, port, tmpDir;
+
+  before(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'portal-proj-journal-'));
+    fs.mkdirSync(path.join(tmpDir, 'journals'));
+    fs.mkdirSync(path.join(tmpDir, 'logs'));
+    fs.mkdirSync(path.join(tmpDir, 'projects'));
+    fs.writeFileSync(path.join(tmpDir, 'projects', 'test-proj.md'), '---\nstatus: active\npriority: high\n---\n\n# Test Proj\n');
+
+    const result = createTestServer({
+      agentDir: tmpDir,
+      sidebar: { type: 'projects', projectsDir: 'projects' },
+    });
+    server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    port = server.address().port;
+  });
+
+  after(() => {
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('creates per-project journal entry', async () => {
+    const { status, data } = await fetchJSON(port, '/api/projects/test-proj/journal', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: 'Project journal test', tag: 'note' }),
+    });
+    assert.equal(status, 200);
+    assert.equal(data.ok, true);
+    assert.equal(data.tag, 'note');
+
+    const content = fs.readFileSync(path.join(tmpDir, 'journals', 'test-proj.md'), 'utf-8');
+    assert.ok(content.includes('Test Proj — Journal'));
+    assert.ok(content.includes('rob | note'));
+    assert.ok(content.includes('Project journal test'));
+  });
+
+  it('rejects invalid tag', async () => {
+    const { status, data } = await fetchJSON(port, '/api/projects/test-proj/journal', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: 'Something', tag: 'bad' }),
+    });
+    assert.equal(status, 400);
+    assert.ok(data.error.includes('Invalid tag'));
+  });
+});
+
+describe('GET /api/projects/:slug/file', () => {
+  let server, port;
+
+  before(async () => {
+    const result = createTestServer({
+      sidebar: { type: 'projects', projectsDir: 'projects' },
+    });
+    server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    port = server.address().port;
+  });
+
+  after(() => server.close());
+
+  it('returns raw project file content', async () => {
+    const { status, data } = await fetchJSON(port, '/api/projects/alpha-feature/file');
+    assert.equal(status, 200);
+    assert.equal(data.slug, 'alpha-feature');
+    assert.ok(data.content.includes('# Alpha Feature'));
+    assert.ok(data.content.includes('priority: high'));
+  });
+
+  it('returns 404 for nonexistent project', async () => {
+    const { status, data } = await fetchJSON(port, '/api/projects/nonexistent/file');
     assert.equal(status, 404);
     assert.ok(data.error.includes('not found'));
   });

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -182,4 +182,41 @@ describe('buildHTML', () => {
     const html = buildHTML(baseConfig);
     assert.ok(!html.includes('function loadRequests'));
   });
+
+  it('renders project sidebar when sidebar.type is projects', () => {
+    const config = {
+      ...baseConfig,
+      sidebar: { type: 'projects', runningLog: true },
+      features: { tabs: ['journal', 'project', 'status'] },
+    };
+    const html = buildHTML(config);
+    assert.ok(html.includes('id="project-list"'));
+    assert.ok(html.includes('id="bobbo-log-item"'));
+    assert.ok(html.includes('function loadProjects'));
+    assert.ok(html.includes('function selectProject'));
+    assert.ok(html.includes('function selectBobboLog'));
+    assert.ok(html.includes('function renderSidebar'));
+    assert.ok(html.includes('function loadProjectFile'));
+    assert.ok(html.includes('"sidebarType":"projects"'));
+  });
+
+  it('renders simple sidebar by default (no project sidebar)', () => {
+    const html = buildHTML(baseConfig);
+    assert.ok(html.includes('id="sidebar-header"'));
+    assert.ok(html.includes('id="status-dot"'));
+    assert.ok(!html.includes('id="project-list"'));
+    assert.ok(!html.includes('function loadProjects'));
+    assert.ok(html.includes('"sidebarType":"simple"'));
+  });
+
+  it('includes project tab in TAB_LOADERS when configured', () => {
+    const config = {
+      ...baseConfig,
+      sidebar: { type: 'projects' },
+      features: { tabs: ['journal', 'project', 'status'] },
+    };
+    const html = buildHTML(config);
+    assert.ok(html.includes('project: loadProjectFile'));
+    assert.ok(html.includes('data-tab="project"'));
+  });
 });


### PR DESCRIPTION
## Summary
- Added `parseFrontmatter()` to helpers for YAML frontmatter parsing
- Created `lib/routes/projects.js` with GET /api/projects, GET/POST /api/projects/:slug/journal, GET /api/projects/:slug/file — gated by `sidebar.type: "projects"`
- Created `lib/ui/sidebar-projects.js` with project list rendering, priority badges, unreviewed output counts, running log
- Updated shell.js to support `sidebar.type` config: "simple" (Coder/PM) vs "projects" (Bobbo)
- Added project sidebar CSS: priority badges, unreviewed badges, project items
- 17 new tests (parseFrontmatter, route, UI), 133 total passing

Refs #15

## Test plan
- [x] All 133 tests pass
- [x] parseFrontmatter handles valid YAML, missing frontmatter, arrays, hyphens
- [x] Project list sorted by priority (high → medium → low)
- [x] Per-project journal read/write works
- [x] Project file route returns raw markdown
- [x] Routes not registered when sidebar.type is not "projects"
- [x] Simple sidebar still renders correctly (regression)
- [x] Manual verification: booted server, confirmed API responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)