### PR TITLE
Fix cycle routes to use framework scripts

### DIFF
--- a/lib/routes/cycle.js
+++ b/lib/routes/cycle.js
@@ -11,6 +11,7 @@ function register(routes, config) {
   const cronFile = config.cronFile;
   const lockFile = config.lockFile;
   const agentDir = config.agentDir;
+  const frameworkDir = path.resolve(__dirname, '..', '..');
 
   // POST /api/cron/toggle — enable or disable the cron wake schedule
   routes['POST /api/cron/toggle'] = (req, res) => {
@@ -49,9 +50,9 @@ function register(routes, config) {
     if (isCycleLocked(lockFile)) {
       return sendJSON(res, 409, { ok: false, error: 'Cycle already running' });
     }
-    const wakeScript = path.join(agentDir, 'scripts/wake.sh');
+    const wakeScript = path.join(frameworkDir, 'scripts/wake.sh');
     try {
-      const child = spawn('bash', [wakeScript], {
+      const child = spawn('bash', [wakeScript, agentDir], {
         detached: true,
         stdio: 'ignore',
         cwd: agentDir,
@@ -68,12 +69,9 @@ function register(routes, config) {
     if (isCycleLocked(lockFile)) {
       return sendJSON(res, 409, { ok: false, error: 'Cycle already running' });
     }
-    const respondScript = path.join(agentDir, 'scripts/respond.sh');
-    if (!fs.existsSync(respondScript)) {
-      return sendJSON(res, 404, { ok: false, error: 'respond.sh not found' });
-    }
+    const respondScript = path.join(frameworkDir, 'scripts/respond.sh');
     try {
-      const child = spawn('bash', [respondScript], {
+      const child = spawn('bash', [respondScript, agentDir], {
         detached: true,
         stdio: 'ignore',
         cwd: agentDir,

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -351,12 +351,13 @@ describe('POST /api/cycle/respond', () => {
 
   after(() => server.close());
 
-  it('returns 404 when respond.sh does not exist', async () => {
+  it('returns 200 when no cycle is running (respond.sh resolved from framework)', async () => {
     const { status, data } = await fetchJSON(port, '/api/cycle/respond', {
       method: 'POST',
     });
-    assert.equal(status, 404);
-    assert.ok(data.error.includes('respond.sh not found'));
+    // Should return 200 OK — respond.sh is now resolved from the framework dir
+    assert.equal(status, 200);
+    assert.equal(data.ok, true);
   });
 });
 


### PR DESCRIPTION
## Summary
- Cycle routes (`POST /api/cycle/run` and `POST /api/cycle/respond`) now call the framework's `wake.sh` and `respond.sh` instead of looking for agent-local copies
- Passes `agentDir` as the first argument, matching the convention both scripts already use
- Removes the `fs.existsSync` guard on `respond.sh` since it's now a framework-level script that's always present

## Test plan
- [x] All 192 existing tests pass
- [x] Updated respond route test to reflect new behavior (200 instead of 404)
- [ ] Manual: trigger "Run Cycle" from portal for an agent without local `wake.sh` — should start a cycle

Fixes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)