### PR TITLE
Add Telegram scripts, journal respond.sh, and rollback logic (PRs 5-7)

### DIFF
--- a/scripts/framework-update.sh
+++ b/scripts/framework-update.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# scripts/framework-update.sh — Pull latest framework, handle rollback if needed.
+# Usage: framework-update.sh <framework-dir> <agent-dir>
+#
+# Called by wake.sh before the cycle starts. Exports FRAMEWORK_COMMIT for
+# wake.sh to use when updating framework-last-known-good after success.
+#
+# Rollback triggers when:
+# 1. The framework commit changed since last-known-good, AND
+# 2. The previous cycle failed (marker file exists)
+set -e
+
+FRAMEWORK_DIR="${1:?Usage: framework-update.sh <framework-dir> <agent-dir>}"
+AGENT_DIR="${2:?Usage: framework-update.sh <framework-dir> <agent-dir>}"
+
+# Read agent config for rollback state
+eval "$(node "$FRAMEWORK_DIR/scripts/read-config.js" "$AGENT_DIR/agent.yaml")"
+
+CYCLE_FAILED_MARKER="/tmp/agent-${AGENT_NAME}-cycle-failed"
+
+# Pull latest framework
+if [ -n "$GH_TOKEN" ]; then
+  git -C "$FRAMEWORK_DIR" pull --ff-only \
+    "https://${GH_TOKEN}@github.com/robhunter/agent-portal.git" main 2>&1 || {
+    echo "Warning: framework pull failed (continuing with current version)"
+  }
+fi
+
+# Record current framework commit
+FRAMEWORK_COMMIT="$(git -C "$FRAMEWORK_DIR" rev-parse HEAD 2>/dev/null || echo "unknown")"
+
+# Rollback check
+if [ -f "$CYCLE_FAILED_MARKER" ] && [ -n "$FRAMEWORK_LAST_KNOWN_GOOD" ] && [ "$FRAMEWORK_LAST_KNOWN_GOOD" != "null" ]; then
+  if [ "$FRAMEWORK_COMMIT" != "$FRAMEWORK_LAST_KNOWN_GOOD" ]; then
+    echo "Previous cycle failed and framework changed — rolling back to $FRAMEWORK_LAST_KNOWN_GOOD"
+    git -C "$FRAMEWORK_DIR" checkout "$FRAMEWORK_LAST_KNOWN_GOOD" 2>&1 || {
+      echo "ERROR: rollback failed"
+      bash "$FRAMEWORK_DIR/scripts/log-event.sh" "$AGENT_DIR" error \
+        "Framework rollback to $FRAMEWORK_LAST_KNOWN_GOOD failed"
+    }
+    FRAMEWORK_COMMIT="$FRAMEWORK_LAST_KNOWN_GOOD"
+    bash "$FRAMEWORK_DIR/scripts/log-event.sh" "$AGENT_DIR" rollback \
+      "Rolled back framework to $FRAMEWORK_LAST_KNOWN_GOOD"
+  fi
+fi
+
+# Export for wake.sh to use after a successful cycle
+echo "FRAMEWORK_COMMIT='$FRAMEWORK_COMMIT'"

