### PR TITLE
Fix commit link URL: derive from git remote

### DIFF
--- a/lib/ui/shell.js
+++ b/lib/ui/shell.js
@@ -7,11 +7,18 @@ const pkg = require('../../package.json');
 const { version } = pkg;
 const { getStyles } = require('./styles');
 
-// Capture git commit at module load time (once, cached for server lifetime)
+// Capture git commit and repo URL at module load time (once, cached for server lifetime)
 let gitCommit = null;
+let gitRepoUrl = null;
 try {
   const repoRoot = path.resolve(__dirname, '..', '..');
   gitCommit = execSync('git rev-parse HEAD', { cwd: repoRoot, encoding: 'utf-8', timeout: 5000 }).trim();
+  const remoteUrl = execSync('git remote get-url origin', { cwd: repoRoot, encoding: 'utf-8', timeout: 5000 }).trim();
+  // Normalize remote URL to HTTPS browsable URL (strip .git, auth tokens, convert SSH)
+  gitRepoUrl = remoteUrl
+    .replace(/^git@github\.com:/, 'https://github.com/')
+    .replace(/\.git$/, '')
+    .replace(/https:\/\/[^@]+@github\.com/, 'https://github.com');
 } catch {
   // Not a git repo or git not available — graceful degradation
 }
@@ -45,8 +52,7 @@ function buildHTML(config) {
   let versionFooter;
   if (gitCommit) {
     const shortHash = gitCommit.slice(0, 7);
-    const repoUrl = (pkg.repository && pkg.repository.url || '').replace(/\.git$/, '');
-    const commitUrl = repoUrl ? `${repoUrl}/commit/${gitCommit}` : '';
+    const commitUrl = gitRepoUrl ? `${gitRepoUrl}/commit/${gitCommit}` : '';
     if (commitUrl) {
       versionFooter = `<a href="${commitUrl}" target="_blank" rel="noopener" style="color:inherit;text-decoration:none" title="${gitCommit}">Agent Portal v${version} (${shortHash})</a>`;
     } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Commit link in portal footer was showing `your-org` instead of actual org name
- Now derives repo URL from `git remote get-url origin` at module load time instead of reading `package.json`
- Handles SSH URLs, auth tokens, and `.git` suffix normalization
- Bumps version to 1.4.4

## Test plan
- [x] Verified output contains `robhunter/agent-portal` (not `your-org`)
- [x] All 218 existing tests pass

Refs #84