### PR TITLE
Fix feedback submit 404 when outputs enabled

### DIFF
--- a/lib/routes/outputs.js
+++ b/lib/routes/outputs.js
@@ -91,8 +91,8 @@ function register(routes, config) {
     };
   }
 
-  // --- Feedback routes (gated by features.feedback) ---
-  if (config.features && config.features.feedback) {
+  // --- Feedback routes (enabled when outputs or feedback is enabled) ---
+  if (config.features && (config.features.feedback || config.features.outputs)) {
     // GET /api/feedback/:filename — get feedback for an output
     routes['GET /api/feedback/:filename'] = (req, res) => {
       const filename = req.params.filename;


### PR DESCRIPTION
## Summary
- Feedback routes were gated by `features.feedback` separately from outputs routes
- When `features.outputs` was enabled but `features.feedback` was not set, the outputs tab rendered feedback controls but `POST /api/feedback/:filename` returned 404
- Fixed by registering feedback routes when either `features.feedback` or `features.outputs` is enabled

## Test plan
- [x] 212 existing tests pass
- [ ] Verify feedback submission works on a portal with `features.outputs: true` but no explicit `features.feedback`

Refs #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)