--- a/scripts/respond.sh
+++ b/scripts/respond.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# scripts/respond.sh — Lightweight journal-respond cycle.
+# Usage: respond.sh [agent-dir]
+# Non-Telegram interaction model: Rob writes to the journal via the portal,
+# agent reads and responds on the next respond cycle.
+# Reads respond-prompt from agent.yaml.
+set -e
+
+FRAMEWORK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+AGENT_DIR="${1:-$(pwd)}"
+cd "$AGENT_DIR"
+
+# Source nvm
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+
+# Source .env
+if [ -f "$AGENT_DIR/.env" ]; then
+  set -a; . "$AGENT_DIR/.env"; set +a
+fi
+
+# Read agent config
+eval "$(node "$FRAMEWORK_DIR/scripts/read-config.js" "$AGENT_DIR/agent.yaml")"
+
+# Mutex — prevent overlapping with a full cycle
+exec 200>"$AGENT_LOCK_FILE"
+if ! flock -n 200; then
+  echo "Agent already running — skipping respond cycle"
+  exit 0
+fi
+
+CYCLE_TS="$(date +%Y%m%d-%H%M)"
+CYCLE_LOG="logs/cycles/${CYCLE_TS}-respond.log"
+mkdir -p logs/cycles
+
+CYCLE_START_EPOCH=$(date +%s)
+
+bash "$FRAMEWORK_DIR/scripts/log-event.sh" "$AGENT_DIR" cycle_start "Respond cycle (journal)"
+
+# Clone/pull workspaces from agent.yaml
+if [ "$WORKSPACES_COUNT" -gt 0 ] 2>/dev/null; then
+  for i in $(seq 0 $((WORKSPACES_COUNT - 1))); do
+    repo_var="WORKSPACE_${i}_REPO"; path_var="WORKSPACE_${i}_PATH"
+    npm_var="WORKSPACE_${i}_NPM_INSTALL"
+    ws_repo="${!repo_var}"; ws_path="${!path_var}"; ws_npm="${!npm_var}"
+
+    if [ -d "$ws_path/.git" ]; then
+      git -C "$ws_path" pull --ff-only 2>/dev/null || echo "Warning: pull failed for $ws_repo"
+    else
+      mkdir -p "$(dirname "$ws_path")"
+      git clone "https://${GH_TOKEN}@github.com/${ws_repo}.git" "$ws_path" 2>/dev/null || {
+        echo "Warning: clone failed for $ws_repo"
+        continue
+      }
+    fi
+
+    if [ "$ws_npm" = "true" ] && [ -f "$ws_path/package.json" ]; then
+      (cd "$ws_path" && npm install --production 2>&1) || echo "Warning: npm install failed for $ws_repo"
+    fi
+  done
+fi
+
+# Read respond prompt from agent.yaml
+if [ -n "$RESPOND_PROMPT_FILE" ] && [ -f "$RESPOND_PROMPT_FILE" ]; then
+  PROMPT_FILE="$RESPOND_PROMPT_FILE"
+else
+  # Fallback prompt
+  PROMPT_FILE="/tmp/agent-${AGENT_NAME}-respond-fallback.txt"
+  cat > "$PROMPT_FILE" <<'FALLBACK'
+You are waking up for a RESPOND cycle — not a full work cycle.
+Read your journals for recent entries from your human and respond thoughtfully.
+Then log a brief event and commit.
+FALLBACK
+fi
+
+# Run Claude with retry
+MAX_RETRIES=2
+RETRY=0
+CLAUDE_EXIT=1
+
+while [ "$CLAUDE_EXIT" -ne 0 ] && [ "$RETRY" -lt "$MAX_RETRIES" ]; do
+  if [ "$RETRY" -gt 0 ]; then
+    bash "$FRAMEWORK_DIR/scripts/log-event.sh" "$AGENT_DIR" retry \
+      "Retrying respond cycle (attempt $((RETRY+1)))"
+    sleep 30
+  fi
+
+  set +e
+  cat "$PROMPT_FILE" | claude --print \
+    --allowedTools "Bash" "Read" "Write" "Edit" "Glob" "Grep" "WebSearch" "WebFetch" \
+    2>&1 | tee "$CYCLE_LOG"
+  CLAUDE_EXIT=${PIPESTATUS[1]}
+  set -e
+
+  RETRY=$((RETRY + 1))
+done
+
+cd "$AGENT_DIR"
+
+if [ "$CLAUDE_EXIT" -ne 0 ]; then
+  bash "$FRAMEWORK_DIR/scripts/log-event.sh" "$AGENT_DIR" error \
+    "Respond cycle: Claude exited with code $CLAUDE_EXIT after $RETRY attempt(s)"
+fi
+
+CYCLE_END_EPOCH=$(date +%s)
+CYCLE_DURATION_S=$((CYCLE_END_EPOCH - CYCLE_START_EPOCH))
+CYCLE_DURATION_M=$((CYCLE_DURATION_S / 60))
+echo "{\"ts\":\"$(date -Iseconds)\",\"type\":\"cycle_end\",\"summary\":\"Respond cycle complete\",\"duration_s\":${CYCLE_DURATION_S},\"duration_m\":${CYCLE_DURATION_M}}" >> "$AGENT_DIR/logs/events.jsonl"
+
+bash "$FRAMEWORK_DIR/scripts/commit.sh" "$AGENT_DIR" "respond cycle"

