### PR TITLE
Add tracked projects section to GitHub tab

### DIFF
--- a/lib/ui/shell.js
+++ b/lib/ui/shell.js
@@ -193,6 +193,7 @@ function buildHTML(config) {
     name,
     tabs,
     hasGitHub: !!(config.features && config.features.github),
+    githubRepos: (config.features && config.features.github && config.features.github.repos) || [],
     sidebarType,
   };
 

--- a/lib/ui/tabs/github.js
+++ b/lib/ui/tabs/github.js
@@ -27,6 +27,25 @@ async function loadGitHub() {
       + '<button class="refresh-btn" onclick="loadGitHub()">Refresh</button>'
       + '</div>';
 
+    // Tracked Projects section
+    if (PORTAL_CONFIG.githubRepos && PORTAL_CONFIG.githubRepos.length > 0) {
+      var projCollapsed = localStorage.getItem('gh-projects-collapsed') === 'true';
+      html += '<div class="gh-section" style="margin-bottom:20px">'
+        + '<h2 style="cursor:pointer;user-select:none" onclick="toggleProjectsSection()">'
+        + '<span id="gh-projects-arrow" style="display:inline-block;transition:transform 0.2s;transform:rotate(' + (projCollapsed ? '-90deg' : '0deg') + ')">\u25BE</span> '
+        + 'Tracked Projects (' + PORTAL_CONFIG.githubRepos.length + ')</h2>'
+        + '<div id="gh-projects-list" style="' + (projCollapsed ? 'display:none' : '') + '">';
+      PORTAL_CONFIG.githubRepos.forEach(function(repo) {
+        var repoName = repo.split('/').pop();
+        var repoUrl = 'https://github.com/' + repo;
+        html += '<div class="gh-item">'
+          + '<a href="' + escapeHtml(repoUrl) + '" target="_blank" rel="noopener" style="font-weight:500">' + escapeHtml(repoName) + '</a>'
+          + '<span style="color:#888;font-size:12px;margin-left:8px">' + escapeHtml(repo) + '</span>'
+          + '</div>';
+      });
+      html += '</div></div>';
+    }
+
     // Issues
     html += '<div class="gh-section"><h2>Open Issues</h2>';
     const issues = Array.isArray(issuesData.items) ? issuesData.items : [];
@@ -83,6 +102,16 @@ async function loadGitHub() {
   } catch (err) {
     contentEl.innerHTML = '<div class="empty">Failed to load GitHub data</div>';
   }
+}
+
+function toggleProjectsSection() {
+  var list = document.getElementById('gh-projects-list');
+  var arrow = document.getElementById('gh-projects-arrow');
+  if (!list || !arrow) return;
+  var hidden = list.style.display === 'none';
+  list.style.display = hidden ? '' : 'none';
+  arrow.style.transform = hidden ? 'rotate(0deg)' : 'rotate(-90deg)';
+  localStorage.setItem('gh-projects-collapsed', hidden ? 'false' : 'true');
 }
 `;
 }

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -102,6 +102,25 @@ describe('buildHTML', () => {
     assert.ok(html.includes('"name":"TestAgent"'));
   });
 
+  it('passes githubRepos to PORTAL_CONFIG when GitHub configured', () => {
+    const config = {
+      ...baseConfig,
+      features: { github: { repos: ['org/repo1', 'org/repo2'] } },
+    };
+    const html = buildHTML(config);
+    assert.ok(html.includes('"githubRepos":["org/repo1","org/repo2"]'));
+  });
+
+  it('includes tracked projects toggle in GitHub tab JS', () => {
+    const config = {
+      ...baseConfig,
+      features: { github: { repos: ['org/repo1'] } },
+    };
+    const html = buildHTML(config);
+    assert.ok(html.includes('toggleProjectsSection'));
+    assert.ok(html.includes('Tracked Projects'));
+  });
+
   it('supports custom tab order via features.tabs', () => {
     const config = {
       ...baseConfig,


### PR DESCRIPTION
## Summary
- Adds a collapsible "Tracked Projects" section at the top of the GitHub tab
- Shows each configured repo with a link to its GitHub page
- Collapse state persists via localStorage
- Repos list passed to client via `PORTAL_CONFIG.githubRepos`

## Test plan
- [x] 2 new UI tests (PORTAL_CONFIG includes repos, toggle function present)
- [x] Pre-existing tests pass (214 total, 2 pre-existing cycle failures unrelated)
- [ ] Verify section appears on portal with GitHub configured, collapses/expands, links work

Refs #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)