### PR TITLE
Deploy + service restart + URL state

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,7 @@ require('./lib/routes/health').register(routes, config);
 require('./lib/routes/requests').register(routes, config);
 require('./lib/routes/projects').register(routes, config);
 require('./lib/routes/outputs').register(routes, config);
+require('./lib/routes/deploy').register(routes, config);
 
 // Build HTML page (cached — config doesn't change at runtime)
 let cachedHTML;

--- a/lib/routes/deploy.js
+++ b/lib/routes/deploy.js
@@ -1,0 +1,62 @@
+// deploy.js — Deploy signal + service restart routes
+// Registered when features.deploy or features.serviceRestart are configured
+
+const fs = require('fs');
+const path = require('path');
+const { sendJSON } = require('../helpers');
+
+function register(routes, config) {
+  const agentDir = config.agentDir || '.';
+
+  // POST /api/deploy — write deploy signal file
+  if (config.features && config.features.deploy) {
+    routes['POST /api/deploy'] = (req, res) => {
+      const signalPath = config.features.deploySignalFile
+        || path.join('/tmp', (config.name || 'agent').toLowerCase() + '-deploy-request');
+      try {
+        fs.writeFileSync(signalPath, new Date().toISOString());
+        sendJSON(res, 202, { ok: true, message: 'Deploy requested. Supervisor will pick it up shortly.' });
+      } catch (e) {
+        sendJSON(res, 500, { error: 'Failed to write deploy signal: ' + e.message });
+      }
+    };
+  }
+
+  // POST /api/services/:name/restart — restart a named service
+  if (config.features && config.features.serviceRestart) {
+    const allowedServices = Array.isArray(config.features.serviceRestart)
+      ? config.features.serviceRestart : [];
+
+    routes['POST /api/services/:name/restart'] = (req, res) => {
+      const name = req.params.name;
+      if (!allowedServices.includes(name)) {
+        return sendJSON(res, 400, {
+          error: 'Unknown service: ' + name + '. Valid: ' + allowedServices.join(', '),
+        });
+      }
+
+      // Special case: restarting the portal server itself
+      if (name === config.name?.toLowerCase() + '-server' || name === 'portal-server') {
+        sendJSON(res, 200, { ok: true, message: name + ' restarting...' });
+        setTimeout(() => process.exit(0), 100);
+        return;
+      }
+
+      // For other services, try to kill via PID file
+      const pidFile = path.join('/tmp', name.replace(/\s/g, '-') + '.pid');
+      try {
+        if (fs.existsSync(pidFile)) {
+          const pid = parseInt(fs.readFileSync(pidFile, 'utf-8').trim(), 10);
+          process.kill(pid, 'SIGTERM');
+          sendJSON(res, 200, { ok: true, message: name + ' restarting (killed PID ' + pid + ')...' });
+        } else {
+          sendJSON(res, 200, { ok: true, message: name + ' restart requested (no PID file found)' });
+        }
+      } catch (e) {
+        sendJSON(res, 500, { error: 'Failed to restart ' + name + ': ' + e.message });
+      }
+    };
+  }
+}
+
+module.exports = { register };

--- a/lib/ui/shell.js
+++ b/lib/ui/shell.js
@@ -9,6 +9,7 @@ const { getHealthTabJS } = require('./tabs/health');
 const { getRequestsTabJS } = require('./tabs/requests');
 const { getOutputsTabJS } = require('./tabs/outputs');
 const { getProjectSidebarJS } = require('./sidebar-projects');