--- a/scripts/telegram-respond.sh
+++ b/scripts/telegram-respond.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# scripts/telegram-respond.sh — Trigger a responsive cycle for a Telegram message.
+# Usage: telegram-respond.sh <agent-dir> <message-text>
+# Reads respond-prompt from agent.yaml. Uses framework commit.sh and notify.sh.
+set -e
+
+FRAMEWORK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+AGENT_DIR="${1:?Usage: telegram-respond.sh <agent-dir> <message-text>}"
+MESSAGE="${2:?Usage: telegram-respond.sh <agent-dir> <message-text>}"
+
+cd "$AGENT_DIR"
+
+# Ensure nvm/node/claude are on PATH
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+
+# Source .env
+if [ -f "$AGENT_DIR/.env" ]; then
+  set -a; . "$AGENT_DIR/.env"; set +a
+fi
+
+# Read agent config
+eval "$(node "$FRAMEWORK_DIR/scripts/read-config.js" "$AGENT_DIR/agent.yaml")"
+
+# Mutex — wait up to 120s for lock (another cycle may be running)
+exec 200>"$AGENT_LOCK_FILE"
+flock -w 120 200 || { echo "Agent busy — cycle didn't complete in 2min"; exit 1; }
+
+# Ensure conversation log exists
+touch logs/conversation.jsonl
+
+# Append human message to conversation buffer
+echo "{\"ts\":\"$(date -Iseconds)\",\"role\":\"human\",\"text\":$(echo "$MESSAGE" | jq -Rs .)}" >> logs/conversation.jsonl
+
+# Build recent conversation context (last 20 messages)
+RECENT_CONVO=$(tail -20 logs/conversation.jsonl | jq -r '"[\(.role)] \(.text)"')
+
+# Log cycle start
+bash "$FRAMEWORK_DIR/scripts/log-event.sh" "$AGENT_DIR" responsive_cycle "Telegram message received"
+
+echo "Running claude..."
+
+# Build prompt: use respond-prompt from agent.yaml as the base, inject conversation context
+# If no respond-prompt configured, use a sensible default
+if [ -n "$RESPOND_PROMPT_FILE" ] && [ -f "$RESPOND_PROMPT_FILE" ]; then
+  BASE_PROMPT="$(cat "$RESPOND_PROMPT_FILE")"
+else
+  BASE_PROMPT="You received a message from your human via Telegram. Follow the 'On Wake' instructions in CLAUDE.md to recall your state, then respond to the conversation."
+fi
+
+FULL_PROMPT="${BASE_PROMPT}
+
+Recent conversation:
+${RECENT_CONVO}
+
+CRITICAL: Your ENTIRE output will be sent directly as a Telegram message. Do NOT narrate your actions, do NOT describe what you did or what tools you used. Just write the actual reply you want your human to read. Be concise, direct, and conversational — this is a chat, not a log.
+
+If the message implies actions (reprioritize, new project, dig deeper on something), do them using tools, then confirm what you did in your response."
+
+set +e
+RESPONSE=$(echo "$FULL_PROMPT" | claude --print \
+  --allowedTools "Edit" "Write" "Read" "Bash(grep:*)" "Bash(jq:*)" "Bash(cat:*)" "Bash(head:*)" "Bash(tail:*)" "Bash(wc:*)" "Bash(date:*)" "Bash(git:*)" \
+  2>>logs/respond_errors.log)
+CLAUDE_EXIT=$?
+set -e
+
+if [ "$CLAUDE_EXIT" -ne 0 ]; then
+  echo "Claude exited with code $CLAUDE_EXIT"
+  bash "$FRAMEWORK_DIR/scripts/log-event.sh" "$AGENT_DIR" error \
+    "Responsive cycle claude exited with code $CLAUDE_EXIT"
+fi
+
+# Guard against empty response
+if [ -z "$RESPONSE" ]; then
+  echo "Warning: claude returned empty response (exit code $CLAUDE_EXIT)"
+  RESPONSE="Sorry, I wasn't able to process that. Please try again."
+fi
+
+echo "Sending response..."
+
+# Dedup guard — skip if identical to the last agent message within 60 seconds
+LAST_AGENT_MSG=$(grep '"role":"agent"' logs/conversation.jsonl | tail -1)
+LAST_AGENT_TEXT=$(echo "$LAST_AGENT_MSG" | jq -r '.text // ""')
+LAST_AGENT_TS=$(echo "$LAST_AGENT_MSG" | jq -r '.ts // ""')
+
+DUPLICATE=false
+if [ "$RESPONSE" = "$LAST_AGENT_TEXT" ] && [ -n "$LAST_AGENT_TS" ]; then
+  LAST_EPOCH=$(date -d "$LAST_AGENT_TS" +%s 2>/dev/null || echo 0)
+  NOW_EPOCH=$(date +%s)
+  DIFF=$((NOW_EPOCH - LAST_EPOCH))
+  if [ "$DIFF" -lt 60 ] && [ "$DIFF" -ge 0 ]; then
+    DUPLICATE=true
+    echo "Skipping duplicate response (same text within 60s)"
+  fi
+fi
+
+# Append agent response to conversation buffer
+echo "{\"ts\":\"$(date -Iseconds)\",\"role\":\"agent\",\"text\":$(echo "$RESPONSE" | jq -Rs .)}" >> logs/conversation.jsonl
+
+if [ "$DUPLICATE" = "false" ]; then
+  bash "$FRAMEWORK_DIR/scripts/notify.sh" "$RESPONSE"
+fi
+
+# Git commit
+bash "$FRAMEWORK_DIR/scripts/commit.sh" "$AGENT_DIR" "responsive cycle (telegram)"
+
+echo "Cycle complete."
+
+bash "$FRAMEWORK_DIR/scripts/log-event.sh" "$AGENT_DIR" cycle_end "Responsive cycle complete"

