### PR TITLE
Add start.sh, cron-setup.sh, and vm-setup.sh

### DIFF
--- a/scripts/cron-setup.sh
+++ b/scripts/cron-setup.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# scripts/cron-setup.sh — Install or show cron entries from agent.yaml.
+# Usage:
+#   cron-setup.sh <agent-dir>          # Show the cron lines
+#   cron-setup.sh <agent-dir> install  # Install them
+set -e
+
+FRAMEWORK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+AGENT_DIR="${1:?Usage: cron-setup.sh <agent-dir> [install]}"
+ACTION="$2"
+
+cd "$AGENT_DIR"
+
+# Read agent config
+eval "$(node "$FRAMEWORK_DIR/scripts/read-config.js" "$AGENT_DIR/agent.yaml")"
+
+# nvm sourcing prefix so claude is on PATH in cron
+NVM_SOURCE='export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" &&'
+
+# Main wake entry from agent.yaml
+WAKE_LINE="${AGENT_CRON_SCHEDULE} root ${NVM_SOURCE} cd ${AGENT_DIR} && bash ${FRAMEWORK_DIR}/scripts/wake.sh ${AGENT_DIR} >> logs/cycles/cron-wake.log 2>&1"
+
+# Build all cron lines
+CRON_LINES="$WAKE_LINE"
+
+# Extra cron entries from agent.yaml
+if [ "$EXTRA_CRON_COUNT" -gt 0 ] 2>/dev/null; then
+  for i in $(seq 0 $((EXTRA_CRON_COUNT - 1))); do
+    sched_var="EXTRA_CRON_${i}_SCHEDULE"
+    cmd_var="EXTRA_CRON_${i}_COMMAND"
+    log_var="EXTRA_CRON_${i}_LOG"
+    schedule="${!sched_var}"; command="${!cmd_var}"; logfile="${!log_var}"
+
+    EXTRA_LINE="${schedule} root ${NVM_SOURCE} cd ${AGENT_DIR} && ${command} >> ${logfile} 2>&1"
+    CRON_LINES="$CRON_LINES
+$EXTRA_LINE"
+  done
+fi
+
+if [ "$ACTION" = "install" ]; then
+  printf '%s\n' "$CRON_LINES" > "$AGENT_CRON_FILE"
+  chmod 644 "$AGENT_CRON_FILE"
+  echo "Installed cron jobs to $AGENT_CRON_FILE"
+  echo ""
+  echo "Contents:"
+  cat "$AGENT_CRON_FILE"
+else
+  echo "Cron lines (install with: cron-setup.sh $AGENT_DIR install):"
+  echo ""
+  echo "$CRON_LINES"
+fi

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# scripts/start.sh — Container entrypoint. Supervises background services.
+# Usage: start.sh [agent-dir]
+# Reads agent.yaml for port, cron config, etc. Expects .env at agent-dir root.
+
+FRAMEWORK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+AGENT_DIR="${1:-$(pwd)}"
+cd "$AGENT_DIR"
+
+# Source nvm if available (may not be installed yet on first run)
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+
+# Source .env
+if [ -f "$AGENT_DIR/.env" ]; then
+  set -a; . "$AGENT_DIR/.env"; set +a
+fi
+
+# Read agent config
+eval "$(node "$FRAMEWORK_DIR/scripts/read-config.js" "$AGENT_DIR/agent.yaml")"
+
+LOG_FILE="logs/supervisor.log"
+mkdir -p logs
+
+log() {
+  echo "$(date -Iseconds) [supervisor] $*" >> "$LOG_FILE"
+  echo "$(date -Iseconds) [supervisor] $*"
+}
+
+log "Starting agent '$AGENT_NAME' (framework=$FRAMEWORK_DIR, agent=$AGENT_DIR)"
+
+# Clean up stale PID files on startup
+for pidfile in /tmp/${AGENT_NAME}-*.pid; do
+  [ -f "$pidfile" ] || continue
+  pid=$(cat "$pidfile" 2>/dev/null)
+  if [ -n "$pid" ] && ! kill -0 "$pid" 2>/dev/null; then
+    log "Removing stale PID file: $pidfile (pid $pid)"
+    rm -f "$pidfile"
+  fi
+done
+
+# supervise NAME COMMAND...
+# Wraps a service in a restart loop with exponential backoff.
+# Writes PID to /tmp/<agent-name>-<NAME>.pid.
+supervise() {
+  local name="$1"
+  shift
+  local pidfile="/tmp/${AGENT_NAME}-${name}.pid"
+  local backoff=1
+  local max_backoff=30
+  local healthy_threshold=60
+
+  (
+    while true; do
+      local start_ts=$(date +%s)
+      log "Starting $name (backoff=${backoff}s)"
+
+      "$@" &
+      local child_pid=$!
+      echo "$child_pid" > "$pidfile"
+
+      wait "$child_pid" 2>/dev/null
+      local exit_code=$?
+      local runtime=$(( $(date +%s) - start_ts ))
+
+      log "$name exited (code=$exit_code, runtime=${runtime}s)"
+      rm -f "$pidfile"
+
+      if [ "$runtime" -ge "$healthy_threshold" ]; then
+        backoff=1
+      else
+        backoff=$(( backoff * 2 ))
+        [ "$backoff" -gt "$max_backoff" ] && backoff=$max_backoff
+      fi
+
+      log "Restarting $name in ${backoff}s"
+      sleep "$backoff"
+    done
+  ) &
+  log "Supervisor loop for $name running (subshell PID $!)"
+}
+
+# Install cron jobs and start daemon
+if command -v cron >/dev/null 2>&1; then
+  bash "$FRAMEWORK_DIR/scripts/cron-setup.sh" "$AGENT_DIR" install \
+    || log "Cron setup failed — will retry on next restart"
+  cron
+  log "Cron daemon started"
+fi
+
+# Pull latest framework code
+log "Pulling latest framework..."
+git -C "$FRAMEWORK_DIR" pull --ff-only 2>/dev/null || log "Framework pull failed (non-fatal)"
+
+# Supervise portal server (portal code from framework, config from agent)
+if command -v node >/dev/null 2>&1 && [ -f "$FRAMEWORK_DIR/index.js" ]; then
+  log "Supervising portal server (port $AGENT_PORT)..."
+  supervise "portal" node "$FRAMEWORK_DIR/index.js" "$AGENT_DIR/portal.config.json"
+else
+  log "Node not found or portal not available — skipping portal server"
+fi
+
+# Supervise Telegram poller if credentials are available
+if [ -n "$TELEGRAM_TOKEN" ] && [ -n "$TELEGRAM_CHAT_ID" ]; then
+  log "Supervising telegram-poller..."
+  supervise "telegram-poller" bash "$FRAMEWORK_DIR/scripts/telegram_poll.sh" "$AGENT_DIR"
+else
+  log "TELEGRAM_TOKEN or TELEGRAM_CHAT_ID not set — skipping Telegram poller"
+fi
+
+# Run post-start hooks
+bash "$FRAMEWORK_DIR/scripts/run-hooks.sh" "$FRAMEWORK_DIR" "$AGENT_DIR" post-start
+
+log "Supervisor ready."
+
+# Keep container alive
+while true; do
+  sleep 60
+done