+const { getURLStateJS } = require('./url-state');
 
 /**
  * Build the full SPA HTML page string from config.
@@ -72,8 +73,10 @@ function buildHTML(config) {
 
   // Project sidebar support
   let projectSidebarJS = '';
+  let urlStateJS = '';
   if (sidebarType === 'projects') {
     projectSidebarJS = getProjectSidebarJS();
+    urlStateJS = getURLStateJS();
     // Override journal loader to use per-project journal when project selected
     tabLoaderEntries[0] = `journal: loadProjectJournal`;
     // Add project tab loader
@@ -123,7 +126,12 @@ function buildHTML(config) {
     initJS = `async function init() {
   await loadProjects();
   await loadNextRun();
-  ${hasRunningLog ? 'await selectBobboLog();' : 'if (projects.length > 0) await selectProject(projects[0].slug);'}
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('project') || params.get('view')) {
+    await initFromURL();
+  } else {
+    ${hasRunningLog ? 'await selectBobboLog();' : 'if (projects.length > 0) await selectProject(projects[0].slug);'}
+  }
 }`;
   } else {
     initJS = `async function init() {
@@ -171,6 +179,7 @@ ${getClientCore()}
 ${projectSidebarJS}
 ${tabJS}
 ${tabLoadersJS}
+${urlStateJS}
 
 // --- Init ---
 ${initJS}

--- a/lib/ui/url-state.js
+++ b/lib/ui/url-state.js
@@ -1,0 +1,101 @@
+// url-state.js — URL state management for Bobbo-style project navigation
+// Encodes project + tab + output as query params, supports back/forward
+
+/**
+ * Get the URL state management client-side JS string.
+ * Requires the project sidebar JS to be loaded first (currentSlug, currentTab, etc.)
+ */
+function getURLStateJS() {
+  return `
+let suppressPushState = false;
+
+function pushURLState() {
+  if (suppressPushState) return;
+  const state = { slug: currentSlug, tab: currentTab, outputFile: typeof currentOutputFile !== 'undefined' ? currentOutputFile : null };
+  const params = new URLSearchParams();
+  if (currentSlug) params.set('project', currentSlug);
+  if (currentTab && currentTab !== 'journal') params.set('tab', currentTab);
+  if (state.outputFile) params.set('output', state.outputFile);
+  if (!currentSlug && !state.outputFile) {
+    const logItem = document.getElementById('bobbo-log-item');
+    if (logItem && logItem.classList.contains('active')) {
+      params.set('view', 'log');
+    }
+  }
+  const qs = params.toString();
+  const url = qs ? '?' + qs : '/';
+  history.pushState(state, '', url);
+}
+
+window.addEventListener('popstate', async function(e) {
+  suppressPushState = true;
+  if (e.state && e.state.slug) {
+    currentSlug = e.state.slug;
+    currentTab = e.state.tab || 'journal';
+    if (typeof currentOutputFile !== 'undefined') currentOutputFile = e.state.outputFile || null;
+    const logItem = document.getElementById('bobbo-log-item');
+    if (logItem) logItem.classList.remove('active');
+    renderSidebar();
+    document.getElementById('tabs').style.display = 'flex';
+    document.querySelectorAll('.tab').forEach(function(t) {
+      t.classList.toggle('active', t.dataset.tab === currentTab);
+    });
+    const loader = TAB_LOADERS[currentTab];
+    if (loader) await loader();
+  } else {
+    await selectBobboLog();
+  }
+  suppressPushState = false;
+});
+
+// Override selectProject/selectBobboLog/switchTab to push URL state
+const _origSelectProject = selectProject;
+selectProject = async function(slug) {
+  await _origSelectProject(slug);
+  pushURLState();
+};
+
+const _origSelectBobboLog = selectBobboLog;
+selectBobboLog = async function() {
+  await _origSelectBobboLog();
+  pushURLState();
+};
+
+const _origSwitchTab = switchTab;
+switchTab = function(tab) {
+  _origSwitchTab(tab);
+  pushURLState();
+};
+
+async function initFromURL() {
+  const params = new URLSearchParams(window.location.search);
+  const slug = params.get('project');
+  const tab = params.get('tab') || 'journal';
+  const outputFile = params.get('output');
+  const view = params.get('view');
+
+  suppressPushState = true;
+  if (slug) {
+    currentSlug = slug;
+    currentTab = tab;
+    if (typeof currentOutputFile !== 'undefined') currentOutputFile = outputFile || null;
+    const logItem = document.getElementById('bobbo-log-item');
+    if (logItem) logItem.classList.remove('active');
+    renderSidebar();
+    document.getElementById('tabs').style.display = 'flex';
+    document.querySelectorAll('.tab').forEach(function(t) {
+      t.classList.toggle('active', t.dataset.tab === currentTab);
+    });
+    const loader = TAB_LOADERS[currentTab];
+    if (loader) await loader();
+    if (outputFile && typeof viewOutput === 'function') await viewOutput(outputFile);
+  } else if (view === 'log') {
+    await selectBobboLog();
+  }
+  suppressPushState = false;
+  history.replaceState({ slug: currentSlug, tab: currentTab, outputFile: typeof currentOutputFile !== 'undefined' ? currentOutputFile : null }, '', window.location.href);
+}
+`;
+}
+
+module.exports = { getURLStateJS };

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -37,6 +37,7 @@ function bootPortal(configOverrides = {}) {
   require('../lib/routes/requests').register(routes, config);
   require('../lib/routes/projects').register(routes, config);
   require('../lib/routes/outputs').register(routes, config);
+  require('../lib/routes/deploy').register(routes, config);
 
   const getHTML = () => buildHTML(config);
 

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -32,6 +32,7 @@ function createTestServer(configOverrides = {}) {
   require('../lib/routes/requests').register(routes, config);
   require('../lib/routes/projects').register(routes, config);
   require('../lib/routes/outputs').register(routes, config);
+  require('../lib/routes/deploy').register(routes, config);
 
   return { server: createServer(config, { routes, getHTML: () => '<html>test</html>' }), config };
 }
@@ -955,5 +956,94 @@ describe('GET /api/feedback/:filename', () => {
     assert.equal(status, 404);
 
     server.close();
+  });
+});
+
+// --- Deploy routes ---
+
+describe('POST /api/deploy', () => {
+  let server, port, tmpDir;
+
+  before(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'portal-deploy-'));
+    fs.mkdirSync(path.join(tmpDir, 'journals'));
+    fs.mkdirSync(path.join(tmpDir, 'logs'));
+
+    const result = createTestServer({
+      agentDir: tmpDir,
+      name: 'TestAgent',
+      features: { deploy: true, deploySignalFile: path.join(tmpDir, 'deploy-signal') },
+    });
+    server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    port = server.address().port;
+  });
+
+  after(() => {
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('writes deploy signal file', async () => {
+    const { status, data } = await fetchJSON(port, '/api/deploy', { method: 'POST' });
+    assert.equal(status, 202);
+    assert.equal(data.ok, true);
+    assert.ok(data.message.includes('Deploy requested'));
+    // Verify signal file was written
+    const content = fs.readFileSync(path.join(tmpDir, 'deploy-signal'), 'utf-8');
+    assert.ok(content.match(/^\d{4}-/)); // ISO timestamp
+  });
+
+  it('returns 404 when feature disabled', async () => {
+    const result = createTestServer({ features: {} });
+    const server2 = result.server;
+    await new Promise(resolve => server2.listen(0, resolve));
+    const port2 = server2.address().port;
+
+    const { status } = await fetchJSON(port2, '/api/deploy', { method: 'POST' });
+    assert.equal(status, 404);
+
+    server2.close();
+  });
+});
+
+describe('POST /api/services/:name/restart', () => {
+  let server, port;
+
+  before(async () => {
+    const result = createTestServer({
+      features: { serviceRestart: ['review-server', 'telegram-poller'] },
+    });
+    server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    port = server.address().port;
+  });
+
+  after(() => server.close());
+
+  it('accepts valid service name', async () => {
+    // telegram-poller won't actually restart (no PID file), but route accepts it
+    const { status, data } = await fetchJSON(port, '/api/services/telegram-poller/restart', { method: 'POST' });
+    assert.equal(status, 200);
+    assert.equal(data.ok, true);
+  });
+
+  it('rejects unknown service name', async () => {
+    const { status, data } = await fetchJSON(port, '/api/services/unknown-service/restart', { method: 'POST' });
+    assert.equal(status, 400);
+    assert.ok(data.error.includes('Unknown service'));
+    assert.ok(data.error.includes('review-server'));
+  });
+
+  it('returns 404 when feature disabled', async () => {
+    const result = createTestServer({ features: {} });
+    const server2 = result.server;
+    await new Promise(resolve => server2.listen(0, resolve));
+    const port2 = server2.address().port;
+
+    const { status } = await fetchJSON(port2, '/api/services/anything/restart', { method: 'POST' });
+    assert.equal(status, 404);
+
+    server2.close();
   });
 });

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -238,4 +238,23 @@ describe('buildHTML', () => {
     assert.ok(!html.includes('function loadOutputs'));
     assert.ok(!html.includes('function viewOutput'));
   });
