### PR TITLE
Outputs + feedback routes and tab

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ require('./lib/routes/roadmap').register(routes, config);
 require('./lib/routes/health').register(routes, config);
 require('./lib/routes/requests').register(routes, config);
 require('./lib/routes/projects').register(routes, config);
+require('./lib/routes/outputs').register(routes, config);
 
 // Build HTML page (cached — config doesn't change at runtime)
 let cachedHTML;

--- a/lib/routes/outputs.js
+++ b/lib/routes/outputs.js
@@ -1,0 +1,153 @@
+// outputs.js — Output listing, detail, delete, feedback routes
+// Registered when features.outputs is true
+
+const fs = require('fs');
+const path = require('path');
+const { sendJSON, readBody } = require('../helpers');
+
+function getOutputFiles(agentDir) {
+  const outputDir = path.join(agentDir, 'output');
+  const feedbackDir = path.join(agentDir, 'input', 'feedback');
+  const processedDir = path.join(feedbackDir, 'processed');
+  try {
+    const files = fs.readdirSync(outputDir)
+      .filter(f => f.endsWith('.md') && f !== '.gitkeep');
+    return files.map(f => {
+      const stat = fs.statSync(path.join(outputDir, f));
+      const feedbackFile = f.replace('.md', '.feedback.yaml');
+      const feedbackPath = path.join(feedbackDir, feedbackFile);
+      const processedPath = path.join(processedDir, feedbackFile);
+      const activePath = fs.existsSync(feedbackPath) ? feedbackPath
+        : fs.existsSync(processedPath) ? processedPath : null;
+      let rating = null;
+      if (activePath) {
+        const content = fs.readFileSync(activePath, 'utf-8');
+        const match = content.match(/^rating:\s*(\S+)/m);
+        if (match) rating = match[1];
+      }
+      return {
+        filename: f,
+        modified: stat.mtime.toISOString(),
+        reviewed: !!activePath,
+        rating,
+      };
+    }).sort((a, b) => new Date(b.modified) - new Date(a.modified));
+  } catch {
+    return [];
+  }
+}
+
+function register(routes, config) {
+  const agentDir = config.agentDir || '.';
+  const outputDir = path.join(agentDir, 'output');
+  const feedbackDir = path.join(agentDir, 'input', 'feedback');
+
+  // --- Output routes (gated by features.outputs) ---
+  if (config.features && config.features.outputs) {
+    // GET /api/outputs — list all output files with review status
+    routes['GET /api/outputs'] = (req, res) => {
+      sendJSON(res, 200, getOutputFiles(agentDir));
+    };
+
+    // GET /api/projects/:slug/outputs — per-project outputs
+    routes['GET /api/projects/:slug/outputs'] = (req, res) => {
+      const slug = req.params.slug;
+      const allOutputs = getOutputFiles(agentDir);
+      const projectOutputs = allOutputs.filter(o => o.filename.startsWith(slug));
+      sendJSON(res, 200, projectOutputs);
+    };
+
+    // GET /api/output/:filename — single output file content
+    routes['GET /api/output/:filename'] = (req, res) => {
+      const filename = req.params.filename;
+      if (filename.includes('/') || filename.includes('\\') || filename.includes('..')) {
+        return sendJSON(res, 400, { error: 'Invalid filename' });
+      }
+      const filePath = path.join(outputDir, filename);
+      if (!fs.existsSync(filePath)) {
+        return sendJSON(res, 404, { error: 'Not found' });
+      }
+      const content = fs.readFileSync(filePath, 'utf-8');
+      sendJSON(res, 200, { filename, content });
+    };
+
+    // DELETE /api/output/:filename — delete output + associated feedback
+    routes['DELETE /api/output/:filename'] = (req, res) => {
+      const filename = req.params.filename;
+      if (filename.includes('/') || filename.includes('\\') || filename.includes('..')) {
+        return sendJSON(res, 400, { error: 'Invalid filename' });
+      }
+      const filePath = path.join(outputDir, filename);
+      if (!fs.existsSync(filePath)) {
+        return sendJSON(res, 404, { error: 'Not found' });
+      }
+      fs.unlinkSync(filePath);
+      const feedbackFile = filename.replace('.md', '.feedback.yaml');
+      const feedbackPath = path.join(feedbackDir, feedbackFile);
+      if (fs.existsSync(feedbackPath)) {
+        fs.unlinkSync(feedbackPath);
+      }
+      sendJSON(res, 200, { ok: true, deleted: filename });
+    };
+  }
+
+  // --- Feedback routes (gated by features.feedback) ---
+  if (config.features && config.features.feedback) {
+    // GET /api/feedback/:filename — get feedback for an output
+    routes['GET /api/feedback/:filename'] = (req, res) => {
+      const filename = req.params.filename;
+      if (filename.includes('/') || filename.includes('\\') || filename.includes('..')) {
+        return sendJSON(res, 400, { error: 'Invalid filename' });
+      }
+      const feedbackFile = filename.replace('.md', '.feedback.yaml');
+      const feedbackPath = path.join(feedbackDir, feedbackFile);
+      if (!fs.existsSync(feedbackPath)) {
+        return sendJSON(res, 404, { error: 'No feedback' });
+      }
+      const content = fs.readFileSync(feedbackPath, 'utf-8');
+      sendJSON(res, 200, { filename: feedbackFile, content });
+    };
+
+    // POST /api/feedback/:filename — submit feedback for an output
+    routes['POST /api/feedback/:filename'] = (req, res) => {
+      const filename = req.params.filename;
+      if (filename.includes('/') || filename.includes('\\') || filename.includes('..')) {
+        return sendJSON(res, 400, { error: 'Invalid filename' });
+      }
+
+      readBody(req).then(body => {
+        try {
+          const data = JSON.parse(body);
+          const rating = data.rating ? parseInt(data.rating, 10) : null;
+          if (rating !== null && (rating < 1 || rating > 2)) {
+            return sendJSON(res, 400, { error: 'Rating must be 1 (thumbs down) or 2 (thumbs up)' });
+          }
+          const notes = (data.notes || '').trim();
+          if (!rating && !notes) {
+            return sendJSON(res, 400, { error: 'Provide a rating and/or notes' });
+          }
+
+          const feedbackFile = filename.replace('.md', '.feedback.yaml');
+          const feedbackPath = path.join(feedbackDir, feedbackFile);
+          // Ensure feedback directory exists
+          if (!fs.existsSync(feedbackDir)) {
+            fs.mkdirSync(feedbackDir, { recursive: true });
+          }
+
+          const now = new Date().toISOString();
+          let yaml = `output: ${filename}\nreviewed_at: ${now}\n`;
+          if (rating) yaml += `rating: ${rating === 2 ? 'up' : 'down'}\n`;
+          if (notes) {
+            yaml += `notes: |\n${notes.split('\n').map(l => '  ' + l).join('\n')}\n`;
+          }
+          fs.writeFileSync(feedbackPath, yaml);
+          sendJSON(res, 200, { ok: true, file: feedbackFile });
+        } catch {
+          sendJSON(res, 400, { error: 'Invalid JSON' });
+        }
+      });
+    };
+  }
+}
+
+module.exports = { register };

