### PR TITLE
Add commit link to version footer

### DIFF
--- a/lib/ui/shell.js
+++ b/lib/ui/shell.js
@@ -1,8 +1,20 @@
 // shell.js — HTML page builder for the agent portal SPA
 // Assembles the complete HTML page from config, using modular UI components
 
-const { version } = require('../../package.json');
+const { execSync } = require('child_process');
+const path = require('path');
+const pkg = require('../../package.json');
+const { version } = pkg;
 const { getStyles } = require('./styles');
+
+// Capture git commit at module load time (once, cached for server lifetime)
+let gitCommit = null;
+try {
+  const repoRoot = path.resolve(__dirname, '..', '..');
+  gitCommit = execSync('git rev-parse HEAD', { cwd: repoRoot, encoding: 'utf-8', timeout: 5000 }).trim();
+} catch {
+  // Not a git repo or git not available — graceful degradation
+}
 const { getClientCore } = require('./client-core');
 const { getGitHubTabJS } = require('./tabs/github');
 const { getRoadmapTabJS } = require('./tabs/roadmap');
@@ -27,6 +39,21 @@ function buildHTML(config) {
   const authors = config.authors || {};
   const sidebarType = (config.sidebar && config.sidebar.type) || 'simple';
   const hasRunningLog = sidebarType === 'projects' && config.sidebar && config.sidebar.runningLog;
+
+  // Build version footer with optional commit link
+  let versionFooter;
+  if (gitCommit) {
+    const shortHash = gitCommit.slice(0, 7);
+    const repoUrl = (pkg.repository && pkg.repository.url || '').replace(/\.git$/, '');
+    const commitUrl = repoUrl ? `${repoUrl}/commit/${gitCommit}` : '';
+    if (commitUrl) {
+      versionFooter = `<a href="${commitUrl}" target="_blank" rel="noopener" style="color:inherit;text-decoration:none" title="${gitCommit}">Agent Portal v${version} (${shortHash})</a>`;
+    } else {
+      versionFooter = `<span title="${gitCommit}">Agent Portal v${version} (${shortHash})</span>`;
+    }
+  } else {
+    versionFooter = `Agent Portal v${version}`;
+  }
 
   // Determine which tabs to show
   const defaultTabs = ['journal', 'status'];
@@ -107,7 +134,7 @@ function buildHTML(config) {
     <div class="meta">Cross-project cycle log</div>
   </div>` : ''}
   <div id="project-list"></div>
-  <div id="sidebar-footer">Agent Portal v${version}</div>
+  <div id="sidebar-footer">${versionFooter}</div>
 </div>`;
   } else {
     sidebarHTML = `<div id="sidebar">
@@ -127,7 +154,7 @@ function buildHTML(config) {
     <span id="stat-issues" style="display:none">-- issues open</span>
     <span id="stat-prs" style="display:none">-- PRs open</span>
   </div>
-  <div id="sidebar-footer">Agent Portal v${version}</div>
+  <div id="sidebar-footer">${versionFooter}</div>
 </div>`;
   }
 

--- a/lib/ui/styles.js
+++ b/lib/ui/styles.js
@@ -29,6 +29,7 @@ function getStyles(authors) {
   #quick-stats { font-size: 12px; color: #666; padding: 0 16px 12px; border-bottom: 1px solid #eee; }
   #quick-stats span { display: block; margin-bottom: 2px; }
   #sidebar-footer { margin-top: auto; padding: 12px 16px; font-size: 11px; color: #aaa; border-top: 1px solid #eee; }
+  #sidebar-footer a:hover { text-decoration: underline; }
 
   /* Main panel */
   #main { flex: 1; display: flex; flex-direction: column; overflow: hidden; }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robhunter/agent-portal",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Version footer in sidebar now displays "Agent Portal v1.1.0 (abc1234)" with a link to the GitHub commit
- Clicking the version text opens the commit page on GitHub in a new tab, so Rob can quickly see what code is deployed
- Full commit hash shown on hover (title attribute)
- Gracefully degrades: if not a git repo or repo URL missing, falls back to plain version text
- Version bumped from 1.0.0 → 1.1.0

## Test plan
- [x] All 184 tests pass
- [x] Verified footer renders correctly in simple sidebar mode
- [x] Verified footer renders correctly in projects sidebar mode
- [x] Link URL points to correct GitHub commit page

Refs #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)