+
+  it('includes URL state JS for project sidebar', () => {
+    const config = {
+      ...baseConfig,
+      sidebar: { type: 'projects', runningLog: true },
+      features: { tabs: ['journal', 'outputs', 'project', 'status'] },
+    };
+    const html = buildHTML(config);
+    assert.ok(html.includes('function pushURLState'));
+    assert.ok(html.includes('function initFromURL'));
+    assert.ok(html.includes('popstate'));
+    assert.ok(html.includes('initFromURL'));
+  });
+
+  it('excludes URL state JS for simple sidebar', () => {
+    const html = buildHTML(baseConfig);
+    assert.ok(!html.includes('function pushURLState'));
+    assert.ok(!html.includes('function initFromURL'));
+  });
 });


### PR DESCRIPTION
## Summary
- Created `lib/routes/deploy.js` with POST /api/deploy (writes signal file, gated by `features.deploy`) and POST /api/services/:name/restart (validates against `features.serviceRestart` allowlist)
- Created `lib/ui/url-state.js` with pushState/popstate support for Bobbo's project navigation model (project + tab + output encoded as query params)
- Updated shell.js to conditionally include URL state JS for project sidebar, with initFromURL on page load
- 7 new tests, 154 total passing

Refs #19

## Test plan
- [x] All 154 tests pass
- [x] Deploy writes signal file with timestamp
- [x] Service restart accepts valid names from allowlist
- [x] Service restart rejects unknown names
- [x] Routes return 404 when features disabled
- [x] URL state JS included only for project sidebar
- [x] URL state JS excluded for simple sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)