--- a/lib/ui/shell.js
+++ b/lib/ui/shell.js
@@ -7,6 +7,7 @@ const { getGitHubTabJS } = require('./tabs/github');
 const { getRoadmapTabJS } = require('./tabs/roadmap');
 const { getHealthTabJS } = require('./tabs/health');
 const { getRequestsTabJS } = require('./tabs/requests');
+const { getOutputsTabJS } = require('./tabs/outputs');
 const { getProjectSidebarJS } = require('./sidebar-projects');
 
 /**
@@ -62,6 +63,11 @@ function buildHTML(config) {
   if (tabs.includes('requests')) {
     tabJS += getRequestsTabJS();
     tabLoaderEntries.push(`requests: loadRequests`);
+  }
+
+  if (tabs.includes('outputs')) {
+    tabJS += getOutputsTabJS();
+    tabLoaderEntries.push(`outputs: loadOutputs`);
   }
 
   // Project sidebar support

--- a/lib/ui/tabs/outputs.js
+++ b/lib/ui/tabs/outputs.js
@@ -1,0 +1,123 @@
+// outputs.js — Outputs tab client-side JavaScript
+// Includes output list, detail view, feedback panel, delete
+
+/**
+ * Get the outputs tab client-side JS string.
+ */
+function getOutputsTabJS() {
+  return `
+let currentOutputFile = null;
+
+async function loadOutputs() {
+  const contentEl = document.getElementById('content');
+  currentOutputFile = null;
+  const slug = typeof currentSlug !== 'undefined' ? currentSlug : null;
+  const url = slug ? '/api/projects/' + encodeURIComponent(slug) + '/outputs' : '/api/outputs';
+  contentEl.innerHTML = '<div class="empty">Loading outputs...</div>';
+  try {
+    const res = await fetch(url);
+    const outputs = await res.json();
+    if (!outputs || outputs.length === 0) {
+      contentEl.innerHTML = '<div class="empty" style="margin-top:60px">No outputs yet.</div>';
+      return;
+    }
+    let html = '<div class="outputs-list" style="max-width:800px">';
+    html += '<h2 style="margin-bottom:16px;color:#444">Outputs</h2>';
+    outputs.forEach(function(o) {
+      const reviewBadge = o.reviewed
+        ? '<span class="state-badge state-merged">' + (o.rating === 'up' ? '\\u{1F44D}' : o.rating === 'down' ? '\\u{1F44E}' : 'reviewed') + '</span>'
+        : '<span class="unreviewed-badge">unreviewed</span>';
+      const dateStr = formatShortDate(o.modified);
+      html += '<div class="gh-item" style="cursor:pointer" onclick="viewOutput(\\'' + escapeHtml(o.filename) + '\\')">'
+        + '<a style="flex:1">' + escapeHtml(o.filename) + '</a>'
+        + reviewBadge
+        + '<span class="date">' + dateStr + '</span>'
+        + '</div>';
+    });
+    html += '</div>';
+    contentEl.innerHTML = html;
+  } catch {
+    contentEl.innerHTML = '<div class="empty">Failed to load outputs</div>';
+  }
+}
+
+async function viewOutput(filename) {
+  currentOutputFile = filename;
+  const contentEl = document.getElementById('content');
+  contentEl.innerHTML = '<div class="empty">Loading output...</div>';
+  try {
+    const res = await fetch('/api/output/' + encodeURIComponent(filename));
+    const data = await res.json();
+    if (res.status !== 200) {
+      contentEl.innerHTML = '<div class="empty">Output not found</div>';
+      return;
+    }
+    let html = '<div style="max-width:800px">';
+    html += '<div style="margin-bottom:16px"><a href="#" onclick="loadOutputs();return false" style="color:#1a73e8;text-decoration:none;font-size:13px">&larr; Back to outputs</a></div>';
+    html += '<div class="status-card"><div class="md-content">' + marked.parse(data.content) + '</div></div>';
+
+    // Feedback panel
+    html += '<div id="feedback-panel" style="margin-top:16px;padding:16px;background:#fff;border-radius:8px;border:1px solid #e8e8e8">';
+    html += '<h3 style="font-size:14px;color:#555;margin-bottom:12px">Feedback</h3>';
+    html += '<div id="feedback-content">Loading feedback...</div>';
+    html += '<div style="margin-top:12px;display:flex;gap:8px;align-items:center">';
+    html += '<button class="refresh-btn" onclick="submitFeedback(\\'' + escapeHtml(filename) + '\\', 2)">\\u{1F44D} Thumbs Up</button>';
+    html += '<button class="refresh-btn" onclick="submitFeedback(\\'' + escapeHtml(filename) + '\\', 1)">\\u{1F44E} Thumbs Down</button>';
+    html += '<input id="feedback-notes" type="text" placeholder="Notes (optional)" style="flex:1;padding:6px 10px;border:1px solid #ddd;border-radius:6px;font-size:13px">';
+    html += '</div>';
+    html += '<div style="margin-top:8px"><button class="refresh-btn" style="background:#fce4ec;color:#c62828" onclick="deleteOutput(\\'' + escapeHtml(filename) + '\\')">Delete Output</button></div>';
+    html += '</div>';
+
+    html += '</div>';
+    contentEl.innerHTML = html;
+    contentEl.querySelectorAll('.md-content a').forEach(function(a) { a.target = '_blank'; a.rel = 'noopener'; });
+    contentEl.scrollTop = 0;
+
+    // Load existing feedback
+    loadFeedback(filename);
+  } catch {
+    contentEl.innerHTML = '<div class="empty">Failed to load output</div>';
+  }
+}
+
+async function loadFeedback(filename) {
+  const el = document.getElementById('feedback-content');
+  if (!el) return;
+  try {
+    const res = await fetch('/api/feedback/' + encodeURIComponent(filename));
+    if (res.status === 404) {
+      el.innerHTML = '<div style="color:#888;font-size:13px">No feedback yet</div>';
+      return;
+    }
+    const data = await res.json();
+    el.innerHTML = '<pre style="font-size:12px;background:#f5f5f5;padding:8px;border-radius:4px;overflow-x:auto">' + escapeHtml(data.content) + '</pre>';
+  } catch {
+    el.innerHTML = '<div style="color:#888;font-size:13px">Could not load feedback</div>';
+  }
+}
+
+async function submitFeedback(filename, rating) {
+  const notesEl = document.getElementById('feedback-notes');
+  const notes = notesEl ? notesEl.value.trim() : '';
+  try {
+    await fetch('/api/feedback/' + encodeURIComponent(filename), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rating: rating, notes: notes })
+    });
+    loadFeedback(filename);
+    if (notesEl) notesEl.value = '';
+  } catch { alert('Failed to submit feedback'); }
+}
+
+async function deleteOutput(filename) {
+  if (!confirm('Delete ' + filename + '?')) return;
+  try {
+    await fetch('/api/output/' + encodeURIComponent(filename), { method: 'DELETE' });
+    loadOutputs();
+  } catch { alert('Failed to delete output'); }
+}
+`;
+}
+
+module.exports = { getOutputsTabJS };

