### PR TITLE
Fix todo formatting — clear checkbox/text association

### DIFF
--- a/lib/ui/styles.js
+++ b/lib/ui/styles.js
@@ -161,11 +161,20 @@ ${authorCSS}
   .md-content th, .md-content td { border: 1px solid #ddd; padding: 8px 12px; text-align: left; }
   .md-content th { background: #f5f5f5; }
 
+  /* Todo items — clear association between checkbox and text */
+  .todo-item { display: flex; align-items: flex-start; gap: 8px; padding: 6px 0; border-bottom: 1px solid #f0f0f0; }
+  .todo-item:last-child { border-bottom: none; }
+  .todo-checkbox { display: flex; align-items: flex-start; gap: 8px; flex: 1; cursor: pointer; margin: 0; }
+  .todo-checkbox input[type="checkbox"] { flex-shrink: 0; margin-top: 3px; width: 16px; height: 16px; cursor: pointer; }
+  .todo-text { flex: 1; font-size: 14px; line-height: 1.5; }
+  .todo-delete { flex-shrink: 0; background: none; border: none; color: #ccc; font-size: 18px; cursor: pointer; padding: 0 4px; line-height: 1; }
+  .todo-delete:hover { color: #e53e3e; }
+  .todo-completed .todo-text { text-decoration: line-through; color: #999; }
+
   /* Todo text markdown — compact rendering inside checkboxes */
-  .todo-text.md-content p { margin-bottom: 4px; }
-  .todo-text.md-content p:last-child { margin-bottom: 0; }
-  .todo-text.md-content { display: inline; }
-  .todo-text.md-content ul, .todo-text.md-content ol { margin-bottom: 4px; }
+  .todo-text.md-content p { margin: 0; }
+  .todo-text.md-content ul, .todo-text.md-content ol { margin: 0 0 4px 16px; }
+  .todo-text.md-content > p + p { margin-top: 4px; }
 
   /* Tabs hidden (running log mode) — hide tab buttons but keep menu btn */
   #tabs.tabs-hidden .tab { display: none; }

--- a/lib/ui/tabs/todos.js
+++ b/lib/ui/tabs/todos.js
@@ -29,7 +29,7 @@ async function loadTodos() {
         html += '<div class="todo-item">'
           + '<label class="todo-checkbox">'
           + '<input type="checkbox" onchange="toggleTodo(' + idx + ', this.checked)">'
-          + '<span class="todo-text md-content">' + marked.parse(t.text) + '</span>'
+          + '<span class="todo-text md-content">' + marked.parse(t.text).trim() + '</span>'
           + '</label>'
           + '<button class="todo-delete" onclick="deleteTodo(' + idx + ')" title="Delete">\\u00d7</button>'
           + '</div>';
@@ -44,7 +44,7 @@ async function loadTodos() {
           html += '<div class="todo-item todo-completed">'
             + '<label class="todo-checkbox">'
             + '<input type="checkbox" checked onchange="toggleTodo(' + idx + ', this.checked)">'
-            + '<span class="todo-text md-content" style="text-decoration:line-through;color:#999">' + marked.parse(t.text) + '</span>'
+            + '<span class="todo-text md-content">' + marked.parse(t.text).trim() + '</span>'
             + '</label>'
             + '<button class="todo-delete" onclick="deleteTodo(' + idx + ')" title="Delete">\\u00d7</button>'
             + '</div>';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Added proper CSS for `.todo-item` layout with flexbox alignment so checkboxes, text, and delete buttons are visually grouped
- Removed inline strikethrough styles in favor of `.todo-completed` CSS class
- Fixed markdown paragraph margins inside todo text to prevent layout bloat
- Bumped to v1.4.5

Refs #91

## Test plan
- [ ] Verify todo tab renders with clear checkbox/text association
- [ ] Verify completed todos show strikethrough styling
- [ ] Verify multi-line todos wrap correctly under the text, not under the checkbox
- [ ] Verify delete button stays right-aligned
- [ ] All 236 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)