### PR TITLE
Add browse.js headless browser tool

### DIFF
--- a/scripts/browse.js
+++ b/scripts/browse.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+// Browse a URL headlessly and return content/screenshot
+// Usage: NODE_PATH=$(npm root -g) node scripts/browse.js <url> [--screenshot <path>] [--selector <css>]
+
+const { chromium } = require('playwright-core');
+
+async function main() {
+  const args = process.argv.slice(2);
+  const url = args[0];
+  if (!url) {
+    console.error('Usage: browse.js <url> [--screenshot <path>] [--selector <css>] [--click <css>] [--type <css> <text>]');
+    process.exit(1);
+  }
+
+  const screenshotIdx = args.indexOf('--screenshot');
+  const screenshotPath = screenshotIdx >= 0 ? args[screenshotIdx + 1] : null;
+  const selectorIdx = args.indexOf('--selector');
+  const selector = selectorIdx >= 0 ? args[selectorIdx + 1] : null;
+
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+
+  try {
+    await page.goto(url, { waitUntil: 'networkidle', timeout: 30000 });
+
+    if (screenshotPath) {
+      await page.screenshot({ path: screenshotPath, fullPage: true });
+      console.log(`Screenshot saved to ${screenshotPath}`);
+    }
+
+    if (selector) {
+      const text = await page.locator(selector).allTextContents();
+      console.log(text.join('\n'));
+    } else {
+      const title = await page.title();
+      const text = await page.locator('body').innerText();
+      console.log(`Title: ${title}\n\n${text.substring(0, 5000)}`);
+    }
+  } catch (e) {
+    console.error('Error:', e.message);
+  } finally {
+    await browser.close();
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

PR 8 of the framework extraction. One file, 46 lines.

**`scripts/browse.js`** — Playwright-based headless browser (from PM). Standalone tool any agent can use for web access beyond what `WebFetch` provides.

Features:
- Fetch a URL and return page text (title + body, truncated to 5000 chars)
- `--screenshot <path>` — full-page screenshot
- `--selector <css>` — extract text from specific elements
- Headless Chromium, 30s timeout, networkidle wait

Requires `playwright-core` (installed globally in containers that need it). No agent.yaml dependency — this is a standalone utility.

**Note:** `review-pr.sh` was planned for this PR but doesn't exist in the Coder repo. Can be added later if needed.

## Test plan

- [x] Script is syntactically valid Node.js
- [ ] Playwright test requires a container with Chromium installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)