### PR TITLE
Increase upload file size limit to 50MB

### DIFF
--- a/lib/routes/uploads.js
+++ b/lib/routes/uploads.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const { sendJSON, readBody } = require('../helpers');
 
-const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
 
 const MIME_TYPES = {
   '.png': 'image/png',
@@ -50,7 +50,7 @@ function register(routes, config) {
     const buffer = Buffer.from(base64Data, 'base64');
 
     if (buffer.length > MAX_FILE_SIZE) {
-      return sendJSON(res, 400, { error: 'File too large (max 5MB)' });
+      return sendJSON(res, 400, { error: 'File too large (max 50MB)' });
     }
 
     // Generate unique filename with timestamp prefix

--- a/lib/ui/client-core.js
+++ b/lib/ui/client-core.js
@@ -412,7 +412,7 @@ async function cancelEditEntry(idx, isProjectJournal) {
 // --- File upload ---
 function handleFileUpload(file, textareaId) {
   if (!file) return;
-  if (file.size > 5 * 1024 * 1024) { alert('File too large (max 5MB)'); return; }
+  if (file.size > 50 * 1024 * 1024) { alert('File too large (max 50MB)'); return; }
   var reader = new FileReader();
   reader.onload = async function() {
     var base64 = reader.result.split(',')[1];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robhunter/agent-portal",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -1124,15 +1124,15 @@ describe('POST /api/upload', () => {
     assert.ok(data.error);
   });
 
-  it('rejects files over 5MB', async () => {
-    const bigData = Buffer.alloc(6 * 1024 * 1024).toString('base64');
+  it('rejects files over 50MB', async () => {
+    const bigData = Buffer.alloc(51 * 1024 * 1024).toString('base64');
     const { status, data } = await fetchJSON(port, '/api/upload', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ filename: 'huge.png', data: bigData }),
     });
     assert.equal(status, 400);
-    assert.ok(data.error.includes('5MB'));
+    assert.ok(data.error.includes('50MB'));
   });
 });
 


### PR DESCRIPTION
## Summary
- Bumped upload file size limit from 5MB to 50MB (server-side and client-side)
- Updated test to validate against new 50MB limit
- Version bump to 1.3.3

Refs #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)