### PR TITLE
Add submit button for text-only feedback

### DIFF
--- a/lib/ui/tabs/outputs.js
+++ b/lib/ui/tabs/outputs.js
@@ -64,6 +64,7 @@ async function viewOutput(filename) {
     html += '<button class="refresh-btn" onclick="submitFeedback(\\'' + escapeHtml(filename) + '\\', 2)">\\u{1F44D} Thumbs Up</button>';
     html += '<button class="refresh-btn" onclick="submitFeedback(\\'' + escapeHtml(filename) + '\\', 1)">\\u{1F44E} Thumbs Down</button>';
     html += '<input id="feedback-notes" type="text" placeholder="Notes (optional)" style="flex:1;padding:6px 10px;border:1px solid #ddd;border-radius:6px;font-size:13px">';
+    html += '<button class="refresh-btn" onclick="submitFeedback(\\'' + escapeHtml(filename) + '\\', null)">Submit</button>';
     html += '</div>';
     html += '<div style="margin-top:8px"><button class="refresh-btn" style="background:#fce4ec;color:#c62828" onclick="deleteOutput(\\'' + escapeHtml(filename) + '\\')">Delete Output</button></div>';
     html += '</div>';
@@ -99,11 +100,15 @@ async function loadFeedback(filename) {
 async function submitFeedback(filename, rating) {
   const notesEl = document.getElementById('feedback-notes');
   const notes = notesEl ? notesEl.value.trim() : '';
+  if (!rating && !notes) return;
+  const body = {};
+  if (rating) body.rating = rating;
+  if (notes) body.notes = notes;
   try {
     await fetch('/api/feedback/' + encodeURIComponent(filename), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ rating: rating, notes: notes })
+      body: JSON.stringify(body)
     });
     loadFeedback(filename);
     if (notesEl) notesEl.value = '';

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -911,6 +911,19 @@ describe('POST /api/feedback/:filename', () => {
     assert.ok(content.includes('rating: down'));
   });
 
+  it('creates feedback with notes only (no rating)', async () => {
+    const { status, data } = await fetchJSON(port, '/api/feedback/notes-only.md', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ notes: 'Just a comment' }),
+    });
+    assert.equal(status, 200);
+    assert.equal(data.ok, true);
+    const content = fs.readFileSync(path.join(tmpDir, 'input', 'feedback', 'notes-only.feedback.yaml'), 'utf-8');
+    assert.ok(!content.includes('rating:'));
+    assert.ok(content.includes('Just a comment'));
+  });
+
   it('rejects invalid rating', async () => {
     const { status, data } = await fetchJSON(port, '/api/feedback/test.md', {
       method: 'POST',


### PR DESCRIPTION
## Summary
- Added a "Submit" button to the feedback panel so users can submit text notes without choosing thumbs up/down
- Updated `submitFeedback()` to handle null rating (notes-only submission) and skip empty submissions
- Added test for notes-only feedback creation

Refs #26

## Test plan
- [x] All 172 tests pass (was 171, +1 new test for notes-only feedback)
- [ ] Verify submit button appears next to notes input in browser
- [ ] Verify clicking Submit with notes but no rating creates feedback file with notes only
- [ ] Verify clicking Submit with empty notes and no rating does nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)