### PR TITLE
Add config reader and utility scripts for agent framework

### DIFF
--- a/agent.yaml.example
+++ b/agent.yaml.example
@@ -1,0 +1,42 @@
+# agent.yaml — Per-agent configuration read by framework scripts.
+# Place this file at the root of each agent's repo.
+
+# Agent identity
+name: bobbo                          # used in logs, PID files, lock files, temp file naming
+repo: robhunter/bobbo-agent          # GitHub org/repo for push URL derivation
+port: 8080                           # portal server port
+lock-file: /tmp/bobbo-agent.lock     # mutex file path
+cron-file: /etc/cron.d/bobbo         # cron file path
+cron-schedule: "0 */2 * * *"         # cron schedule expression
+
+# Prompts — multi-line text piped to Claude on each cycle type.
+# read-config.js writes these to temp files and outputs the file path.
+wake-prompt: |
+  You are waking up for a scheduled work cycle. Follow the 'On Wake'
+  instructions in CLAUDE.md. This is an autonomous cycle — no human is present.
+  [agent-specific prompt content]
+
+respond-prompt: |
+  You are waking up for a RESPOND cycle.
+  [agent-specific prompt content]
+
+# Optional: workspaces to clone/pull before each cycle.
+# Omit or leave empty for self-contained agents (like Bobbo).
+workspaces:
+  - repo: robhunter/agentdeals
+    path: /root/workspaces/agentdeals
+    npm-install: true                # run npm install after pull
+
+# Optional: extra cron entries for agent-specific scheduled scripts.
+# These are in addition to the framework's wake.sh entry.
+extra-cron:
+  - schedule: "0 3 * * 0"
+    command: "bash scripts/reflect.sh"
+    log: "logs/cycles/cron-reflect.log"
+  - schedule: "0 18 * * 1-5"
+    command: "bash scripts/review-reminder.sh"
+    log: "logs/cycles/cron-reminder.log"
+
+# Framework versioning — updated automatically after successful cycles.
+# Do not edit manually.
+framework-last-known-good: null

--- a/core-hooks.yaml
+++ b/core-hooks.yaml
@@ -1,0 +1,3 @@
+pre-cycle: []
+post-cycle: []
+post-start: []

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,40 @@
+{
+  "name": "@robhunter/agent-portal",
+  "version": "1.3.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@robhunter/agent-portal",
+      "version": "1.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^4.1.0"
+      },
+      "bin": {
+        "agent-portal": "index.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
   "license": "MIT",
   "engines": {
     "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "js-yaml": "^4.1.0"
   }
 }

--- a/scripts/log-event.sh
+++ b/scripts/log-event.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# scripts/log-event.sh — Append a JSON event to the agent's events.jsonl
+# Usage: log-event.sh <agent-dir> <type> <summary> [project]
+set -e
+
+AGENT_DIR="$1"
+TYPE="$2"
+SUMMARY="$3"
+PROJECT="$4"
+
+if [ -z "$AGENT_DIR" ] || [ -z "$TYPE" ] || [ -z "$SUMMARY" ]; then
+  echo "Usage: log-event.sh <agent-dir> <type> <summary> [project]"
+  exit 1
+fi
+
+ENTRY="{\"ts\":\"$(date -Iseconds)\",\"type\":\"$TYPE\",\"summary\":\"$SUMMARY\""
+[ -n "$PROJECT" ] && ENTRY="$ENTRY,\"project\":\"$PROJECT\""
+ENTRY="$ENTRY}"
+
+mkdir -p "$AGENT_DIR/logs"
+echo "$ENTRY" >> "$AGENT_DIR/logs/events.jsonl"

