### PR TITLE
Fix race condition in cycle detection

### DIFF
--- a/lib/cron.js
+++ b/lib/cron.js
@@ -13,8 +13,26 @@ function isCronRunning() {
   }
 }
 
+const STARTING_MARKER_TTL_MS = 30000; // 30 seconds
+
 function isCycleLocked(lockFile) {
   if (!lockFile) return false;
+
+  // Check for .starting marker (covers the gap before wake.sh acquires flock)
+  const markerFile = lockFile + '.starting';
+  try {
+    const stat = fs.statSync(markerFile);
+    const age = Date.now() - stat.mtimeMs;
+    if (age < STARTING_MARKER_TTL_MS) {
+      return true; // cycle is starting up, not yet holding flock
+    }
+    // Stale marker — clean it up
+    try { fs.unlinkSync(markerFile); } catch {}
+  } catch {
+    // No marker file — that's fine
+  }
+
+  // Check the actual flock
   try {
     execSync(`flock -n ${lockFile} echo ok`, { timeout: 3000, stdio: 'ignore' });
     return false;

--- a/lib/routes/cycle.js
+++ b/lib/routes/cycle.js
@@ -52,6 +52,9 @@ function register(routes, config) {
     }
     const wakeScript = path.join(frameworkDir, 'scripts/wake.sh');
     try {
+      // Write starting marker before spawn so status is immediately correct
+      const markerFile = lockFile + '.starting';
+      fs.writeFileSync(markerFile, String(process.pid));
       const child = spawn('bash', [wakeScript, agentDir], {
         detached: true,
         stdio: 'ignore',
@@ -60,6 +63,8 @@ function register(routes, config) {
       child.unref();
       return sendJSON(res, 200, { ok: true });
     } catch (e) {
+      // Clean up marker on spawn failure
+      try { fs.unlinkSync(lockFile + '.starting'); } catch {}
       return sendJSON(res, 500, { error: 'Failed to start cycle: ' + e.message });
     }
   };
@@ -71,6 +76,9 @@ function register(routes, config) {
     }
     const respondScript = path.join(frameworkDir, 'scripts/respond.sh');
     try {
+      // Write starting marker before spawn so status is immediately correct
+      const markerFile = lockFile + '.starting';
+      fs.writeFileSync(markerFile, String(process.pid));
       const child = spawn('bash', [respondScript, agentDir], {
         detached: true,
         stdio: 'ignore',
@@ -79,6 +87,8 @@ function register(routes, config) {
       child.unref();
       return sendJSON(res, 200, { ok: true });
     } catch (e) {
+      // Clean up marker on spawn failure
+      try { fs.unlinkSync(lockFile + '.starting'); } catch {}
       return sendJSON(res, 500, { error: 'Failed to start respond cycle: ' + e.message });
     }
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robhunter/agent-portal",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/scripts/respond.sh
+++ b/scripts/respond.sh
@@ -28,6 +28,8 @@ if ! flock -n 200; then
   echo "Agent already running — skipping respond cycle"
   exit 0
 fi
+# Remove starting marker now that real flock is held
+rm -f "${AGENT_LOCK_FILE}.starting"
 
 CYCLE_TS="$(date +%Y%m%d-%H%M)"
 CYCLE_LOG="logs/cycles/${CYCLE_TS}-respond.log"

--- a/scripts/wake.sh
+++ b/scripts/wake.sh
@@ -43,6 +43,8 @@ if ! flock -n 200; then
   bash "$FRAMEWORK_DIR/scripts/log-event.sh" "$AGENT_DIR" cycle_skipped "Lock held by another cycle"
   exit 0
 fi
+# Remove starting marker now that real flock is held
+rm -f "${AGENT_LOCK_FILE}.starting"
 step "lock acquired"
 
 # Branch guard — ensure agent repo on main

--- a/test/cron.test.js
+++ b/test/cron.test.js
@@ -1,6 +1,9 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
-const { expandField } = require('../lib/cron');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { expandField, isCycleLocked } = require('../lib/cron');
 
 describe('expandField', () => {
   it('expands wildcard', () => {
@@ -51,5 +54,43 @@ describe('expandField', () => {
   it('expands step starting from value', () => {
     const values = expandField('5/10', 0, 59);
     assert.deepEqual([...values].sort((a, b) => a - b), [5, 15, 25, 35, 45, 55]);
+  });
+});
+
+describe('isCycleLocked', () => {
+  it('returns false when no lock file exists', () => {
+    const lockFile = path.join(os.tmpdir(), `test-lock-${Date.now()}-noexist`);
+    assert.equal(isCycleLocked(lockFile), false);
+  });
+
+  it('returns false when lockFile is falsy', () => {
+    assert.equal(isCycleLocked(null), false);
+    assert.equal(isCycleLocked(''), false);
+  });
+
+  it('returns true when .starting marker exists and is fresh', () => {
+    const lockFile = path.join(os.tmpdir(), `test-lock-${Date.now()}-marker`);
+    const markerFile = lockFile + '.starting';
+    fs.writeFileSync(markerFile, '1');
+    try {
+      assert.equal(isCycleLocked(lockFile), true);
+    } finally {
+      try { fs.unlinkSync(markerFile); } catch {}
+    }
+  });
+
+  it('cleans up stale .starting marker and returns false', () => {
+    const lockFile = path.join(os.tmpdir(), `test-lock-${Date.now()}-stale`);
+    const markerFile = lockFile + '.starting';
+    fs.writeFileSync(markerFile, '1');
+    // Backdate the marker to 60 seconds ago
+    const past = new Date(Date.now() - 60000);
+    fs.utimesSync(markerFile, past, past);
+    try {
+      assert.equal(isCycleLocked(lockFile), false);
+      assert.equal(fs.existsSync(markerFile), false, 'stale marker should be cleaned up');
+    } finally {
+      try { fs.unlinkSync(markerFile); } catch {}
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Portal now writes a `.starting` marker file before spawning wake.sh/respond.sh
- `isCycleLocked()` checks for fresh marker (< 30s) in addition to flock
- wake.sh and respond.sh remove the marker once the real flock is acquired
- Stale markers from crashed spawns are auto-cleaned on next check
- 4 new tests for marker-based lock detection (200 total)
- Version bump to 1.3.1

Refs #52

## Test plan
- [x] 200 tests pass (`node --test`)
- [x] Fresh marker detected as locked
- [x] Stale marker cleaned up and not detected as locked

🤖 Generated with [Claude Code](https://claude.com/claude-code)