### PR TITLE
Add Copy Raw button to output files

### DIFF
--- a/lib/ui/tabs/outputs.js
+++ b/lib/ui/tabs/outputs.js
@@ -7,6 +7,16 @@
 function getOutputsTabJS() {
   return `
 let currentOutputFile = null;
+let currentOutputRaw = null;
+
+async function copyRawOutput() {
+  if (!currentOutputRaw) return;
+  try {
+    await navigator.clipboard.writeText(currentOutputRaw);
+    const btn = document.getElementById('copy-raw-btn');
+    if (btn) { btn.textContent = 'Copied!'; setTimeout(function() { btn.textContent = 'Copy Raw'; }, 2000); }
+  } catch { alert('Failed to copy to clipboard'); }
+}
 
 async function loadOutputs() {
   const contentEl = document.getElementById('content');
@@ -52,8 +62,12 @@ async function viewOutput(filename) {
       contentEl.innerHTML = '<div class="empty">Output not found</div>';
       return;
     }
+    currentOutputRaw = data.content;
     let html = '<div style="max-width:800px">';
-    html += '<div style="margin-bottom:16px"><a href="#" onclick="loadOutputs();return false" style="color:#1a73e8;text-decoration:none;font-size:13px">&larr; Back to outputs</a></div>';
+    html += '<div style="margin-bottom:16px;display:flex;justify-content:space-between;align-items:center">';
+    html += '<a href="#" onclick="loadOutputs();return false" style="color:#1a73e8;text-decoration:none;font-size:13px">&larr; Back to outputs</a>';
+    html += '<button class="refresh-btn" onclick="copyRawOutput()" id="copy-raw-btn" style="font-size:12px;padding:4px 10px">Copy Raw</button>';
+    html += '</div>';
     html += '<div class="status-card"><div class="md-content">' + marked.parse(data.content) + '</div></div>';
 
     // Feedback panel

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -243,6 +243,17 @@ describe('buildHTML', () => {
     assert.ok(html.includes('outputs: loadOutputs'));
   });
 
+  it('includes copy raw button in outputs tab JS', () => {
+    const config = {
+      ...baseConfig,
+      features: { tabs: ['journal', 'outputs', 'status'], outputs: true },
+    };
+    const html = buildHTML(config);
+    assert.ok(html.includes('function copyRawOutput'));
+    assert.ok(html.includes('copy-raw-btn'));
+    assert.ok(html.includes('Copy Raw'));
+  });
+
   it('excludes outputs tab JS when not configured', () => {
     const html = buildHTML(baseConfig);
     assert.ok(!html.includes('function loadOutputs'));


### PR DESCRIPTION
## Summary
- Adds a "Copy Raw" button in the top-right of output file detail view
- Copies raw markdown content to clipboard via `navigator.clipboard.writeText`
- Button shows "Copied!" feedback for 2 seconds
- 1 new test (197 total)

Refs #49

## Test plan
- [x] 197 tests pass (`node --test`)
- [x] Copy Raw button included in outputs tab HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)