### PR TITLE
Add mobile-friendly responsive layout

### DIFF
--- a/lib/ui/client-core.js
+++ b/lib/ui/client-core.js
@@ -11,6 +11,16 @@ function getClientCore() {
   return `
 let currentTab = PORTAL_CONFIG.tabs[0] || 'journal';
 
+function toggleSidebar() {
+  document.getElementById('sidebar').classList.toggle('open');
+  document.getElementById('sidebar-overlay').classList.toggle('open');
+}
+
+function closeSidebar() {
+  document.getElementById('sidebar').classList.remove('open');
+  document.getElementById('sidebar-overlay').classList.remove('open');
+}
+
 function escapeHtml(s) {
   return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
 }

--- a/lib/ui/shell.js
+++ b/lib/ui/shell.js
@@ -178,8 +178,11 @@ ${getStyles(authors)}
 
 ${sidebarHTML}
 
+<div id="sidebar-overlay" onclick="closeSidebar()"></div>
+
 <div id="main">
   <div id="tabs">
+    <button id="menu-btn" onclick="toggleSidebar()" aria-label="Menu">&#9776;</button>
     ${tabsHTML}
   </div>
   <div id="content"><div class="empty">Loading...</div></div>

--- a/lib/ui/sidebar-projects.js
+++ b/lib/ui/sidebar-projects.js
@@ -48,7 +48,8 @@ async function selectProject(slug) {
   const logItem = document.getElementById('bobbo-log-item');
   if (logItem) logItem.classList.remove('active');
   renderSidebar();
-  document.getElementById('tabs').style.display = 'flex';
+  document.getElementById('tabs').classList.remove('tabs-hidden');
+  closeSidebar();
   switchTab('journal');
 }
 
@@ -57,7 +58,8 @@ async function selectBobboLog() {
   renderSidebar();
   const logItem = document.getElementById('bobbo-log-item');
   if (logItem) logItem.classList.add('active');
-  document.getElementById('tabs').style.display = 'none';
+  document.getElementById('tabs').classList.add('tabs-hidden');
+  closeSidebar();
   // Load cross-project running log (the monthly journal files)
   const contentEl = document.getElementById('content');
   contentEl.innerHTML = '<div class="empty">Loading running log...</div>';

--- a/lib/ui/styles.js
+++ b/lib/ui/styles.js
@@ -149,6 +149,33 @@ ${authorCSS}
   .md-content table { border-collapse: collapse; margin-bottom: 12px; }
   .md-content th, .md-content td { border: 1px solid #ddd; padding: 8px 12px; text-align: left; }
   .md-content th { background: #f5f5f5; }
+
+  /* Tabs hidden (running log mode) — hide tab buttons but keep menu btn */
+  #tabs.tabs-hidden .tab { display: none; }
+
+  /* Mobile hamburger */
+  #menu-btn { display: none; background: none; border: none; font-size: 22px; cursor: pointer; color: #444; padding: 8px 12px; line-height: 1; }
+  #sidebar-overlay { display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.3); z-index: 9; }
+
+  /* Mobile responsive */
+  @media (max-width: 768px) {
+    #sidebar { position: fixed; top: 0; left: -280px; height: 100vh; z-index: 10; transition: left 0.2s ease; box-shadow: none; }
+    #sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.15); }
+    #sidebar-overlay.open { display: block; }
+    #menu-btn { display: block; }
+    #tabs { padding: 0 8px; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+    .tab { padding: 10px 14px; font-size: 13px; white-space: nowrap; }
+    #content { padding: 16px; }
+    .journal-entry { padding: 10px 12px; }
+    .journal-entry-header { font-size: 12px; gap: 6px; }
+    .gh-item { flex-wrap: wrap; gap: 6px; padding: 8px 12px; }
+    .gh-item .date { margin-left: 0; }
+    .event-item { flex-wrap: wrap; gap: 4px; padding: 6px 10px; }
+    .event-item .event-ts { min-width: auto; }
+    #add-note-form .form-row { flex-wrap: wrap; }
+    .edit-entry-form .form-row { flex-wrap: wrap; }
+    #sidebar h1 { padding: 16px 16px 8px; }
+  }
 `;
 }
 

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -267,4 +267,19 @@ describe('buildHTML', () => {
     assert.ok(!html.includes('function pushURLState'));
     assert.ok(!html.includes('function initFromURL'));
   });
+
+  it('includes mobile menu button and sidebar overlay', () => {
+    const html = buildHTML(baseConfig);
+    assert.ok(html.includes('id="menu-btn"'));
+    assert.ok(html.includes('id="sidebar-overlay"'));
+    assert.ok(html.includes('function toggleSidebar'));
+    assert.ok(html.includes('function closeSidebar'));
+  });
+
+  it('includes mobile responsive CSS', () => {
+    const html = buildHTML(baseConfig);
+    assert.ok(html.includes('@media (max-width: 768px)'));
+    assert.ok(html.includes('#menu-btn'));
+    assert.ok(html.includes('#sidebar-overlay'));
+  });
 });


### PR DESCRIPTION
## Summary
- Adds responsive CSS with 768px breakpoint for mobile viewports
- Hamburger menu button appears on mobile, sidebar slides in from left as fixed overlay with dimming background
- Fixes Bobbo running log mode to hide tab buttons without hiding the hamburger
- Auto-closes sidebar on project/log selection in project sidebar variant
- 2 new UI tests verifying mobile elements are present

## Test plan
- [x] All 184 tests pass (`node --test`)
- [x] Visual verification via screenshots at 375x812 (mobile) and 1280x800 (desktop)
- [x] Verified both simple sidebar and project sidebar (Bobbo) configs
- [x] Hamburger visible on mobile, hidden on desktop
- [x] Sidebar opens/closes correctly with overlay
- [x] Bobbo running log mode keeps hamburger visible

Refs #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)