--- a/test/fixtures/input/feedback/alpha-feature-api-endpoints.feedback.yaml
+++ b/test/fixtures/input/feedback/alpha-feature-api-endpoints.feedback.yaml
@@ -1,0 +1,5 @@
+output: alpha-feature-api-endpoints.md
+reviewed_at: 2026-02-21T15:00:00.000Z
+rating: up
+notes: |
+  Clean implementation. Good test coverage.

--- a/test/fixtures/output/alpha-feature-api-endpoints.md
+++ b/test/fixtures/output/alpha-feature-api-endpoints.md
@@ -1,0 +1,13 @@
+# Alpha Feature — API Endpoints
+
+## Summary
+
+Implemented the core REST API endpoints for the alpha feature:
+
+- `GET /api/alpha/items` — list all items
+- `POST /api/alpha/items` — create new item
+- `GET /api/alpha/items/:id` — get item by ID
+
+## Testing
+
+All endpoints tested with integration tests. 12 tests passing.

--- a/test/fixtures/output/alpha-feature-migrations.md
+++ b/test/fixtures/output/alpha-feature-migrations.md
@@ -1,0 +1,8 @@
+# Alpha Feature — Database Migrations
+
+Created migration files for the alpha feature schema:
+
+- `001_create_items.sql` — items table
+- `002_add_indexes.sql` — performance indexes
+
+Tested against local PostgreSQL instance.