--- a/scripts/telegram_poll.sh
+++ b/scripts/telegram_poll.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# scripts/telegram_poll.sh — Lightweight Telegram long-polling daemon.
+# Usage: telegram_poll.sh [agent-dir]
+# Runs persistently in the container. No Claude Code dependency.
+# Token-gated: exits if TELEGRAM_TOKEN or TELEGRAM_CHAT_ID not set.
+
+FRAMEWORK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+AGENT_DIR="${1:-$(pwd)}"
+cd "$AGENT_DIR"
+
+# Ensure nvm/node/claude are on PATH
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+
+# Source .env for credentials if not already in environment
+if [ -z "$TELEGRAM_TOKEN" ] && [ -f "$AGENT_DIR/.env" ]; then
+  set -a; . "$AGENT_DIR/.env"; set +a
+fi
+
+if [ -z "$TELEGRAM_TOKEN" ] || [ -z "$TELEGRAM_CHAT_ID" ]; then
+  echo "$(date -Iseconds) FATAL: TELEGRAM_TOKEN or TELEGRAM_CHAT_ID not set"
+  exit 1
+fi
+
+API_BASE="https://api.telegram.org/bot${TELEGRAM_TOKEN}"
+OFFSET=0
+
+echo "$(date -Iseconds) Telegram poller started"
+
+while true; do
+  # Long-poll with 30s timeout
+  RESPONSE=$(curl -sS --connect-timeout 10 --max-time 35 "${API_BASE}/getUpdates?offset=${OFFSET}&timeout=30" 2>&1)
+
+  if [ $? -ne 0 ]; then
+    echo "$(date -Iseconds) ERROR: curl failed: $RESPONSE"
+    sleep 5
+    continue
+  fi
+
+  # Check API response is OK
+  OK=$(echo "$RESPONSE" | jq -r '.ok // false')
+  if [ "$OK" != "true" ]; then
+    echo "$(date -Iseconds) ERROR: Telegram API returned ok=false: $RESPONSE"
+    sleep 5
+    continue
+  fi
+
+  # Process each update
+  UPDATES=$(echo "$RESPONSE" | jq -c '.result[]')
+
+  while IFS= read -r UPDATE; do
+    [ -z "$UPDATE" ] && continue
+
+    UPDATE_ID=$(echo "$UPDATE" | jq -r '.update_id')
+    CHAT_ID=$(echo "$UPDATE" | jq -r '.message.chat.id // empty')
+    TEXT=$(echo "$UPDATE" | jq -r '.message.text // empty')
+
+    # Advance offset past this update
+    OFFSET=$((UPDATE_ID + 1))
+
+    # Only process messages from our chat
+    if [ "$CHAT_ID" != "$TELEGRAM_CHAT_ID" ]; then
+      echo "$(date -Iseconds) Ignoring message from chat $CHAT_ID"
+      continue
+    fi
+
+    # Skip empty messages (photos, stickers, etc.)
+    if [ -z "$TEXT" ]; then
+      echo "$(date -Iseconds) Skipping non-text message"
+      continue
+    fi
+
+    echo "$(date -Iseconds) Received message: ${TEXT:0:80}..."
+
+    # ACK immediately so the human knows the message was received
+    curl -sS --connect-timeout 10 -X POST "${API_BASE}/sendMessage" \
+      -d chat_id="${TELEGRAM_CHAT_ID}" \
+      -d text="Got it, thinking..." > /dev/null 2>&1
+
+    # Trigger responsive cycle via framework's telegram-respond.sh
+    bash "$FRAMEWORK_DIR/scripts/telegram-respond.sh" "$AGENT_DIR" "$TEXT" 2>&1 | while IFS= read -r line; do
+      echo "$(date -Iseconds) [respond] $line"
+    done
+
+  done <<< "$UPDATES"
+done


