### PR TITLE
Add Claude credentials status indicator

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,7 @@ require('./lib/routes/requests').register(routes, config);
 require('./lib/routes/projects').register(routes, config);
 require('./lib/routes/outputs').register(routes, config);
 require('./lib/routes/deploy').register(routes, config);
+require('./lib/routes/claude').register(routes, config);
 
 // Build HTML page (cached — config doesn't change at runtime)
 let cachedHTML;

--- a/lib/routes/claude.js
+++ b/lib/routes/claude.js
@@ -1,0 +1,21 @@
+// routes/claude.js — /api/claude/status
+
+const { execSync } = require('child_process');
+const { sendJSON } = require('../helpers');
+
+function register(routes) {
+  routes['GET /api/claude/status'] = (req, res) => {
+    try {
+      const output = execSync('claude auth status --json', {
+        encoding: 'utf-8',
+        timeout: 5000,
+      });
+      const status = JSON.parse(output);
+      sendJSON(res, 200, status);
+    } catch {
+      sendJSON(res, 200, { loggedIn: false });
+    }
+  };
+}
+
+module.exports = { register };

--- a/lib/ui/client-core.js
+++ b/lib/ui/client-core.js
@@ -83,6 +83,29 @@ async function updateStatusDot() {
   } catch {}
 }
 