--- a/scripts/log-journal.sh
+++ b/scripts/log-journal.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# scripts/log-journal.sh — Append a timestamped journal entry
+# Usage: log-journal.sh <agent-dir> <journal-file> <author> <tag> <content>
+#
+# journal-file is relative to agent-dir/journals/ (e.g., "bobbo.md" or "ai-research.md")
+set -e
+
+AGENT_DIR="$1"
+JOURNAL_FILE="$2"
+AUTHOR="$3"
+TAG="$4"
+CONTENT="$5"
+
+if [ -z "$AGENT_DIR" ] || [ -z "$JOURNAL_FILE" ] || [ -z "$AUTHOR" ] || [ -z "$TAG" ] || [ -z "$CONTENT" ]; then
+  echo "Usage: log-journal.sh <agent-dir> <journal-file> <author> <tag> <content>"
+  exit 1
+fi
+
+JOURNAL_PATH="$AGENT_DIR/journals/$JOURNAL_FILE"
+mkdir -p "$(dirname "$JOURNAL_PATH")"
+
+{
+  echo ""
+  echo "### $(date -Iseconds) | $AUTHOR | $TAG"
+  echo "$CONTENT"
+} >> "$JOURNAL_PATH"

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# scripts/notify.sh — Send a Telegram message. Token-gated no-op.
+# Usage: notify.sh <message>
+#
+# Expects TELEGRAM_TOKEN and TELEGRAM_CHAT_ID in environment (sourced by caller).
+# If either is missing, logs the message to stderr and exits 0 (no-op).
+set -e
+
+TEXT="$1"
+
+if [ -z "$TEXT" ]; then
+  echo "Usage: notify.sh <message>"
+  exit 1
+fi
+
+if [ -z "$TELEGRAM_TOKEN" ] || [ -z "$TELEGRAM_CHAT_ID" ]; then
+  echo "Warning: TELEGRAM_TOKEN or TELEGRAM_CHAT_ID not set. Notification not sent." >&2
+  echo "Message was: $TEXT" >&2
+  exit 0
+fi
+
+curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_TOKEN}/sendMessage" \
+  -d chat_id="${TELEGRAM_CHAT_ID}" \
+  -d text="${TEXT}"