### PR DESCRIPTION
## Summary

PRs 5, 6, and 7 of the framework extraction — all independent, landing together. Three commits, 353 lines total.

---

### PR 5: Telegram scripts (195 lines)

**`scripts/telegram_poll.sh`** (86 lines) — Long-polling daemon:
- Takes `agent-dir` as arg, sources agent's `.env` for credentials
- Calls framework's `telegram-respond.sh` (not agent's local script)
- ACKs immediately, token-gated exit if no credentials

**`scripts/telegram-respond.sh`** (109 lines) — Responsive cycle handler:
- Reads `respond-prompt` from agent.yaml, injects conversation context
- Waits up to 120s for mutex, dedup guard (60s window)
- Uses framework's `notify.sh` and `commit.sh`

### PR 6: Journal respond cycle (110 lines)

**`scripts/respond.sh`** — Lightweight journal-respond cycle (from PM):
- Non-Telegram interaction: Rob writes to journal via portal, agent responds
- Reads respond-prompt from agent.yaml, pulls workspaces
- Retry logic + duration tracking matching wake.sh

### PR 7: Rollback logic (48 lines)

**`scripts/framework-update.sh`** — Pull framework + automatic rollback:
- Pulls latest framework code
- If previous cycle failed (marker file) AND framework commit changed since last-known-good → rollback
- Outputs `FRAMEWORK_COMMIT` for wake.sh to record after success
- Marker file (`/tmp/agent-<name>-cycle-failed`) tracks success/failure across invocations

## Test plan

- [x] `bash -n` syntax check passes for all four scripts
- [ ] Telegram integration test deferred to Bobbo migration
- [ ] Journal respond test deferred to PM migration
- [ ] Rollback test deferred to integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)