### PR TITLE
Fix CLAUDECODE env var leak in manual cycle spawns

### DIFF
--- a/lib/routes/cycle.js
+++ b/lib/routes/cycle.js
@@ -55,10 +55,13 @@ function register(routes, config) {
       // Write starting marker before spawn so status is immediately correct
       const markerFile = lockFile + '.starting';
       fs.writeFileSync(markerFile, String(process.pid));
+      const cleanEnv = { ...process.env };
+      delete cleanEnv.CLAUDECODE;
       const child = spawn('bash', [wakeScript, agentDir], {
         detached: true,
         stdio: 'ignore',
         cwd: agentDir,
+        env: cleanEnv,
       });
       child.unref();
       return sendJSON(res, 200, { ok: true });
@@ -79,10 +82,13 @@ function register(routes, config) {
       // Write starting marker before spawn so status is immediately correct
       const markerFile = lockFile + '.starting';
       fs.writeFileSync(markerFile, String(process.pid));
+      const cleanEnv2 = { ...process.env };
+      delete cleanEnv2.CLAUDECODE;
       const child = spawn('bash', [respondScript, agentDir], {
         detached: true,
         stdio: 'ignore',
         cwd: agentDir,
+        env: cleanEnv2,
       });
       child.unref();
       return sendJSON(res, 200, { ok: true });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Strip `CLAUDECODE` from spawned process env in both `/api/cycle/run` and `/api/cycle/respond` routes
- Prevents "Claude Code cannot be launched inside another Claude Code session" errors when portal inherits the variable
- Cron-triggered cycles are unaffected (crond provides clean env)
- Bumped version to v1.4.7

Refs #93

## Test plan
- [x] All 236 existing tests pass
- [ ] Manual cycle trigger works when CLAUDECODE is set in portal env
- [ ] Cron cycles continue to work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)