### PR TITLE
Wire wake.sh to use framework-update.sh for rollback

### DIFF
--- a/scripts/framework-update.sh
+++ b/scripts/framework-update.sh
@@ -18,11 +18,11 @@ eval "$(node "$FRAMEWORK_DIR/scripts/read-config.js" "$AGENT_DIR/agent.yaml")"
 
 CYCLE_FAILED_MARKER="/tmp/agent-${AGENT_NAME}-cycle-failed"
 
-# Pull latest framework
+# Pull latest framework (informational output to stderr)
 if [ -n "$GH_TOKEN" ]; then
   git -C "$FRAMEWORK_DIR" pull --ff-only \
-    "https://${GH_TOKEN}@github.com/robhunter/agent-portal.git" main 2>&1 || {
-    echo "Warning: framework pull failed (continuing with current version)"
+    "https://${GH_TOKEN}@github.com/robhunter/agent-portal.git" main >&2 2>&1 || {
+    echo "Warning: framework pull failed (continuing with current version)" >&2
   }
 fi
 
@@ -32,9 +32,9 @@ FRAMEWORK_COMMIT="$(git -C "$FRAMEWORK_DIR" rev-parse HEAD 2>/dev/null || echo "
 # Rollback check
 if [ -f "$CYCLE_FAILED_MARKER" ] && [ -n "$FRAMEWORK_LAST_KNOWN_GOOD" ] && [ "$FRAMEWORK_LAST_KNOWN_GOOD" != "null" ]; then
   if [ "$FRAMEWORK_COMMIT" != "$FRAMEWORK_LAST_KNOWN_GOOD" ]; then
-    echo "Previous cycle failed and framework changed — rolling back to $FRAMEWORK_LAST_KNOWN_GOOD"
-    git -C "$FRAMEWORK_DIR" checkout "$FRAMEWORK_LAST_KNOWN_GOOD" 2>&1 || {
-      echo "ERROR: rollback failed"
+    echo "Previous cycle failed and framework changed — rolling back to $FRAMEWORK_LAST_KNOWN_GOOD" >&2
+    git -C "$FRAMEWORK_DIR" checkout "$FRAMEWORK_LAST_KNOWN_GOOD" >&2 2>&1 || {
+      echo "ERROR: rollback failed" >&2
       bash "$FRAMEWORK_DIR/scripts/log-event.sh" "$AGENT_DIR" error \
         "Framework rollback to $FRAMEWORK_LAST_KNOWN_GOOD failed"
     }

--- a/scripts/wake.sh
+++ b/scripts/wake.sh
@@ -79,17 +79,9 @@ touch "$CYCLE_FAILED_MARKER"
 bash "$FRAMEWORK_DIR/scripts/log-event.sh" "$AGENT_DIR" cycle_start "Scheduled wake"
 step "cycle_start logged"
 
-# Pull latest framework code
-step "framework pull starting"
-if [ -z "$GH_TOKEN" ]; then
-  step "framework pull skipped — GH_TOKEN not set"
-else
-  git -C "$FRAMEWORK_DIR" pull --ff-only \
-    "https://${GH_TOKEN}@github.com/robhunter/agent-portal.git" main 200>&- 2>&1 || {
-    step "framework pull failed (non-fatal, continuing)"
-  }
-fi
-FRAMEWORK_COMMIT="$(git -C "$FRAMEWORK_DIR" rev-parse HEAD 2>/dev/null || echo "unknown")"
+# Pull latest framework code + rollback check
+step "framework update starting"
+eval "$(bash "$FRAMEWORK_DIR/scripts/framework-update.sh" "$FRAMEWORK_DIR" "$AGENT_DIR")"
 step "framework at $FRAMEWORK_COMMIT"
 
 # Clone/pull workspaces from agent.yaml


### PR DESCRIPTION
## Summary

Fixes a gap from PRs 3 and 7: wake.sh was doing the framework pull inline, bypassing the rollback logic in framework-update.sh.

**Changes:**
- **wake.sh**: Replace 10-line inline pull block with `eval "$(bash framework-update.sh ...)"` — one line that handles pull + rollback + exports `FRAMEWORK_COMMIT`
- **framework-update.sh**: Send informational output (pull progress, rollback messages) to stderr so only `FRAMEWORK_COMMIT='...'` goes to stdout for clean eval

Net -8 lines.

## Test plan

- [x] `bash -n` syntax check passes for both files
- [ ] Rollback integration test during Bobbo migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)