### PR TITLE
Remove hardcoded robhunter username from scripts and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ In your container, clone into `/root/workspaces/agent-portal`:
 
 ```bash
 mkdir -p /root/workspaces
-git clone "https://${GH_TOKEN}@github.com/robhunter/agent-portal.git" /root/workspaces/agent-portal
+git clone "https://${GH_TOKEN}@github.com/your-org/agent-portal.git" /root/workspaces/agent-portal
 ```
 
 ### 2. Create your config file

--- a/agent.yaml.example
+++ b/agent.yaml.example
@@ -2,11 +2,11 @@
 # Place this file at the root of each agent's repo.
 
 # Agent identity
-name: bobbo                          # used in logs, PID files, lock files, temp file naming
-repo: robhunter/bobbo-agent          # GitHub org/repo for push URL derivation
+name: my-agent                       # used in logs, PID files, lock files, temp file naming
+repo: your-org/your-agent            # GitHub org/repo for push URL derivation
 port: 8080                           # portal server port
-lock-file: /tmp/bobbo-agent.lock     # mutex file path
-cron-file: /etc/cron.d/bobbo         # cron file path
+lock-file: /tmp/my-agent.lock         # mutex file path
+cron-file: /etc/cron.d/my-agent      # cron file path
 cron-schedule: "0 */2 * * *"         # cron schedule expression
 
 # Prompts — multi-line text piped to Claude on each cycle type.
@@ -23,7 +23,7 @@ respond-prompt: |
 # Optional: workspaces to clone/pull before each cycle.
 # Omit or leave empty for self-contained agents (like Bobbo).
 workspaces:
-  - repo: robhunter/agentdeals
+  - repo: your-org/your-project
     path: /root/workspaces/agentdeals
     npm-install: true                # run npm install after pull
 

--- a/examples/coder.config.json
+++ b/examples/coder.config.json
@@ -11,7 +11,7 @@
   },
   "features": {
     "github": {
-      "repos": ["robhunter/agentdeals"]
+      "repos": ["your-org/your-project"]
     }
   }
 }

