### PR TITLE
Add drag-and-drop file upload to text areas

### DIFF
--- a/lib/ui/client-core.js
+++ b/lib/ui/client-core.js
@@ -388,42 +388,76 @@ async function cancelEditEntry(idx, isProjectJournal) {
 }
 
 // --- File upload ---
+function handleFileUpload(file, textareaId) {
+  if (!file) return;
+  if (file.size > 5 * 1024 * 1024) { alert('File too large (max 5MB)'); return; }
+  var reader = new FileReader();
+  reader.onload = async function() {
+    var base64 = reader.result.split(',')[1];
+    try {
+      var res = await fetch('/api/upload', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ filename: file.name, data: base64 })
+      });
+      var data = await res.json();
+      if (!data.ok) { alert('Upload failed: ' + (data.error || 'Unknown')); return; }
+      var textarea = document.getElementById(textareaId);
+      if (textarea) {
+        var isImage = /\\.(png|jpg|jpeg|gif|webp|svg)$/i.test(file.name);
+        var ref = isImage ? '![' + file.name + '](' + data.url + ')' : '[' + file.name + '](' + data.url + ')';
+        var pos = textarea.selectionStart || textarea.value.length;
+        var before = textarea.value.substring(0, pos);
+        var after = textarea.value.substring(pos);
+        var sep = before.length > 0 && !before.endsWith('\\n') ? '\\n' : '';
+        textarea.value = before + sep + ref + after;
+        textarea.focus();
+      }
+    } catch { alert('Upload failed'); }
+  };
+  reader.readAsDataURL(file);
+}
+
 function uploadFile(textareaId) {
   var input = document.createElement('input');
   input.type = 'file';
   input.accept = 'image/*,.pdf,.txt';
-  input.onchange = async function() {
-    var file = input.files[0];
-    if (!file) return;
-    if (file.size > 5 * 1024 * 1024) { alert('File too large (max 5MB)'); return; }
-    var reader = new FileReader();
-    reader.onload = async function() {
-      var base64 = reader.result.split(',')[1];
-      try {
-        var res = await fetch('/api/upload', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ filename: file.name, data: base64 })
-        });
-        var data = await res.json();
-        if (!data.ok) { alert('Upload failed: ' + (data.error || 'Unknown')); return; }
-        var textarea = document.getElementById(textareaId);
-        if (textarea) {
-          var isImage = /\\.(png|jpg|jpeg|gif|webp|svg)$/i.test(file.name);
-          var ref = isImage ? '![' + file.name + '](' + data.url + ')' : '[' + file.name + '](' + data.url + ')';
-          var pos = textarea.selectionStart || textarea.value.length;
-          var before = textarea.value.substring(0, pos);
-          var after = textarea.value.substring(pos);
-          var sep = before.length > 0 && !before.endsWith('\\n') ? '\\n' : '';
-          textarea.value = before + sep + ref + after;
-          textarea.focus();
-        }
-      } catch { alert('Upload failed'); }
-    };
-    reader.readAsDataURL(file);
-  };
+  input.onchange = function() { handleFileUpload(input.files[0], textareaId); };
   input.click();
 }
+
+// --- Drag and drop upload ---
+var _dragCounter = 0;
+document.addEventListener('dragenter', function(e) {
+  var textarea = e.target.closest('textarea');
+  if (!textarea || !textarea.id) return;
+  e.preventDefault();
+  _dragCounter++;
+  textarea.classList.add('drag-over');
+});
+document.addEventListener('dragover', function(e) {
+  if (e.target.closest('textarea')) e.preventDefault();
+});
+document.addEventListener('dragleave', function(e) {
+  var textarea = e.target.closest('textarea');
+  if (!textarea || !textarea.id) return;
+  _dragCounter--;
+  if (_dragCounter <= 0) {
+    _dragCounter = 0;
+    textarea.classList.remove('drag-over');
+  }
+});
+document.addEventListener('drop', function(e) {
+  var textarea = e.target.closest('textarea');
+  if (!textarea || !textarea.id) return;
+  e.preventDefault();
+  _dragCounter = 0;
+  textarea.classList.remove('drag-over');
+  var files = e.dataTransfer.files;
+  for (var i = 0; i < files.length; i++) {
+    handleFileUpload(files[i], textarea.id);
+  }
+});
 
 // --- Status tab ---
 async function loadStatus() {

--- a/lib/ui/styles.js
+++ b/lib/ui/styles.js
@@ -139,6 +139,9 @@ ${authorCSS}
   .attach-btn { padding: 8px 14px; background: #f5f5f5; border: 1px solid #ddd; border-radius: 6px; font-size: 13px; cursor: pointer; color: #555; white-space: nowrap; }
   .attach-btn:hover { background: #e8e8e8; color: #333; }
 
+  /* Drag and drop */
+  textarea.drag-over { border: 2px dashed #1a73e8 !important; background: #e8f0fe !important; }
+
   /* Uploaded images in markdown */
   .md-content img { max-width: 100%; height: auto; border-radius: 6px; margin: 8px 0; border: 1px solid #e8e8e8; }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robhunter/agent-portal",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -282,4 +282,19 @@ describe('buildHTML', () => {
     assert.ok(html.includes('#menu-btn'));
     assert.ok(html.includes('#sidebar-overlay'));
   });
+
+  it('includes drag-and-drop upload JS', () => {
+    const html = buildHTML(baseConfig);
+    assert.ok(html.includes('function handleFileUpload'));
+    assert.ok(html.includes('dragenter'));
+    assert.ok(html.includes('dragover'));
+    assert.ok(html.includes('dragleave'));
+    assert.ok(html.includes('e.dataTransfer.files'));
+  });
+
+  it('includes drag-over CSS class', () => {
+    const html = buildHTML(baseConfig);
+    assert.ok(html.includes('textarea.drag-over'));
+    assert.ok(html.includes('dashed'));
+  });
 });


### PR DESCRIPTION
## Summary
- Adds drag-and-drop file upload to all textareas in the portal (journal notes, project notes, request replies, feedback)
- Dragging a file over a textarea shows a blue dashed border visual indicator
- Dropping files triggers the same upload flow as the Attach button (base64 POST to /api/upload, markdown reference inserted)
- Supports multiple files dropped at once
- Refactored upload logic into shared `handleFileUpload()` function used by both the Attach button and drag-and-drop
- Version bumped to 1.3.0

Refs #37

## Test plan
- [x] 192 tests pass (2 new: drag-and-drop JS presence, drag-over CSS class)
- [ ] Manual test: drag image onto journal note textarea, verify upload and markdown insertion
- [ ] Manual test: drag non-image file (.pdf, .txt), verify link reference inserted
- [ ] Manual test: drag multiple files at once
- [ ] Manual test: verify drag-over visual indicator (blue dashed border) appears/disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)