### PR TITLE
Add URL mapping for output files and tabs

### DIFF
--- a/lib/ui/client-core.js
+++ b/lib/ui/client-core.js
@@ -262,6 +262,18 @@ function switchTab(tab) {
   document.querySelectorAll('.tab').forEach(function(t) {
     t.classList.toggle('active', t.dataset.tab === tab);
   });
+  // Update URL with current tab (preserve other params like file)
+  var params = new URLSearchParams(window.location.search);
+  if (tab !== PORTAL_CONFIG.tabs[0]) {
+    params.set('tab', tab);
+  } else {
+    params.delete('tab');
+  }
+  // Clear file param when switching away from outputs
+  if (tab !== 'outputs') params.delete('file');
+  var qs = params.toString();
+  history.replaceState(null, '', qs ? '?' + qs : window.location.pathname);
+
   const loader = TAB_LOADERS[tab];
   if (loader) loader();
   else document.getElementById('content').innerHTML = '<div class="empty">Unknown tab: ' + escapeHtml(tab) + '</div>';

--- a/lib/ui/shell.js
+++ b/lib/ui/shell.js
@@ -185,7 +185,18 @@ function buildHTML(config) {
     loadQuickStats(),
     updateClaudeStatus(),
   ]);
+  // Check URL params for deep linking
+  var params = new URLSearchParams(window.location.search);
+  var urlTab = params.get('tab');
+  var urlFile = params.get('file');
+  if (urlTab && PORTAL_CONFIG.tabs.indexOf(urlTab) !== -1) {
+    currentTab = urlTab;
+  }
   switchTab(currentTab);
+  // If deep-linked to a specific output file, open it
+  if (urlFile && currentTab === 'outputs' && typeof viewOutput === 'function') {
+    viewOutput(urlFile);
+  }
 }`;
   }
 

--- a/lib/ui/tabs/outputs.js
+++ b/lib/ui/tabs/outputs.js
@@ -21,6 +21,13 @@ async function copyRawOutput() {
 async function loadOutputs() {
   const contentEl = document.getElementById('content');
   currentOutputFile = null;
+  // Clear file param from URL when returning to list
+  var params = new URLSearchParams(window.location.search);
+  if (params.has('file')) {
+    params.delete('file');
+    var qs = params.toString();
+    history.replaceState(null, '', qs ? '?' + qs : window.location.pathname);
+  }
   const slug = typeof currentSlug !== 'undefined' ? currentSlug : null;
   const url = slug ? '/api/projects/' + encodeURIComponent(slug) + '/outputs' : '/api/outputs';
   contentEl.innerHTML = '<div class="empty">Loading outputs...</div>';
@@ -53,6 +60,11 @@ async function loadOutputs() {
 
 async function viewOutput(filename) {
   currentOutputFile = filename;
+  // Update URL to allow deep linking to this output
+  var params = new URLSearchParams(window.location.search);
+  params.set('tab', 'outputs');
+  params.set('file', filename);
+  history.replaceState(null, '', '?' + params.toString());
   const contentEl = document.getElementById('content');
   contentEl.innerHTML = '<div class="empty">Loading output...</div>';
   try {

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -121,6 +121,27 @@ describe('buildHTML', () => {
     assert.ok(html.includes('Tracked Projects'));
   });
 
+  it('includes URL-based deep linking for outputs tab', () => {
+    const config = {
+      ...baseConfig,
+      features: { tabs: ['journal', 'outputs'], outputs: true },
+    };
+    const html = buildHTML(config);
+    assert.ok(html.includes("params.get('tab')"));
+    assert.ok(html.includes("params.get('file')"));
+    assert.ok(html.includes('viewOutput(urlFile)'));
+  });
+
+  it('outputs tab updates URL on viewOutput', () => {
+    const config = {
+      ...baseConfig,
+      features: { tabs: ['journal', 'outputs'], outputs: true },
+    };
+    const html = buildHTML(config);
+    assert.ok(html.includes("params.set('tab', 'outputs')"));
+    assert.ok(html.includes("params.set('file', filename)"));
+  });
+
   it('supports custom tab order via features.tabs', () => {
     const config = {
       ...baseConfig,


### PR DESCRIPTION
## Summary
- Output files now have unique URLs: `?tab=outputs&file=filename.md`
- Tab navigation persists to URL params for deep linking
- Page load checks URL params and auto-navigates to the right tab/file
- Enables bookmarking and sharing links to specific outputs

## Test plan
- [x] 2 new UI tests (deep link init logic, viewOutput URL update)
- [x] 216 tests pass (2 pre-existing cycle test failures unrelated)
- [ ] Verify: click output file → URL updates, reload page → same output shown, share URL → opens correctly

Refs #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)