--- a/scripts/read-config.js
+++ b/scripts/read-config.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// scripts/read-config.js — Read agent.yaml and output shell-friendly variables.
+//
+// Usage:
+//   eval "$(node read-config.js /path/to/agent.yaml)"
+//   node read-config.js /path/to/agent.yaml --set key=value
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const args = process.argv.slice(2);
+const yamlPath = args[0];
+
+if (!yamlPath) {
+  console.error('Usage: read-config.js <agent.yaml> [--set key=value]');
+  process.exit(1);
+}
+
+// --set mode: update a single key in the YAML file
+const setArg = args.find(a => a.startsWith('--set'));
+if (setArg !== undefined) {
+  const setIdx = args.indexOf('--set');
+  const kvArg = args[setIdx + 1] || args.find(a => a.startsWith('--set='))?.slice(6);
+  let key, value;
+
+  if (args[setIdx] === '--set' && args[setIdx + 1]) {
+    [key, ...rest] = args[setIdx + 1].split('=');
+    value = rest.join('=');
+  } else if (args[setIdx].startsWith('--set=')) {
+    [key, ...rest] = args[setIdx].slice(6).split('=');
+    value = rest.join('=');
+  }
+
+  if (!key) {
+    console.error('Usage: read-config.js <agent.yaml> --set key=value');
+    process.exit(1);
+  }
+
+  const content = fs.readFileSync(yamlPath, 'utf8');
+  const doc = yaml.load(content);
+  doc[key] = value === 'null' ? null : value;
+  fs.writeFileSync(yamlPath, yaml.dump(doc, { lineWidth: -1, quotingType: '"' }));
+  process.exit(0);
+}
+
+// Read mode: output shell variables
+const content = fs.readFileSync(yamlPath, 'utf8');
+const doc = yaml.load(content);
+
+// Shell-escape a value for safe eval
+function shellEscape(val) {
+  if (val === null || val === undefined) return '""';
+  const s = String(val);
+  // Single-quote the value, escaping any embedded single quotes
+  return "'" + s.replace(/'/g, "'\\''") + "'";
+}
+
+// Scalar values
+const scalars = {
+  AGENT_NAME: doc.name,
+  AGENT_REPO: doc.repo,
+  AGENT_PORT: doc.port,
+  AGENT_LOCK_FILE: doc['lock-file'],
+  AGENT_CRON_FILE: doc['cron-file'],
+  AGENT_CRON_SCHEDULE: doc['cron-schedule'],
+  FRAMEWORK_LAST_KNOWN_GOOD: doc['framework-last-known-good'],
+};
+
+for (const [key, val] of Object.entries(scalars)) {
+  console.log(`${key}=${shellEscape(val)}`);
+}
+
+// Multi-line values — write to temp files, output paths
+const agentName = doc.name || 'agent';
+
+if (doc['wake-prompt']) {
+  const promptPath = `/tmp/agent-${agentName}-wake-prompt.txt`;
+  fs.writeFileSync(promptPath, doc['wake-prompt']);
+  console.log(`WAKE_PROMPT_FILE=${shellEscape(promptPath)}`);
+} else {
+  console.log('WAKE_PROMPT_FILE=""');
+}
+
+if (doc['respond-prompt']) {
+  const promptPath = `/tmp/agent-${agentName}-respond-prompt.txt`;
+  fs.writeFileSync(promptPath, doc['respond-prompt']);
+  console.log(`RESPOND_PROMPT_FILE=${shellEscape(promptPath)}`);
+} else {
+  console.log('RESPOND_PROMPT_FILE=""');
+}
+
+// Array values — indexed variables
+const workspaces = doc.workspaces || [];
+console.log(`WORKSPACES_COUNT=${workspaces.length}`);
+workspaces.forEach((ws, i) => {
+  console.log(`WORKSPACE_${i}_REPO=${shellEscape(ws.repo)}`);
+  console.log(`WORKSPACE_${i}_PATH=${shellEscape(ws.path)}`);
+  console.log(`WORKSPACE_${i}_NPM_INSTALL=${shellEscape(ws['npm-install'] ? 'true' : 'false')}`);
+});
+
+const extraCron = doc['extra-cron'] || [];
+console.log(`EXTRA_CRON_COUNT=${extraCron.length}`);
+extraCron.forEach((entry, i) => {
+  console.log(`EXTRA_CRON_${i}_SCHEDULE=${shellEscape(entry.schedule)}`);
+  console.log(`EXTRA_CRON_${i}_COMMAND=${shellEscape(entry.command)}`);
+  console.log(`EXTRA_CRON_${i}_LOG=${shellEscape(entry.log)}`);
+});

--- a/scripts/read-core-hooks.js
+++ b/scripts/read-core-hooks.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+// scripts/read-core-hooks.js — Read core-hooks.yaml and output hook names for an extension point.
+//
+// Usage: node read-core-hooks.js <core-hooks.yaml> <extension-point>
+// Output: one hook name per line (for grep -qx matching in run-hooks.sh)
+
+const fs = require('fs');
+const yaml = require('js-yaml');
+
+const yamlPath = process.argv[2];
+const extensionPoint = process.argv[3];
+
+if (!yamlPath || !extensionPoint) {
+  console.error('Usage: read-core-hooks.js <core-hooks.yaml> <extension-point>');
+  process.exit(1);
+}
+
+const content = fs.readFileSync(yamlPath, 'utf8');
+const doc = yaml.load(content);
+
+const hooks = doc[extensionPoint];
+if (Array.isArray(hooks)) {
+  hooks.forEach(name => console.log(name));
+}


### PR DESCRIPTION
## Summary

PR 1 of the framework extraction (see `framework-implementation-plan.md` in bobbo-agent). Adds the foundational scripts that all subsequent PRs depend on.

- **`scripts/read-config.js`** — Reads `agent.yaml` and outputs shell-friendly variables. Handles scalars (key=value), multi-line values (temp files), and arrays (indexed variables). Also supports `--set key=value` for writing back (used for `framework-last-known-good`).
- **`scripts/read-core-hooks.js`** — Reads `core-hooks.yaml` and outputs hook names for a given extension point. Used by `run-hooks.sh` (PR 3) to skip promoted hooks.
- **`scripts/log-event.sh`** — Appends a JSON event to an agent's `logs/events.jsonl`.
- **`scripts/log-journal.sh`** — Appends a timestamped entry to an agent's journal file.
- **`scripts/notify.sh`** — Sends a Telegram message. Token-gated no-op if `TELEGRAM_TOKEN`/`TELEGRAM_CHAT_ID` not in environment.
- **`agent.yaml.example`** — Documented schema showing all configuration fields.
- **`core-hooks.yaml`** — Empty hook registry (populated when agent hooks are promoted to core).
- **`package.json`** — Added `js-yaml` dependency.

## Design decisions

- **Indexed variables for arrays** — `read-config.js` outputs `WORKSPACES_COUNT=1`, `WORKSPACE_0_REPO=...` etc. rather than JSON. No `jq` dependency needed, easy to iterate in bash with indirect expansion.
- **Temp files for prompts** — Multi-line values can't be shell variables, so they're written to `/tmp/agent-<name>-*.txt` and the path is output.
- **notify.sh relies on env inheritance** — The calling script (wake.sh) sources the agent's `.env` with `set -a`. notify.sh checks for the vars and no-ops if missing.

## Test plan

- [x] `read-config.js` outputs correct variables from `agent.yaml.example`
- [x] `eval` consumption works in bash
- [x] Prompt temp files written correctly
- [x] `--set` mode updates YAML key
- [x] `read-core-hooks.js` outputs nothing for empty registry, correct names for populated registry
- [x] `log-event.sh` appends valid JSONL with and without project field
- [x] `log-journal.sh` appends correctly formatted journal entry
- [x] All shell scripts pass `bash -n` syntax check

🤖 Generated with [Claude Code](https://claude.com/claude-code)