### PR TITLE
Add edit support for journal entries

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -108,4 +108,33 @@ function parseFrontmatter(content) {
   return fm;
 }
 
-module.exports = { sendJSON, readBody, readLastLines, parseJournal, getAllJournalEntries, parseFrontmatter };
+/**
+ * Edit a journal entry in a markdown file by timestamp.
+ * Finds the entry matching `ts`, replaces its content and tag.
+ * Returns true if found and updated, false otherwise.
+ */
+function editJournalEntry(filePath, ts, newText, newTag) {
+  if (!fs.existsSync(filePath)) return false;
+  const content = fs.readFileSync(filePath, 'utf-8');
+
+  const firstEntryIdx = content.search(/^### /m);
+  if (firstEntryIdx === -1) return false;
+  const header = content.substring(0, firstEntryIdx);
+
+  const entries = parseJournal(content);
+  const idx = entries.findIndex(e => e.ts === ts);
+  if (idx === -1) return false;
+
+  entries[idx].content = newText;
+  entries[idx].tag = newTag;
+
+  let rebuilt = header;
+  for (const entry of entries) {
+    rebuilt += `### ${entry.ts} | ${entry.author} | ${entry.tag}\n\n${entry.content}\n\n`;
+  }
+
+  fs.writeFileSync(filePath, rebuilt);
+  return true;
+}
+
+module.exports = { sendJSON, readBody, readLastLines, parseJournal, getAllJournalEntries, parseFrontmatter, editJournalEntry };

--- a/lib/routes/journal.js
+++ b/lib/routes/journal.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { sendJSON, readBody, getAllJournalEntries } = require('../helpers');
+const { sendJSON, readBody, getAllJournalEntries, editJournalEntry } = require('../helpers');
 
 const VALID_TAGS = ['output', 'feedback', 'outcome', 'observation', 'note', 'direction', 'question'];
 
@@ -48,6 +48,41 @@ function register(routes, config) {
       fs.writeFileSync(journalPath, header + entry);
     } else {
       fs.appendFileSync(journalPath, entry);
+    }
+
+    sendJSON(res, 200, { ok: true, ts, tag });
+  };
+
+  routes['PUT /api/journal'] = async (req, res) => {
+    const body = await readBody(req);
+    let data;
+    try {
+      data = JSON.parse(body);
+    } catch {
+      return sendJSON(res, 400, { error: 'Invalid JSON' });
+    }
+
+    const ts = (data.ts || '').trim();
+    const text = (data.text || '').trim();
+    const tag = (data.tag || '').trim();
+
+    if (!ts) return sendJSON(res, 400, { error: 'ts is required' });
+    if (!text) return sendJSON(res, 400, { error: 'text is required' });
+    if (!tag || !VALID_TAGS.includes(tag)) {
+      return sendJSON(res, 400, { error: 'Invalid tag. Must be one of: ' + VALID_TAGS.join(', ') });
+    }
+
+    // Determine which journal file contains this entry by parsing the timestamp
+    const d = new Date(ts);
+    if (isNaN(d.getTime())) return sendJSON(res, 400, { error: 'Invalid timestamp' });
+
+    const yyyy = d.getUTCFullYear();
+    const mm = String(d.getUTCMonth() + 1).padStart(2, '0');
+    const filename = `${yyyy}-${mm}.md`;
+    const journalPath = path.join(journalsDir, filename);
+
+    if (!editJournalEntry(journalPath, ts, text, tag)) {
+      return sendJSON(res, 404, { error: 'Entry not found' });
     }
 
     sendJSON(res, 200, { ok: true, ts, tag });

--- a/lib/routes/projects.js
+++ b/lib/routes/projects.js
@@ -3,7 +3,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { sendJSON, readBody, parseJournal, parseFrontmatter } = require('../helpers');
+const { sendJSON, readBody, parseJournal, parseFrontmatter, editJournalEntry } = require('../helpers');
 
 function getOutputFiles(agentDir) {
   const outputDir = path.join(agentDir, 'output');
@@ -134,6 +134,38 @@ function register(routes, config) {
           fs.writeFileSync(journalPath, header + entry);
         } else {
           fs.appendFileSync(journalPath, entry);
+        }
+
+        sendJSON(res, 200, { ok: true, ts, tag });
+      } catch {
+        sendJSON(res, 400, { error: 'Invalid JSON' });
+      }
+    });
+  };
+
+  // PUT /api/projects/:slug/journal — edit a per-project journal entry
+  routes['PUT /api/projects/:slug/journal'] = (req, res) => {
+    const slug = req.params.slug;
+    const journalPath = path.join(journalsDir, slug + '.md');
+    if (!journalPath.startsWith(journalsDir)) {
+      return sendJSON(res, 400, { error: 'Invalid slug' });
+    }
+
+    readBody(req).then(body => {
+      try {
+        const data = JSON.parse(body);
+        const ts = (data.ts || '').trim();
+        const text = (data.text || '').trim();
+        const tag = (data.tag || '').trim();
+        if (!ts) return sendJSON(res, 400, { error: 'ts is required' });
+        if (!text) return sendJSON(res, 400, { error: 'text is required' });
+        const validTags = ['output', 'feedback', 'outcome', 'observation', 'note', 'direction', 'question'];
+        if (!tag || !validTags.includes(tag)) {
+          return sendJSON(res, 400, { error: 'Invalid tag. Must be one of: ' + validTags.join(', ') });
+        }
+
+        if (!editJournalEntry(journalPath, ts, text, tag)) {
+          return sendJSON(res, 404, { error: 'Entry not found' });
         }
 
         sendJSON(res, 200, { ok: true, ts, tag });

--- a/lib/ui/client-core.js
+++ b/lib/ui/client-core.js
@@ -242,18 +242,22 @@ async function loadJournal() {
   try {
     const res = await fetch('/api/journal');
     const data = await res.json();
+    _journalEntries = data.entries || [];
     let html = '<div class="journal-thread">';
 
-    if (!data.entries || data.entries.length === 0) {
+    if (_journalEntries.length === 0) {
       html += '<div class="empty" style="margin-top:60px">No journal entries yet. Add the first note below.</div>';
     } else {
-      data.entries.forEach(function(e) {
+      data.entries.forEach(function(e, idx) {
         const dateStr = formatTimestamp(e.ts);
-        html += '<div class="journal-entry author-' + escapeHtml(e.author) + '">'
+        const editBtn = e.author === 'rob'
+          ? '<button class="edit-entry-btn" onclick="startEditEntry(' + idx + ', false)" title="Edit">Edit</button>' : '';
+        html += '<div class="journal-entry author-' + escapeHtml(e.author) + '" id="entry-' + idx + '">'
           + '<div class="journal-entry-header">'
           + '<span class="author-badge ' + escapeHtml(e.author) + '">' + escapeHtml(e.author) + '</span>'
           + '<span class="tag-badge tag-' + escapeHtml(e.tag) + '">' + escapeHtml(e.tag) + '</span>'
           + '<span class="timestamp">' + dateStr + '</span>'
+          + editBtn
           + '</div>'
           + '<div class="journal-entry-body md-content">' + marked.parse(e.content) + '</div>'
           + '</div>';
@@ -306,6 +310,70 @@ async function submitNote() {
     });
   } catch {}
   await loadJournal();
+}
+
+var _journalEntries = [];
+
+function startEditEntry(idx, isProjectJournal) {
+  var entry = _journalEntries[idx];
+  if (!entry) return;
+  var el = document.getElementById('entry-' + idx);
+  if (!el) return;
+  var bodyEl = el.querySelector('.journal-entry-body');
+  if (!bodyEl) return;
+
+  var tagOptions = ['note','output','feedback','outcome','observation','direction','question'];
+  var tagSelect = '<select id="edit-tag-' + idx + '">'
+    + tagOptions.map(function(t) { return '<option value="' + t + '"' + (t === entry.tag ? ' selected' : '') + '>' + t + '</option>'; }).join('')
+    + '</select>';
+
+  bodyEl.innerHTML = '<div class="edit-entry-form">'
+    + '<textarea id="edit-text-' + idx + '">' + escapeHtml(entry.content) + '</textarea>'
+    + '<div class="form-row">'
+    + tagSelect
+    + '<button onclick="saveEditEntry(' + idx + ', ' + isProjectJournal + ')">Save</button>'
+    + '<button class="cancel-btn" onclick="cancelEditEntry(' + idx + ', ' + isProjectJournal + ')">Cancel</button>'
+    + '</div>'
+    + '</div>';
+}
+
+async function saveEditEntry(idx, isProjectJournal) {
+  var entry = _journalEntries[idx];
+  if (!entry) return;
+  var text = document.getElementById('edit-text-' + idx).value.trim();
+  var tag = document.getElementById('edit-tag-' + idx).value;
+  if (!text) return;
+
+  var url = '/api/journal';
+  if (isProjectJournal && typeof currentSlug !== 'undefined' && currentSlug) {
+    url = '/api/projects/' + encodeURIComponent(currentSlug) + '/journal';
+  }
+
+  try {
+    var res = await fetch(url, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ts: entry.ts, text: text, tag: tag })
+    });
+    var data = await res.json();
+    if (!data.ok) { alert('Error: ' + (data.error || 'Unknown')); return; }
+  } catch { alert('Network error'); return; }
+
+  if (isProjectJournal) {
+    if (typeof loadProjectJournal === 'function') await loadProjectJournal();
+    else await loadJournal();
+  } else {
+    await loadJournal();
+  }
+}
+
+async function cancelEditEntry(idx, isProjectJournal) {
+  if (isProjectJournal) {
+    if (typeof loadProjectJournal === 'function') await loadProjectJournal();
+    else await loadJournal();
+  } else {
+    await loadJournal();
+  }
 }
 
 // --- Status tab ---

--- a/lib/ui/sidebar-projects.js
+++ b/lib/ui/sidebar-projects.js
@@ -65,16 +65,20 @@ async function selectBobboLog() {
     const res = await fetch('/api/journal');
     const data = await res.json();
     let html = '<div class="journal-thread"><h2 style="margin-bottom:16px;color:#444">Running Log</h2>';
-    if (!data.entries || data.entries.length === 0) {
+    _journalEntries = data.entries || [];
+    if (_journalEntries.length === 0) {
       html += '<div class="empty" style="margin-top:40px">No entries yet.</div>';
     } else {
-      data.entries.forEach(function(e) {
+      _journalEntries.forEach(function(e, idx) {
         const dateStr = formatTimestamp(e.ts);
-        html += '<div class="journal-entry author-' + escapeHtml(e.author) + '">'
+        const editBtn = e.author === 'rob'
+          ? '<button class="edit-entry-btn" onclick="startEditEntry(' + idx + ', false)" title="Edit">Edit</button>' : '';
+        html += '<div class="journal-entry author-' + escapeHtml(e.author) + '" id="entry-' + idx + '">'
           + '<div class="journal-entry-header">'
           + '<span class="author-badge ' + escapeHtml(e.author) + '">' + escapeHtml(e.author) + '</span>'
           + '<span class="tag-badge tag-' + escapeHtml(e.tag) + '">' + escapeHtml(e.tag) + '</span>'
           + '<span class="timestamp">' + dateStr + '</span>'
+          + editBtn
           + '</div>'
           + '<div class="journal-entry-body md-content">' + marked.parse(e.content) + '</div>'
           + '</div>';
@@ -140,17 +144,21 @@ async function loadProjectJournal() {
   try {
     const res = await fetch('/api/projects/' + encodeURIComponent(currentSlug) + '/journal');
     const data = await res.json();
+    _journalEntries = data.entries || [];
     let html = '<div class="journal-thread">';
-    if (!data.entries || data.entries.length === 0) {
+    if (_journalEntries.length === 0) {
       html += '<div class="empty" style="margin-top:60px">No journal entries yet.</div>';
     } else {
-      data.entries.forEach(function(e) {
+      _journalEntries.forEach(function(e, idx) {
         const dateStr = formatTimestamp(e.ts);
-        html += '<div class="journal-entry author-' + escapeHtml(e.author) + '">'
+        const editBtn = e.author === 'rob'
+          ? '<button class="edit-entry-btn" onclick="startEditEntry(' + idx + ', true)" title="Edit">Edit</button>' : '';
+        html += '<div class="journal-entry author-' + escapeHtml(e.author) + '" id="entry-' + idx + '">'
           + '<div class="journal-entry-header">'
           + '<span class="author-badge ' + escapeHtml(e.author) + '">' + escapeHtml(e.author) + '</span>'
           + '<span class="tag-badge tag-' + escapeHtml(e.tag) + '">' + escapeHtml(e.tag) + '</span>'
           + '<span class="timestamp">' + dateStr + '</span>'
+          + editBtn
           + '</div>'
           + '<div class="journal-entry-body md-content">' + marked.parse(e.content) + '</div>'
           + '</div>';

--- a/lib/ui/styles.js
+++ b/lib/ui/styles.js
@@ -123,6 +123,17 @@ ${authorCSS}
   .unreviewed-badge { display: inline-block; font-size: 10px; font-weight: 600; padding: 1px 6px; border-radius: 8px; background: #e3f2fd; color: #1565c0; }
   #project-list { flex: 1; overflow-y: auto; }
 
+  /* Edit entry */
+  .edit-entry-btn { margin-left: auto; padding: 2px 10px; font-size: 11px; background: #f5f5f5; border: 1px solid #ddd; border-radius: 4px; cursor: pointer; color: #666; }
+  .edit-entry-btn:hover { background: #e8e8e8; color: #333; }
+  .edit-entry-form textarea { width: 100%; min-height: 80px; border: 1px solid #ddd; border-radius: 6px; padding: 8px; font-family: inherit; font-size: 14px; resize: vertical; margin-bottom: 8px; }
+  .edit-entry-form .form-row { display: flex; gap: 8px; align-items: center; }
+  .edit-entry-form select { border: 1px solid #ddd; border-radius: 6px; padding: 6px 8px; font-family: inherit; font-size: 13px; background: #fff; }
+  .edit-entry-form button { padding: 6px 16px; background: #1a73e8; color: #fff; border: none; border-radius: 6px; font-size: 13px; cursor: pointer; }
+  .edit-entry-form button:hover { background: #1557b0; }
+  .edit-entry-form .cancel-btn { background: #fff; color: #555; border: 1px solid #ddd; }
+  .edit-entry-form .cancel-btn:hover { background: #f5f5f5; }
+
   /* Markdown styling */
   .md-content h1 { font-size: 24px; margin-bottom: 8px; }
   .md-content h2 { font-size: 20px; margin-top: 24px; margin-bottom: 8px; }

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const http = require('http');
-const { sendJSON, readBody, readLastLines, parseJournal, getAllJournalEntries, parseFrontmatter } = require('../lib/helpers');
+const { sendJSON, readBody, readLastLines, parseJournal, getAllJournalEntries, parseFrontmatter, editJournalEntry } = require('../lib/helpers');
 
 // --- parseJournal ---
 
@@ -247,5 +247,64 @@ describe('sendJSON', () => {
         });
       });
     });
+  });
+});
+
+// --- editJournalEntry ---
+
+describe('editJournalEntry', () => {
+  let tmpFile;
+
+  before(() => {
+    tmpFile = path.join(os.tmpdir(), 'test-edit-journal-' + Date.now() + '.md');
+    const content = `# Test Journal — 2026-03
+
+---
+
+### 2026-03-01T10:00:00.000Z | rob | note
+
+Original first entry
+
+### 2026-03-01T12:00:00.000Z | coder | output
+
+Agent output here
+
+### 2026-03-01T14:00:00.000Z | rob | question
+
+Should we do X?
+`;
+    fs.writeFileSync(tmpFile, content);
+  });
+
+  after(() => {
+    try { fs.unlinkSync(tmpFile); } catch {}
+  });
+
+  it('edits an existing entry by timestamp', () => {
+    const result = editJournalEntry(tmpFile, '2026-03-01T10:00:00.000Z', 'Updated first entry', 'direction');
+    assert.equal(result, true);
+    const entries = parseJournal(fs.readFileSync(tmpFile, 'utf-8'));
+    const edited = entries.find(e => e.ts === '2026-03-01T10:00:00.000Z');
+    assert.equal(edited.content, 'Updated first entry');
+    assert.equal(edited.tag, 'direction');
+    assert.equal(edited.author, 'rob');
+  });
+
+  it('preserves other entries when editing', () => {
+    const entries = parseJournal(fs.readFileSync(tmpFile, 'utf-8'));
+    assert.equal(entries.length, 3);
+    const agent = entries.find(e => e.ts === '2026-03-01T12:00:00.000Z');
+    assert.equal(agent.content, 'Agent output here');
+    assert.equal(agent.author, 'coder');
+  });
+
+  it('returns false for nonexistent timestamp', () => {
+    const result = editJournalEntry(tmpFile, '1999-01-01T00:00:00.000Z', 'nope', 'note');
+    assert.equal(result, false);
+  });
+
+  it('returns false for nonexistent file', () => {
+    const result = editJournalEntry('/nonexistent/file.md', '2026-03-01T10:00:00.000Z', 'nope', 'note');
+    assert.equal(result, false);
   });
 });

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -192,6 +192,112 @@ describe('Journal write + read integration', () => {
   });
 });
 
+describe('Journal edit integration', () => {
+  let server, port, tmpDir;
+
+  before(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'portal-int-edit-'));
+    fs.mkdirSync(path.join(tmpDir, 'journals'));
+    fs.mkdirSync(path.join(tmpDir, 'logs'));
+    fs.mkdirSync(path.join(tmpDir, 'projects'));
+
+    // Write a project file for project journal test
+    fs.writeFileSync(path.join(tmpDir, 'projects', 'test-proj.md'), '# Test Project\n');
+
+    const result = bootPortal({
+      agentDir: tmpDir,
+      sidebar: { type: 'projects', projectsDir: 'projects' },
+    });
+    server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    port = server.address().port;
+  });
+
+  after(() => {
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('edits a main journal entry via PUT /api/journal', async () => {
+    // Create entry
+    const createRes = await fetchJSON(port, '/api/journal', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: 'Original text', tag: 'note' }),
+    });
+    assert.equal(createRes.status, 200);
+    const ts = createRes.data.ts;
+
+    // Edit entry
+    const editRes = await fetchJSON(port, '/api/journal', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ts, text: 'Edited text', tag: 'direction' }),
+    });
+    assert.equal(editRes.status, 200);
+    assert.equal(editRes.data.ok, true);
+
+    // Verify edit
+    const readRes = await fetchJSON(port, '/api/journal');
+    const entry = readRes.data.entries.find(e => e.ts === ts);
+    assert.ok(entry);
+    assert.equal(entry.content, 'Edited text');
+    assert.equal(entry.tag, 'direction');
+  });
+
+  it('returns 404 for nonexistent timestamp', async () => {
+    const editRes = await fetchJSON(port, '/api/journal', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ts: '1999-01-01T00:00:00.000Z', text: 'nope', tag: 'note' }),
+    });
+    assert.equal(editRes.status, 404);
+  });
+
+  it('rejects edit with missing fields', async () => {
+    const noTs = await fetchJSON(port, '/api/journal', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: 'text', tag: 'note' }),
+    });
+    assert.equal(noTs.status, 400);
+
+    const noText = await fetchJSON(port, '/api/journal', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ts: '2026-01-01T00:00:00.000Z', tag: 'note' }),
+    });
+    assert.equal(noText.status, 400);
+  });
+
+  it('edits a project journal entry via PUT /api/projects/:slug/journal', async () => {
+    // Create project journal entry
+    const createRes = await fetchJSON(port, '/api/projects/test-proj/journal', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: 'Project original', tag: 'note' }),
+    });
+    assert.equal(createRes.status, 200);
+    const ts = createRes.data.ts;
+
+    // Edit
+    const editRes = await fetchJSON(port, '/api/projects/test-proj/journal', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ts, text: 'Project edited', tag: 'feedback' }),
+    });
+    assert.equal(editRes.status, 200);
+    assert.equal(editRes.data.ok, true);
+
+    // Verify
+    const readRes = await fetchJSON(port, '/api/projects/test-proj/journal');
+    const entry = readRes.data.entries.find(e => e.ts === ts);
+    assert.ok(entry);
+    assert.equal(entry.content, 'Project edited');
+    assert.equal(entry.tag, 'feedback');
+  });
+});
+
 describe('Config variations', () => {
   it('boots with GitHub repos configured', async () => {
     const result = bootPortal({

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -81,6 +81,9 @@ describe('buildHTML', () => {
     assert.ok(html.includes('function updateStatusDot'));
     assert.ok(html.includes('function loadNextRun'));
     assert.ok(html.includes('function init'));
+    assert.ok(html.includes('function startEditEntry'));
+    assert.ok(html.includes('function saveEditEntry'));
+    assert.ok(html.includes('function cancelEditEntry'));
     // loadGitHub is only included when GitHub feature is enabled
     assert.ok(!html.includes('function loadGitHub'));
   });


### PR DESCRIPTION
## Summary
- Adds inline edit capability for journal entries across all message surfaces (main journal, project journals, running log)
- Edit button appears on rob-authored entries; agent entries are read-only
- New `PUT /api/journal` and `PUT /api/projects/:slug/journal` endpoints
- Edit form shows textarea + tag selector with save/cancel

Refs #29

## Test plan
- [x] 8 new tests (4 unit, 4 integration) — all 182 passing
- [x] Edit main journal entry via PUT, verify content and tag updated
- [x] Edit project journal entry via PUT, verify updated
- [x] Reject edits with missing fields (400)
- [x] Reject edits for nonexistent timestamps (404)
- [x] Verify other entries preserved after edit
- [x] UI includes startEditEntry, saveEditEntry, cancelEditEntry functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)