### PR TITLE
Add journal pagination with load-older button

### DIFF
--- a/lib/routes/journal.js
+++ b/lib/routes/journal.js
@@ -10,8 +10,24 @@ function register(routes, config) {
   const journalsDir = path.join(config.agentDir, 'journals');
 
   routes['GET /api/journal'] = (req, res) => {
-    const entries = getAllJournalEntries(journalsDir);
-    sendJSON(res, 200, { entries });
+    const url = new URL(req.url, 'http://localhost');
+    const limit = Math.min(parseInt(url.searchParams.get('limit')) || 0, 200);
+    const before = url.searchParams.get('before') || '';
+
+    const allEntries = getAllJournalEntries(journalsDir);
+
+    if (!limit) {
+      // No pagination requested — return all (backwards compat)
+      return sendJSON(res, 200, { entries: allEntries });
+    }
+
+    // Filter entries before the cursor, then take the last `limit` entries
+    let filtered = before
+      ? allEntries.filter(e => e.ts < before)
+      : allEntries;
+    const hasMore = filtered.length > limit;
+    const entries = filtered.slice(-limit);
+    sendJSON(res, 200, { entries, hasMore });
   };
 
   routes['POST /api/journal'] = async (req, res) => {

--- a/lib/ui/client-core.js
+++ b/lib/ui/client-core.js
@@ -280,31 +280,45 @@ function switchTab(tab) {
 }
 
 // --- Journal tab ---
+var _journalHasMore = false;
+var _journalPageSize = 30;
+
+function renderJournalEntry(e, idx) {
+  const dateStr = formatTimestamp(e.ts);
+  const editBtn = e.author === 'rob'
+    ? '<button class="edit-entry-btn" onclick="startEditEntry(' + idx + ', false)" title="Edit">Edit</button>' : '';
+  return '<div class="journal-entry author-' + escapeHtml(e.author) + '" id="entry-' + idx + '">'
+    + '<div class="journal-entry-header">'
+    + '<span class="author-badge ' + escapeHtml(e.author) + '">' + escapeHtml(e.author) + '</span>'
+    + '<span class="tag-badge tag-' + escapeHtml(e.tag) + '">' + escapeHtml(e.tag) + '</span>'
+    + '<span class="timestamp">' + dateStr + '</span>'
+    + editBtn
+    + '</div>'
+    + '<div class="journal-entry-body md-content">' + marked.parse(e.content) + '</div>'
+    + '</div>';
+}
+
 async function loadJournal() {
   const contentEl = document.getElementById('content');
   contentEl.innerHTML = '<div class="empty">Loading journal...</div>';
   try {
-    const res = await fetch('/api/journal');
+    const res = await fetch('/api/journal?limit=' + _journalPageSize);
     const data = await res.json();
     _journalEntries = data.entries || [];
+    _journalHasMore = !!data.hasMore;
     let html = '<div class="journal-thread">';
+
+    if (_journalHasMore) {
+      html += '<div id="load-older-wrap" style="text-align:center;padding:12px 0">'
+        + '<button id="load-older-btn" onclick="loadOlderEntries()" style="cursor:pointer;padding:6px 16px;border:1px solid #555;border-radius:4px;background:transparent;color:inherit">Load older entries</button>'
+        + '</div>';
+    }
 
     if (_journalEntries.length === 0) {
       html += '<div class="empty" style="margin-top:60px">No journal entries yet. Add the first note below.</div>';
     } else {
-      data.entries.forEach(function(e, idx) {
-        const dateStr = formatTimestamp(e.ts);
-        const editBtn = e.author === 'rob'
-          ? '<button class="edit-entry-btn" onclick="startEditEntry(' + idx + ', false)" title="Edit">Edit</button>' : '';
-        html += '<div class="journal-entry author-' + escapeHtml(e.author) + '" id="entry-' + idx + '">'
-          + '<div class="journal-entry-header">'
-          + '<span class="author-badge ' + escapeHtml(e.author) + '">' + escapeHtml(e.author) + '</span>'
-          + '<span class="tag-badge tag-' + escapeHtml(e.tag) + '">' + escapeHtml(e.tag) + '</span>'
-          + '<span class="timestamp">' + dateStr + '</span>'
-          + editBtn
-          + '</div>'
-          + '<div class="journal-entry-body md-content">' + marked.parse(e.content) + '</div>'
-          + '</div>';
+      _journalEntries.forEach(function(e, idx) {
+        html += renderJournalEntry(e, idx);
       });
     }
 
@@ -338,6 +352,53 @@ async function loadJournal() {
   }
 }
 
+async function loadOlderEntries() {
+  if (!_journalHasMore || _journalEntries.length === 0) return;
+  var btn = document.getElementById('load-older-btn');
+  if (btn) { btn.disabled = true; btn.textContent = 'Loading...'; }
+  try {
+    var oldest = _journalEntries[0].ts;
+    var res = await fetch('/api/journal?limit=' + _journalPageSize + '&before=' + encodeURIComponent(oldest));
+    var data = await res.json();
+    var older = data.entries || [];
+    _journalHasMore = !!data.hasMore;
+    if (older.length === 0) { _journalHasMore = false; }
+
+    // Re-index: prepend older entries
+    _journalEntries = older.concat(_journalEntries);
+
+    // Rebuild entry HTML with correct indices
+    var thread = document.querySelector('.journal-thread');
+    if (!thread) return;
+
+    // Remove old load-older button
+    var wrap = document.getElementById('load-older-wrap');
+    if (wrap) wrap.remove();
+
+    // Build new entries HTML + new button if needed
+    var insertHtml = '';
+    if (_journalHasMore) {
+      insertHtml += '<div id="load-older-wrap" style="text-align:center;padding:12px 0">'
+        + '<button id="load-older-btn" onclick="loadOlderEntries()" style="cursor:pointer;padding:6px 16px;border:1px solid #555;border-radius:4px;background:transparent;color:inherit">Load older entries</button>'
+        + '</div>';
+    }
+    for (var i = 0; i < older.length; i++) {
+      insertHtml += renderJournalEntry(older[i], i);
+    }
+
+    // Re-number existing entry IDs
+    var existingEntries = thread.querySelectorAll('.journal-entry');
+    existingEntries.forEach(function(el, idx) {
+      el.id = 'entry-' + (older.length + idx);
+    });
+
+    thread.insertAdjacentHTML('afterbegin', insertHtml);
+    fixOutputLinks(thread);
+  } catch (err) {
+    if (btn) { btn.disabled = false; btn.textContent = 'Load older entries'; }
+  }
+}
+
 async function submitNote() {
   const text = document.getElementById('note-text').value.trim();
   const tag = document.getElementById('note-tag').value;
@@ -355,8 +416,6 @@ async function submitNote() {
   } catch {}
   await loadJournal();
 }
-
-var _journalEntries = [];
 
 function startEditEntry(idx, isProjectJournal) {
   var entry = _journalEntries[idx];

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -134,6 +134,24 @@ describe('GET /api/journal', () => {
       assert.ok(data.entries[i].ts >= data.entries[i - 1].ts);
     }
   });
+
+  it('supports limit parameter for pagination', async () => {
+    const { status, data } = await fetchJSON(port, '/api/journal?limit=2');
+    assert.equal(status, 200);
+    assert.equal(data.entries.length, 2);
+    assert.equal(data.hasMore, true);
+    // Should return the last 2 entries (newest)
+    const all = (await fetchJSON(port, '/api/journal')).data;
+    assert.equal(data.entries[1].ts, all.entries[all.entries.length - 1].ts);
+  });
+
+  it('supports before parameter for cursor pagination', async () => {
+    const all = (await fetchJSON(port, '/api/journal')).data;
+    const midTs = all.entries[2].ts;
+    const { data } = await fetchJSON(port, '/api/journal?limit=10&before=' + encodeURIComponent(midTs));
+    assert.ok(data.entries.every(e => e.ts < midTs));
+    assert.equal(data.hasMore, false);
+  });
 });
 
 describe('POST /api/journal', () => {


### PR DESCRIPTION
## Summary
- Server: `GET /api/journal` now supports `?limit=N&before=TS` cursor pagination
- Client: Initial load fetches 30 entries instead of all; "Load older entries" button at top loads previous page
- Backwards compatible: requests without `limit` return all entries
- 2 new pagination tests (238 total)

Refs #87

## Test plan
- [x] 238 tests pass (+2 new pagination tests)
- [ ] Journal tab loads quickly with paginated initial fetch
- [ ] "Load older entries" button loads previous page correctly
- [ ] After submitting a new note, journal reloads with latest entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)