--- a/test/fixtures/output/beta-cleanup-deprecated.md
+++ b/test/fixtures/output/beta-cleanup-deprecated.md
@@ -1,0 +1,7 @@
+# Beta Cleanup — Deprecated Methods Removed
+
+Removed 3 deprecated methods from the beta module:
+
+- `betaLegacyInit()` — replaced by `betaInit()`
+- `betaOldFormat()` — replaced by `betaFormat()`
+- `betaCompat()` — no longer needed

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -36,6 +36,7 @@ function bootPortal(configOverrides = {}) {
   require('../lib/routes/health').register(routes, config);
   require('../lib/routes/requests').register(routes, config);
   require('../lib/routes/projects').register(routes, config);
+  require('../lib/routes/outputs').register(routes, config);
 
   const getHTML = () => buildHTML(config);
 

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -31,6 +31,7 @@ function createTestServer(configOverrides = {}) {
   require('../lib/routes/health').register(routes, config);
   require('../lib/routes/requests').register(routes, config);
   require('../lib/routes/projects').register(routes, config);
+  require('../lib/routes/outputs').register(routes, config);
 
   return { server: createServer(config, { routes, getHTML: () => '<html>test</html>' }), config };
 }
@@ -752,5 +753,207 @@ describe('GET /api/projects/:slug/file', () => {
     const { status, data } = await fetchJSON(port, '/api/projects/nonexistent/file');
     assert.equal(status, 404);
     assert.ok(data.error.includes('not found'));
+  });
+});
+
+// --- Output routes ---
+
+describe('GET /api/outputs', () => {
+  it('returns output files with review status when feature enabled', async () => {
+    const result = createTestServer({ features: { outputs: true, feedback: true } });
+    const server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    const port = server.address().port;
+
+    const { status, data } = await fetchJSON(port, '/api/outputs');
+    assert.equal(status, 200);
+    assert.ok(Array.isArray(data));
+    assert.equal(data.length, 3);
+    // Should be sorted by modification date (newest first)
+    assert.ok(data.every(o => o.filename.endsWith('.md')));
+    // alpha-feature-api-endpoints has feedback
+    const reviewed = data.find(o => o.filename === 'alpha-feature-api-endpoints.md');
+    assert.ok(reviewed);
+    assert.equal(reviewed.reviewed, true);
+    assert.equal(reviewed.rating, 'up');
+    // beta-cleanup has no feedback
+    const unreviewed = data.find(o => o.filename === 'beta-cleanup-deprecated.md');
+    assert.ok(unreviewed);
+    assert.equal(unreviewed.reviewed, false);
+
+    server.close();
+  });
+
+  it('returns 404 when feature disabled', async () => {
+    const result = createTestServer({ features: {} });
+    const server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    const port = server.address().port;
+
+    const { status } = await fetchJSON(port, '/api/outputs');
+    assert.equal(status, 404);
+
+    server.close();
+  });
+});
+
+describe('GET /api/output/:filename', () => {
+  let server, port;
+
+  before(async () => {
+    const result = createTestServer({ features: { outputs: true } });
+    server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    port = server.address().port;
+  });
+
+  after(() => server.close());
+
+  it('returns output file content', async () => {
+    const { status, data } = await fetchJSON(port, '/api/output/alpha-feature-api-endpoints.md');
+    assert.equal(status, 200);
+    assert.equal(data.filename, 'alpha-feature-api-endpoints.md');
+    assert.ok(data.content.includes('API Endpoints'));
+  });
+
+  it('returns 404 for nonexistent output', async () => {
+    const { status } = await fetchJSON(port, '/api/output/nonexistent.md');
+    assert.equal(status, 404);
+  });
+
+  it('rejects path traversal', async () => {
+    const { status, data } = await fetchJSON(port, '/api/output/..%2F..%2Fetc%2Fpasswd');
+    assert.equal(status, 400);
+    assert.ok(data.error.includes('Invalid filename'));
+  });
+});
+
+describe('DELETE /api/output/:filename', () => {
+  let server, port, tmpDir;
+
+  before(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'portal-output-del-'));
+    fs.mkdirSync(path.join(tmpDir, 'journals'));
+    fs.mkdirSync(path.join(tmpDir, 'logs'));
+    fs.mkdirSync(path.join(tmpDir, 'output'));
+    fs.mkdirSync(path.join(tmpDir, 'input', 'feedback'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'output', 'delete-me.md'), '# To delete');
+    fs.writeFileSync(path.join(tmpDir, 'input', 'feedback', 'delete-me.feedback.yaml'), 'rating: up\n');
+
+    const result = createTestServer({ agentDir: tmpDir, features: { outputs: true } });
+    server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    port = server.address().port;
+  });
+
+  after(() => {
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('deletes output and associated feedback', async () => {
+    const { status, data } = await fetchJSON(port, '/api/output/delete-me.md', { method: 'DELETE' });
+    assert.equal(status, 200);
+    assert.equal(data.ok, true);
+    assert.equal(data.deleted, 'delete-me.md');
+    // Verify both files removed
+    assert.ok(!fs.existsSync(path.join(tmpDir, 'output', 'delete-me.md')));
+    assert.ok(!fs.existsSync(path.join(tmpDir, 'input', 'feedback', 'delete-me.feedback.yaml')));
+  });
+});
+
+// --- Feedback routes ---
+
+describe('POST /api/feedback/:filename', () => {
+  let server, port, tmpDir;
+
+  before(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'portal-feedback-'));
+    fs.mkdirSync(path.join(tmpDir, 'journals'));
+    fs.mkdirSync(path.join(tmpDir, 'logs'));
+    fs.mkdirSync(path.join(tmpDir, 'input', 'feedback'), { recursive: true });
+
+    const result = createTestServer({ agentDir: tmpDir, features: { feedback: true } });
+    server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    port = server.address().port;
+  });
+
+  after(() => {
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('creates feedback YAML file with thumbs up', async () => {
+    const { status, data } = await fetchJSON(port, '/api/feedback/test-output.md', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rating: 2, notes: 'Great work' }),
+    });
+    assert.equal(status, 200);
+    assert.equal(data.ok, true);
+    assert.equal(data.file, 'test-output.feedback.yaml');
+
+    const content = fs.readFileSync(path.join(tmpDir, 'input', 'feedback', 'test-output.feedback.yaml'), 'utf-8');
+    assert.ok(content.includes('rating: up'));
+    assert.ok(content.includes('Great work'));
+  });
+
+  it('creates feedback with thumbs down', async () => {
+    const { status, data } = await fetchJSON(port, '/api/feedback/bad-output.md', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rating: 1 }),
+    });
+    assert.equal(status, 200);
+    const content = fs.readFileSync(path.join(tmpDir, 'input', 'feedback', 'bad-output.feedback.yaml'), 'utf-8');
+    assert.ok(content.includes('rating: down'));
+  });
+
+  it('rejects invalid rating', async () => {
+    const { status, data } = await fetchJSON(port, '/api/feedback/test.md', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rating: 5 }),
+    });
+    assert.equal(status, 400);
+    assert.ok(data.error.includes('Rating must be'));
+  });
+
+  it('rejects empty feedback', async () => {
+    const { status, data } = await fetchJSON(port, '/api/feedback/test.md', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    assert.equal(status, 400);
+    assert.ok(data.error.includes('Provide a rating'));
+  });
+});
+
+describe('GET /api/feedback/:filename', () => {
+  it('returns existing feedback', async () => {
+    const result = createTestServer({ features: { feedback: true } });
+    const server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    const port = server.address().port;
+
+    const { status, data } = await fetchJSON(port, '/api/feedback/alpha-feature-api-endpoints.md');
+    assert.equal(status, 200);
+    assert.ok(data.content.includes('rating: up'));
+
+    server.close();
+  });
+
+  it('returns 404 for missing feedback', async () => {
+    const result = createTestServer({ features: { feedback: true } });
+    const server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    const port = server.address().port;
+
+    const { status } = await fetchJSON(port, '/api/feedback/no-feedback.md');
+    assert.equal(status, 404);
+
+    server.close();
   });
 });

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -219,4 +219,23 @@ describe('buildHTML', () => {
     assert.ok(html.includes('project: loadProjectFile'));
     assert.ok(html.includes('data-tab="project"'));
   });