+// --- Claude credentials status ---
+async function updateClaudeStatus() {
+  const el = document.getElementById('claude-status');
+  if (!el) return;
+  try {
+    const res = await fetch('/api/claude/status');
+    const data = await res.json();
+    if (data.loggedIn) {
+      const sub = data.subscriptionType ? ' (' + escapeHtml(data.subscriptionType) + ')' : '';
+      el.innerHTML = '<span class="status-dot status-green" style="width:8px;height:8px;vertical-align:middle;margin-right:4px"></span>Claude: authenticated' + sub;
+      el.title = (data.email || '') + ' via ' + (data.authMethod || 'unknown');
+      el.style.color = '#2e7d32';
+    } else {
+      el.innerHTML = '<span class="status-dot status-red" style="width:8px;height:8px;vertical-align:middle;margin-right:4px"></span>Claude: not authenticated';
+      el.title = 'Claude credentials missing or expired';
+      el.style.color = '#c62828';
+    }
+  } catch {
+    el.textContent = 'Claude: unknown';
+    el.style.color = '#888';
+  }
+}
+
 // --- Next run ---
 async function loadNextRun() {
   try {
@@ -377,11 +400,34 @@ async function loadStatus() {
       + '<div class="value">' + formatTimestamp(status.serverTime || '') + '</div>'
       + '</div>';
 
+    // Claude credentials
+    html += '<div id="claude-status-detail" class="status-card">'
+      + '<div class="label">Claude Credentials</div>'
+      + '<div class="value">Loading...</div>'
+      + '</div>';
+
     html += '</div>';
 
     contentEl.innerHTML = html;
     contentEl.querySelectorAll('.md-content a').forEach(function(a) { a.target = '_blank'; a.rel = 'noopener'; });
     contentEl.scrollTop = 0;
+
+    // Load Claude credentials detail
+    try {
+      const claudeRes = await fetch('/api/claude/status');
+      const claudeData = await claudeRes.json();
+      const detailEl = document.getElementById('claude-status-detail');
+      if (detailEl) {
+        if (claudeData.loggedIn) {
+          detailEl.querySelector('.value').innerHTML = '<span style="color:#2e7d32">Authenticated</span>'
+            + (claudeData.email ? ' &middot; ' + escapeHtml(claudeData.email) : '')
+            + (claudeData.subscriptionType ? ' &middot; ' + escapeHtml(claudeData.subscriptionType) : '')
+            + (claudeData.authMethod ? ' &middot; ' + escapeHtml(claudeData.authMethod) : '');
+        } else {
+          detailEl.querySelector('.value').innerHTML = '<span style="color:#c62828">Not authenticated</span>';
+        }
+      }
+    } catch {}
   } catch (err) {
     contentEl.innerHTML = '<div class="empty">Failed to load status</div>';
   }

--- a/lib/ui/shell.js
+++ b/lib/ui/shell.js
@@ -95,6 +95,7 @@ function buildHTML(config) {
     sidebarHTML = `<div id="sidebar">
   <h1>${name}</h1>
   <div id="next-run">Next run: loading...</div>
+  <div id="claude-status" style="font-size:12px;padding:0 16px 8px;color:#888">Claude: checking...</div>
   <div id="cron-toggle-wrap" style="padding:4px 16px 8px;display:none"><button id="cron-toggle-btn" class="refresh-btn" style="width:100%" onclick="toggleCron()">Loading...</button></div>
   <div style="padding:4px 16px 8px;display:flex;gap:6px">
     <button id="run-cycle-btn" class="refresh-btn" style="flex:1" onclick="runCycle()">Run Cycle</button>
@@ -115,6 +116,7 @@ function buildHTML(config) {
     <span id="status-dot" class="status-dot status-red" title="Unknown"></span>
   </div>
   <div id="next-run">Next run: loading...</div>
+  <div id="claude-status" style="font-size:12px;padding:0 16px 8px;color:#888">Claude: checking...</div>
   <div id="cron-toggle-wrap" style="padding:4px 16px 8px;display:none"><button id="cron-toggle-btn" class="refresh-btn" style="width:100%" onclick="toggleCron()">Loading...</button></div>
   <div style="padding:4px 16px 8px;display:flex;gap:6px">
     <button id="run-cycle-btn" class="refresh-btn" style="flex:1" onclick="runCycle()">Run Cycle</button>
@@ -134,7 +136,7 @@ function buildHTML(config) {
   if (sidebarType === 'projects') {
     initJS = `async function init() {
   await loadProjects();
-  await Promise.all([loadNextRun(), updateStatusDot()]);
+  await Promise.all([loadNextRun(), updateStatusDot(), updateClaudeStatus()]);
   const params = new URLSearchParams(window.location.search);
   if (params.get('project') || params.get('view')) {
     await initFromURL();
@@ -148,6 +150,7 @@ function buildHTML(config) {
     updateStatusDot(),
     loadNextRun(),
     loadQuickStats(),
+    updateClaudeStatus(),
   ]);
   switchTab(currentTab);
 }`;
@@ -196,6 +199,7 @@ ${initJS}
 init();
 setInterval(loadNextRun, 60000);
 setInterval(updateStatusDot, 10000);
+setInterval(updateClaudeStatus, 60000);
 <\/script>
 </body>
 </html>`;

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -33,6 +33,7 @@ function createTestServer(configOverrides = {}) {
   require('../lib/routes/projects').register(routes, config);
   require('../lib/routes/outputs').register(routes, config);
   require('../lib/routes/deploy').register(routes, config);
+  require('../lib/routes/claude').register(routes, config);
 
   return { server: createServer(config, { routes, getHTML: () => '<html>test</html>' }), config };
 }
@@ -1058,5 +1059,22 @@ describe('POST /api/services/:name/restart', () => {
     assert.equal(status, 404);
 
     server2.close();
+  });
+});
+
+// --- Claude status route ---
+
+describe('GET /api/claude/status', () => {
+  it('returns a response with loggedIn field', async () => {
+    const result = createTestServer();
+    const server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    const port = server.address().port;
+
+    const { status, data } = await fetchJSON(port, '/api/claude/status');
+    assert.equal(status, 200);
+    assert.equal(typeof data.loggedIn, 'boolean');
+
+    server.close();
   });
 });

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -128,6 +128,13 @@ describe('buildHTML', () => {
     assert.ok(html.includes('function runRespond'));
   });
 
+  it('includes Claude credentials status indicator', () => {
+    const html = buildHTML(baseConfig);
+    assert.ok(html.includes('id="claude-status"'));
+    assert.ok(html.includes('function updateClaudeStatus'));
+    assert.ok(html.includes('setInterval(updateClaudeStatus'));
+  });
+
   it('includes cycle-running status indicator', () => {
     const html = buildHTML(baseConfig);
     assert.ok(html.includes('id="cycle-status"'));


### PR DESCRIPTION
## Summary
- New `/api/claude/status` endpoint that shells out to `claude auth status --json` (5s timeout, graceful fallback)
- Sidebar indicator shows green/red dot with auth state, subscription type, and email tooltip
- Status tab shows full credential details (email, subscription, auth method) in the System section
- Polls every 60 seconds; indicator present in both simple and projects sidebar layouts

Refs #25

## Test plan
- [x] All 174 tests pass (was 172, +2 new: route test + UI test)
- [ ] Verify sidebar shows green dot with tooltip when Claude is authenticated
- [ ] Verify sidebar shows red dot when Claude is not authenticated
- [ ] Verify status tab System section shows credential details

🤖 Generated with [Claude Code](https://claude.com/claude-code)