--- a/scripts/vm-setup.sh
+++ b/scripts/vm-setup.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# scripts/vm-setup.sh — Set up a fresh container/VM to run an agent.
+# Usage: vm-setup.sh [agent-dir]
+#
+# Prerequisites:
+#   - Ubuntu/Debian (1GB+ RAM)
+#   - Git installed
+#   - Agent repo cloned
+#
+# What this script does:
+#   1. Installs Node.js (via nvm)
+#   2. Installs Claude Code CLI
+#   3. Installs GitHub CLI (gh) and configures auth
+#   4. Configures git identity
+#
+# What you do manually after:
+#   - claude /login  (authenticate Claude Code)
+#   - Test: bash scripts/wake.sh
+set -e
+
+FRAMEWORK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+AGENT_DIR="${1:-$(pwd)}"
+cd "$AGENT_DIR"
+
+# Source .env for GH_TOKEN and git identity
+if [ -f "$AGENT_DIR/.env" ]; then
+  set -a; . "$AGENT_DIR/.env"; set +a
+fi
+
+# Read agent config if agent.yaml exists
+AGENT_NAME="agent"
+if [ -f "$AGENT_DIR/agent.yaml" ]; then
+  eval "$(node "$FRAMEWORK_DIR/scripts/read-config.js" "$AGENT_DIR/agent.yaml" 2>/dev/null)" || true
+fi
+
+echo "=== Agent VM Setup ($AGENT_NAME) ==="
+echo "Agent directory: $AGENT_DIR"
+echo "Framework directory: $FRAMEWORK_DIR"
+echo ""
+
+# Step 1: Node.js via nvm
+if ! command -v node &>/dev/null; then
+  echo "--- Installing nvm and Node.js ---"
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+  export NVM_DIR="$HOME/.nvm"
+  [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+  nvm install --lts
+  echo ""
+else
+  echo "--- Node.js already installed: $(node --version) ---"
+fi
+
+# Step 2: Claude Code
+if ! command -v claude &>/dev/null; then
+  echo "--- Installing Claude Code ---"
+  npm install -g @anthropic-ai/claude-code
+  echo ""
+else
+  echo "--- Claude Code already installed: $(claude --version 2>/dev/null || echo 'unknown version') ---"
+fi
+
+# Step 3: GitHub CLI
+if ! command -v gh &>/dev/null; then
+  echo "--- Installing GitHub CLI ---"
+  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg 2>/dev/null
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+  apt-get update -qq && apt-get install -y -qq gh
+  echo ""
+else
+  echo "--- GitHub CLI already installed: $(gh --version | head -1) ---"
+fi
+
+# Configure gh auth if GH_TOKEN is available
+if [ -n "$GH_TOKEN" ] && command -v gh &>/dev/null; then
+  echo "--- Configuring gh auth ---"
+  echo "$GH_TOKEN" | gh auth login --with-token 2>/dev/null || true
+  gh auth setup-git 2>/dev/null || true
+  echo "  gh auth status: $(gh auth status 2>&1 | grep -o 'Logged in.*' || echo 'not configured')"
+  echo ""
+fi
+
+# Step 4: Git identity
+if [ -n "$GIT_AUTHOR_NAME" ]; then
+  echo "--- Configuring git identity from env ---"
+  git config --global user.name "$GIT_AUTHOR_NAME"
+  git config --global user.email "${GIT_AUTHOR_EMAIL:-${AGENT_NAME}@agent.local}"
+else
+  echo "--- Configuring git identity (defaults for $AGENT_NAME) ---"
+  git config --global user.name "$AGENT_NAME"
+  git config --global user.email "${AGENT_NAME}@agent.local"
+fi
+echo "  user.name: $(git config --global user.name)"
+echo "  user.email: $(git config --global user.email)"
+echo ""
+
+# Step 5: Install framework dependencies
+echo "--- Installing framework dependencies ---"
+(cd "$FRAMEWORK_DIR" && npm install --production 2>&1) || echo "Warning: framework npm install failed"
+echo ""
+
+echo "=== Setup complete ==="
+echo ""
+echo "Next steps:"
+echo "  1. Authenticate Claude Code:"
+echo "       claude /login"
+echo ""
+echo "  2. Test a manual cycle:"
+echo "       bash $FRAMEWORK_DIR/scripts/wake.sh $AGENT_DIR"
+echo ""


### PR DESCRIPTION
## Summary

PR 4 of the framework extraction. Three files, 281 lines total.

**`scripts/start.sh`** (119 lines) — Container entrypoint with supervisor pattern:
- Reads agent.yaml for agent name, port, etc.
- Cleans up stale PID files using agent name prefix
- `supervise()` function with exponential backoff (identical pattern across all agents)
- Installs cron via `cron-setup.sh`
- Pulls latest framework code
- Supervises portal server: `node "$FRAMEWORK_DIR/index.js" "$AGENT_DIR/portal.config.json"`
- Supervises Telegram poller if tokens present in env
- Runs post-start hooks via `run-hooks.sh`
- Keep-alive sleep loop

**`scripts/cron-setup.sh`** (51 lines) — Generates cron entries from agent.yaml:
- Main wake entry: uses `cron-schedule` field + framework's `wake.sh` path
- Extra entries: iterates `extra-cron` array from agent.yaml (e.g., reflect.sh, review-reminder.sh)
- All entries get nvm sourcing prefix so `claude` is on PATH
- Supports dry-run (show) and install modes

**`scripts/vm-setup.sh`** (111 lines) — Superset of all agent setups:
- Node.js via nvm
- Claude Code CLI
- GitHub CLI (gh) with auth via GH_TOKEN
- Git identity from env or agent.yaml defaults
- Framework npm install

## Test plan

- [x] `bash -n` syntax check passes for all three
- [x] `cron-setup.sh` dry run outputs correct lines from agent.yaml.example (main wake + 2 extra entries)
- [x] Wake entry uses framework's wake.sh path; extra entries use agent's own script paths
- [ ] Full container test deferred to Bobbo integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)