+
+  it('includes outputs tab JS when configured', () => {
+    const config = {
+      ...baseConfig,
+      features: { tabs: ['journal', 'outputs', 'status'], outputs: true },
+    };
+    const html = buildHTML(config);
+    assert.ok(html.includes('data-tab="outputs"'));
+    assert.ok(html.includes('function loadOutputs'));
+    assert.ok(html.includes('function viewOutput'));
+    assert.ok(html.includes('function submitFeedback'));
+    assert.ok(html.includes('outputs: loadOutputs'));
+  });
+
+  it('excludes outputs tab JS when not configured', () => {
+    const html = buildHTML(baseConfig);
+    assert.ok(!html.includes('function loadOutputs'));
+    assert.ok(!html.includes('function viewOutput'));
+  });
 });


### PR DESCRIPTION
## Summary
- Created `lib/routes/outputs.js` with GET /api/outputs, GET/DELETE /api/output/:filename, GET /api/projects/:slug/outputs (gated by `features.outputs`), GET/POST /api/feedback/:filename (gated by `features.feedback`)
- Created `lib/ui/tabs/outputs.js` with output list, detail view with markdown rendering, feedback panel (thumbs up/down + notes), delete button
- Path traversal protection on all filename parameters
- Feedback stored as YAML files (rating: up/down, notes, reviewed_at timestamp)
- 14 new tests, 147 total passing

Refs #17

## Test plan
- [x] All 147 tests pass
- [x] Output list returns files with review status and rating
- [x] Output detail serves markdown content
- [x] Feedback creates/reads YAML files correctly
- [x] Delete removes both output and feedback files
- [x] Routes not registered when features disabled
- [x] Path traversal blocked
- [x] Rating validation (1=down, 2=up only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)