### PR TITLE
Cap Recent PRs to 30 total

### DIFF
--- a/lib/routes/github.js
+++ b/lib/routes/github.js
@@ -78,9 +78,9 @@ function register(routes, config) {
         }
       }
     }
-    // Sort by createdAt descending (newest first)
+    // Sort by createdAt descending (newest first), cap at 30
     allItems.sort((a, b) => (b.createdAt || '').localeCompare(a.createdAt || ''));
-    const response = { items: allItems, repos };
+    const response = { items: allItems.slice(0, 30), repos };
     if (errors.length > 0) response.errors = errors;
     sendJSON(res, 200, response);
   };


### PR DESCRIPTION
## Summary
- Caps the combined PR list to 30 items after sorting by date
- With 3+ repos at 20 PRs each, the list was unbounded

Refs #96

## Test plan
- [x] 236 tests pass
- [ ] GitHub tab shows at most 30 PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)