--- a/examples/pm.config.json
+++ b/examples/pm.config.json
@@ -11,7 +11,7 @@
   },
   "features": {
     "github": {
-      "repos": ["robhunter/agentdeals", "robhunter/agent-pm"]
+      "repos": ["your-org/your-project", "your-org/your-agent"]
     },
     "tabs": ["journal", "github", "roadmap", "health", "requests", "status"],
     "cronToggle": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@robhunter/agent-portal",
-  "version": "1.3.0",
+  "name": "agent-portal",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@robhunter/agent-portal",
-      "version": "1.3.0",
+      "name": "agent-portal",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@robhunter/agent-portal",
+  "name": "agent-portal",
   "version": "1.4.1",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/robhunter/agent-portal.git"
+    "url": "https://github.com/your-org/agent-portal.git"
   },
   "license": "MIT",
   "engines": {

--- a/test/fixtures/logs/cycles/wake-steps.log
+++ b/test/fixtures/logs/cycles/wake-steps.log
@@ -1,0 +1,27 @@
+2026-03-06T14:22:41+00:00 wake.sh started (framework=/root/workspaces/agent-portal, agent=/root/workspaces/agent-portal/test/fixtures)
+2026-03-06T14:22:41+00:00 .env not found at /root/workspaces/agent-portal/test/fixtures/.env
+2026-03-06T14:22:41+00:00 config loaded (name=)
+2026-03-06T14:25:16+00:00 wake.sh started (framework=/root/workspaces/agent-portal, agent=/root/workspaces/agent-portal/test/fixtures)
+2026-03-06T14:25:16+00:00 .env not found at /root/workspaces/agent-portal/test/fixtures/.env
+2026-03-06T14:25:16+00:00 config loaded (name=)
+2026-03-06T14:25:59+00:00 wake.sh started (framework=/root/workspaces/agent-portal, agent=/root/workspaces/agent-portal/test/fixtures)
+2026-03-06T14:25:59+00:00 .env not found at /root/workspaces/agent-portal/test/fixtures/.env
+2026-03-06T14:25:59+00:00 config loaded (name=)
+2026-03-07T00:03:10+00:00 wake.sh started (framework=/root/workspaces/agent-portal, agent=/root/workspaces/agent-portal/test/fixtures)
+2026-03-07T00:03:10+00:00 .env not found at /root/workspaces/agent-portal/test/fixtures/.env
+2026-03-07T00:03:10+00:00 config loaded (name=)
+2026-03-08T16:01:31+00:00 wake.sh started (framework=/root/workspaces/agent-portal, agent=/root/workspaces/agent-portal/test/fixtures)
+2026-03-08T16:01:31+00:00 .env not found at /root/workspaces/agent-portal/test/fixtures/.env
+2026-03-08T16:01:31+00:00 config loaded (name=)
+2026-03-09T20:03:01+00:00 wake.sh started (framework=/root/workspaces/agent-portal, agent=/root/workspaces/agent-portal/test/fixtures)
+2026-03-09T20:03:01+00:00 .env not found at /root/workspaces/agent-portal/test/fixtures/.env
+2026-03-09T20:03:01+00:00 config loaded (name=)
+2026-03-09T20:07:27+00:00 wake.sh started (framework=/root/workspaces/agent-portal, agent=/root/workspaces/agent-portal/test/fixtures)
+2026-03-09T20:07:27+00:00 .env not found at /root/workspaces/agent-portal/test/fixtures/.env
+2026-03-09T20:07:27+00:00 config loaded (name=)
+2026-03-10T06:03:54+00:00 wake.sh started (framework=/root/workspaces/agent-portal, agent=/root/workspaces/agent-portal/test/fixtures)
+2026-03-10T06:03:54+00:00 .env not found at /root/workspaces/agent-portal/test/fixtures/.env
+2026-03-10T06:03:54+00:00 config loaded (name=)
+2026-03-10T06:05:21+00:00 wake.sh started (framework=/root/workspaces/agent-portal, agent=/root/workspaces/agent-portal/test/fixtures)
+2026-03-10T06:05:21+00:00 .env not found at /root/workspaces/agent-portal/test/fixtures/.env
+2026-03-10T06:05:21+00:00 config loaded (name=)

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -301,7 +301,7 @@ describe('Journal edit integration', () => {
 describe('Config variations', () => {
   it('boots with GitHub repos configured', async () => {
     const result = bootPortal({
-      features: { github: { repos: ['robhunter/agent-portal'] } },
+      features: { github: { repos: ['test-org/test-portal'] } },
     });
     const server = result.server;
     await new Promise(resolve => server.listen(0, resolve));
@@ -344,7 +344,7 @@ describe('PM portal integration', () => {
         pm: { color: '#00695c', bg: '#e0f2f1' },
       },
       features: {
-        github: { repos: ['robhunter/agentdeals'] },
+        github: { repos: ['test-org/test-repo'] },
         tabs: ['journal', 'github', 'roadmap', 'health', 'requests', 'status'],
         cronToggle: true,
         cycleButtons: true,
@@ -581,7 +581,7 @@ describe('Coder config regression check', () => {
     const result = bootPortal({
       name: 'Coder',
       features: {
-        github: { repos: ['robhunter/agentdeals'] },
+        github: { repos: ['test-org/test-repo'] },
         tabs: ['journal', 'github', 'status'],
       },
     });

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -44,7 +44,7 @@ describe('buildHTML', () => {
   it('includes GitHub tab when features.github is configured', () => {
     const config = {
       ...baseConfig,
-      features: { github: { repos: ['robhunter/agentdeals'] } },
+      features: { github: { repos: ['test-org/test-repo'] } },
     };
     const html = buildHTML(config);
     assert.ok(html.includes('data-tab="github"'));
@@ -91,7 +91,7 @@ describe('buildHTML', () => {
   it('includes loadGitHub when GitHub is configured', () => {
     const config = {
       ...baseConfig,
-      features: { github: { repos: ['robhunter/agentdeals'] } },
+      features: { github: { repos: ['test-org/test-repo'] } },
     };
     const html = buildHTML(config);
     assert.ok(html.includes('function loadGitHub'));


### PR DESCRIPTION
## Summary

- Replaced all `robhunter` references with generic placeholders across examples, docs, and tests
- `agent.yaml.example`: uses `your-org/your-agent`, `your-org/your-project`
- Example configs: use `your-org/your-project`, `your-org/your-agent`
- `README.md`: clone URL uses `your-org/agent-portal`
- `package.json`: name changed from `@robhunter/agent-portal` to `agent-portal`
- Test files: use `test-org/test-repo`, `test-org/test-portal`
- 212 tests pass, zero `robhunter` references remain

Refs #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)