### PR TITLE
Add markdown support and multi-line todos

### DIFF
--- a/lib/routes/todos.js
+++ b/lib/routes/todos.js
@@ -43,6 +43,9 @@ function parseTodos(content) {
           text: match[2].trim(),
           done: match[1] !== ' ',
         });
+      } else if (todos.length > 0 && line.match(/^\s+\S/) && !line.match(/^- \[/)) {
+        // Continuation line (indented, not a new checkbox) — append to previous todo
+        todos[todos.length - 1].text += '\n' + line.trimStart();
       }
     } else if (section === 'notes') {
       const headerMatch = line.match(/^### (\S+)\s*\|\s*(\w+)\s*\|\s*(\w+)/);
@@ -68,7 +71,11 @@ function parseTodos(content) {
 function serializeTodos(todos, notes) {
   let md = '## Todos\n\n';
   for (const t of todos) {
-    md += `- [${t.done ? 'x' : ' '}] ${t.text}\n`;
+    const lines = t.text.split('\n');
+    md += `- [${t.done ? 'x' : ' '}] ${lines[0]}\n`;
+    for (let i = 1; i < lines.length; i++) {
+      md += `  ${lines[i]}\n`;
+    }
   }
   md += '\n## Notes\n\n';
   for (const n of notes) {

--- a/lib/ui/styles.js
+++ b/lib/ui/styles.js
@@ -161,6 +161,12 @@ ${authorCSS}
   .md-content th, .md-content td { border: 1px solid #ddd; padding: 8px 12px; text-align: left; }
   .md-content th { background: #f5f5f5; }
 
+  /* Todo text markdown — compact rendering inside checkboxes */
+  .todo-text.md-content p { margin-bottom: 4px; }
+  .todo-text.md-content p:last-child { margin-bottom: 0; }
+  .todo-text.md-content { display: inline; }
+  .todo-text.md-content ul, .todo-text.md-content ol { margin-bottom: 4px; }
+
   /* Tabs hidden (running log mode) — hide tab buttons but keep menu btn */
   #tabs.tabs-hidden .tab { display: none; }
 

--- a/lib/ui/tabs/todos.js
+++ b/lib/ui/tabs/todos.js
@@ -29,7 +29,7 @@ async function loadTodos() {
         html += '<div class="todo-item">'
           + '<label class="todo-checkbox">'
           + '<input type="checkbox" onchange="toggleTodo(' + idx + ', this.checked)">'
-          + '<span class="todo-text">' + escapeHtml(t.text) + '</span>'
+          + '<span class="todo-text md-content">' + marked.parse(t.text) + '</span>'
           + '</label>'
           + '<button class="todo-delete" onclick="deleteTodo(' + idx + ')" title="Delete">\\u00d7</button>'
           + '</div>';
@@ -44,7 +44,7 @@ async function loadTodos() {
           html += '<div class="todo-item todo-completed">'
             + '<label class="todo-checkbox">'
             + '<input type="checkbox" checked onchange="toggleTodo(' + idx + ', this.checked)">'
-            + '<span class="todo-text" style="text-decoration:line-through;color:#999">' + escapeHtml(t.text) + '</span>'
+            + '<span class="todo-text md-content" style="text-decoration:line-through;color:#999">' + marked.parse(t.text) + '</span>'
             + '</label>'
             + '<button class="todo-delete" onclick="deleteTodo(' + idx + ')" title="Delete">\\u00d7</button>'
             + '</div>';

--- a/test/todos.test.js
+++ b/test/todos.test.js
@@ -53,6 +53,38 @@ Agent response.
     assert.equal(notes[1].author, 'coder');
     assert.equal(notes[1].content, 'Agent response.');
   });
+  it('parses multi-line todos with indented continuation', () => {
+    const content = `## Todos
+
+- [ ] First todo
+  with more detail
+  and another line
+- [x] Simple done
+- [ ] Third todo
+  continued here
+
+## Notes
+`;
+    const { todos } = parseTodos(content);
+    assert.equal(todos.length, 3);
+    assert.equal(todos[0].text, 'First todo\nwith more detail\nand another line');
+    assert.equal(todos[0].done, false);
+    assert.equal(todos[1].text, 'Simple done');
+    assert.equal(todos[1].done, true);
+    assert.equal(todos[2].text, 'Third todo\ncontinued here');
+  });
+
+  it('round-trips multi-line todos', () => {
+    const todos = [
+      { text: 'Multi line\nwith detail', done: false },
+      { text: 'Simple', done: true },
+    ];
+    const md = serializeTodos(todos, []);
+    assert.ok(md.includes('- [ ] Multi line\n  with detail'));
+    const parsed = parseTodos(md);
+    assert.equal(parsed.todos[0].text, 'Multi line\nwith detail');
+    assert.equal(parsed.todos[1].text, 'Simple');
+  });
 });
 
 describe('serializeTodos', () => {


### PR DESCRIPTION
## Summary
- Todo text now renders as markdown (bold, links, code, lists) instead of plain escaped text
- Parser handles indented continuation lines as multi-line todo content
- Serializer preserves multi-line formatting with proper indentation
- Compact CSS prevents markdown paragraphs from bloating checkbox layout

## Test plan
- [x] 2 new tests: multi-line parsing and round-trip serialization
- [x] 214 tests pass (2 pre-existing cycle test failures unrelated)
- [ ] Verify todos with markdown formatting (bold, links, newlines) render correctly

Refs #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)