### PR TITLE
Fix rollback marker timing

### DIFF
--- a/scripts/wake.sh
+++ b/scripts/wake.sh
@@ -73,10 +73,6 @@ CYCLE_TS="$(date +%Y%m%d-%H%M)"
 CYCLE_LOG="logs/cycles/${CYCLE_TS}.log"
 CYCLE_START_EPOCH=$(date +%s)
 
-# Create cycle-failed marker (deleted on success at end of cycle)
-CYCLE_FAILED_MARKER="/tmp/agent-${AGENT_NAME}-cycle-failed"
-touch "$CYCLE_FAILED_MARKER"
-
 # Log cycle start
 bash "$FRAMEWORK_DIR/scripts/log-event.sh" "$AGENT_DIR" cycle_start "Scheduled wake"
 step "cycle_start logged"
@@ -85,6 +81,12 @@ step "cycle_start logged"
 step "framework update starting"
 eval "$(bash "$FRAMEWORK_DIR/scripts/framework-update.sh" "$FRAMEWORK_DIR" "$AGENT_DIR")"
 step "framework at $FRAMEWORK_COMMIT"
+
+# Create cycle-failed marker (deleted on success at end of cycle)
+# Placed AFTER framework update so the marker reflects the PREVIOUS cycle's status,
+# not the current one — framework-update.sh uses this marker for rollback decisions.
+CYCLE_FAILED_MARKER="/tmp/agent-${AGENT_NAME}-cycle-failed"
+touch "$CYCLE_FAILED_MARKER"
 
 # Clone/pull workspaces from agent.yaml
 if [ "$WORKSPACES_COUNT" -gt 0 ] 2>/dev/null; then


### PR DESCRIPTION
## Summary

- Moves the cycle-failed marker creation in `scripts/wake.sh` from before `framework-update.sh` to after it
- The marker was being created too early, causing `framework-update.sh` to always see it and always roll back framework updates — even after successful cycles
- Marker now correctly reflects the previous cycle's outcome when the rollback check runs

Refs #57

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>