### PR TITLE
log-journal.sh: support 'auto' monthly filename

### DIFF
--- a/scripts/log-journal.sh
+++ b/scripts/log-journal.sh
@@ -7,6 +7,9 @@ set -e
 
 AGENT_DIR="$1"
 JOURNAL_FILE="$2"
+if [ "$JOURNAL_FILE" = "auto" ]; then
+  JOURNAL_FILE="$(date +%Y-%m).md"
+fi
 AUTHOR="$3"
 TAG="$4"
 CONTENT="$5"


### PR DESCRIPTION
## Summary
- When journal-file argument is `auto`, derives filename as `$(date +%Y-%m).md`
- Explicit filenames (e.g., `bobbo.md`, `ai-research.md`) work as before
- Verified both modes manually

Refs #53

## Test plan
- [x] `auto` resolves to `2026-03.md` (current month)
- [x] Explicit filenames still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)