### PR TITLE
Add time-series activity charts to Status page

### DIFF
--- a/lib/routes/events.js
+++ b/lib/routes/events.js
@@ -16,6 +16,57 @@ function register(routes, config) {
     sendJSON(res, 200, events);
   };
 
+  routes['GET /api/events/timeseries'] = (req, res) => {
+    const eventsPath = path.join(logsDir, 'events.jsonl');
+    const days = 30;
+    const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+    // Build day-keyed buckets for the last 30 days
+    const buckets = {};
+    for (let i = 0; i < days; i++) {
+      const d = new Date(Date.now() - i * 24 * 60 * 60 * 1000);
+      const key = d.toISOString().slice(0, 10);
+      buckets[key] = { cycles: 0, work: 0, errors: 0, idle: 0, totalDuration: 0, cycleEnds: 0 };
+    }
+
+    try {
+      const content = fs.readFileSync(eventsPath, 'utf-8').trim();
+      if (content) {
+        for (const line of content.split('\n')) {
+          try {
+            const evt = JSON.parse(line);
+            const evtDate = new Date(evt.ts);
+            if (evtDate < cutoff) continue;
+            const key = evtDate.toISOString().slice(0, 10);
+            if (!buckets[key]) continue;
+            if (evt.type === 'cycle_start') buckets[key].cycles++;
+            else if (evt.type === 'work') buckets[key].work++;
+            else if (evt.type === 'error') buckets[key].errors++;
+            else if (evt.type === 'idle') buckets[key].idle++;
+            if (evt.type === 'cycle_end' && evt.duration_m != null) {
+              buckets[key].totalDuration += evt.duration_m;
+              buckets[key].cycleEnds++;
+            }
+          } catch {}
+        }
+      }
+    } catch {}
+
+    // Convert to sorted array
+    const series = Object.keys(buckets).sort().map(date => {
+      const b = buckets[date];
+      return {
+        date,
+        cycles: b.cycles,
+        work: b.work,
+        errors: b.errors,
+        idle: b.idle,
+        avgDuration: b.cycleEnds > 0 ? Math.round(b.totalDuration / b.cycleEnds) : 0,
+      };
+    });
+    sendJSON(res, 200, { days, series });
+  };
+
   routes['GET /api/wins'] = (req, res) => {
     const winsPath = path.join(logsDir, 'wins.jsonl');
     let allWins = [];

--- a/lib/ui/client-core.js
+++ b/lib/ui/client-core.js
@@ -551,24 +551,86 @@ document.addEventListener('drop', function(e) {
   }
 });
 
+// --- SVG chart builder ---
+function buildSvgChart(series, key, color, label) {
+  var W = 600, H = 160, padL = 40, padR = 10, padT = 10, padB = 30;
+  var chartW = W - padL - padR;
+  var chartH = H - padT - padB;
+  var vals = series.map(function(d) { return d[key] || 0; });
+  var maxVal = Math.max.apply(null, vals);
+  if (maxVal === 0) maxVal = 1;
+
+  // Y-axis: pick nice grid lines
+  var gridCount = 4;
+  var gridStep = Math.ceil(maxVal / gridCount) || 1;
+  var yMax = gridStep * gridCount;
+
+  var svg = '<svg viewBox="0 0 ' + W + ' ' + H + '" class="ts-chart">';
+  // Grid lines
+  for (var g = 0; g <= gridCount; g++) {
+    var gy = padT + chartH - (g * chartH / gridCount);
+    svg += '<line x1="' + padL + '" y1="' + gy + '" x2="' + (W - padR) + '" y2="' + gy + '" stroke="#e0e0e0" stroke-width="1"/>';
+    svg += '<text x="' + (padL - 4) + '" y="' + (gy + 4) + '" text-anchor="end" class="ts-axis-label">' + (g * gridStep) + '</text>';
+  }
+
+  // Bars
+  var barGap = 1;
+  var barW = Math.max(1, (chartW / vals.length) - barGap);
+  for (var i = 0; i < vals.length; i++) {
+    var barH = vals[i] > 0 ? Math.max(2, (vals[i] / yMax) * chartH) : 0;
+    var bx = padL + i * (barW + barGap);
+    var by = padT + chartH - barH;
+    svg += '<rect x="' + bx + '" y="' + by + '" width="' + barW + '" height="' + barH + '" fill="' + color + '" rx="1">';
+    svg += '<title>' + series[i].date + ': ' + vals[i] + ' ' + label + '</title></rect>';
+  }
+
+  // X-axis labels (every 7 days)
+  for (var j = 0; j < series.length; j += 7) {
+    var lx = padL + j * (barW + barGap) + barW / 2;
+    var parts = series[j].date.split('-');
+    svg += '<text x="' + lx + '" y="' + (H - 4) + '" text-anchor="middle" class="ts-axis-label">' + parts[1] + '/' + parts[2] + '</text>';
+  }
+  svg += '</svg>';
+  return svg;
+}
+
 // --- Status tab ---
 async function loadStatus() {
   const contentEl = document.getElementById('content');
   contentEl.innerHTML = '<div class="empty">Loading status...</div>';
 
   try {
-    const [statusRes, eventsRes, winsRes, todayRes] = await Promise.all([
+    const [statusRes, eventsRes, winsRes, todayRes, tsRes] = await Promise.all([
       fetch('/api/status'),
       fetch('/api/events'),
       fetch('/api/wins'),
       fetch('/api/today'),
+      fetch('/api/events/timeseries'),
     ]);
     const status = await statusRes.json();
     const events = await eventsRes.json();
     const wins = await winsRes.json();
     const today = await todayRes.json();
+    const tsData = await tsRes.json();
 
     let html = '';
+
+    // Activity charts (last 30 days)
+    if (tsData && tsData.series && tsData.series.length > 0) {
+      var totalCycles = 0, totalWork = 0, totalErrors = 0;
+      tsData.series.forEach(function(d) { totalCycles += d.cycles; totalWork += d.work; totalErrors += d.errors; });
+      html += '<div class="status-section"><h2>Activity (Last 30 Days)</h2>';
+      html += '<div class="ts-summary">'
+        + '<span class="ts-stat"><strong>' + totalCycles + '</strong> cycles</span>'
+        + '<span class="ts-stat"><strong>' + totalWork + '</strong> work events</span>'
+        + '<span class="ts-stat"><strong>' + totalErrors + '</strong> errors</span>'
+        + '</div>';
+      html += '<div class="ts-charts">';
+      html += '<div class="ts-chart-wrap"><div class="ts-chart-title">Cycles per Day</div>' + buildSvgChart(tsData.series, 'cycles', '#1565c0', 'cycles') + '</div>';
+      html += '<div class="ts-chart-wrap"><div class="ts-chart-title">Work Events per Day</div>' + buildSvgChart(tsData.series, 'work', '#e65100', 'work events') + '</div>';
+      html += '<div class="ts-chart-wrap"><div class="ts-chart-title">Avg Cycle Duration (min)</div>' + buildSvgChart(tsData.series, 'avgDuration', '#2e7d32', 'min avg') + '</div>';
+      html += '</div></div>';
+    }
 
     // Today.md
     html += '<div class="status-section">'

--- a/lib/ui/styles.js
+++ b/lib/ui/styles.js
@@ -111,6 +111,18 @@ ${authorCSS}
   .win-item .win-desc { font-size: 14px; }
   .win-item .win-meta { font-size: 12px; color: #888; margin-top: 4px; }
 
+  /* Time-series charts */
+  .ts-summary { display: flex; gap: 20px; margin-bottom: 12px; flex-wrap: wrap; }
+  .ts-stat { font-size: 14px; color: #555; }
+  .ts-stat strong { font-size: 18px; color: #222; }
+  .ts-charts { display: grid; grid-template-columns: 1fr; gap: 16px; }
+  .ts-chart-wrap { background: #fff; border: 1px solid #e8e8e8; border-radius: 8px; padding: 12px 16px; }
+  .ts-chart-title { font-size: 13px; font-weight: 600; color: #555; margin-bottom: 8px; }
+  .ts-chart { width: 100%; height: auto; }
+  .ts-axis-label { font-size: 10px; fill: #999; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
+  @media (min-width: 900px) { .ts-charts { grid-template-columns: 1fr 1fr; } }
+  @media (min-width: 1200px) { .ts-charts { grid-template-columns: 1fr 1fr 1fr; } }
+
   /* Project sidebar */
   .project-item { padding: 12px 16px; border-bottom: 1px solid #f0f0f0; cursor: pointer; transition: background 0.1s; }
   .project-item:hover { background: #f8f8f8; }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -246,6 +246,75 @@ describe('GET /api/events', () => {
   });
 });
 
+describe('GET /api/events/timeseries', () => {
+  let server, port, tmpDir;
+
+  before(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'portal-ts-'));
+    fs.mkdirSync(path.join(tmpDir, 'logs'));
+    const today = new Date().toISOString().slice(0, 10);
+    const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+    const events = [
+      `{"ts":"${yesterday}T08:00:00Z","type":"cycle_start","summary":"Scheduled wake"}`,
+      `{"ts":"${yesterday}T08:10:00Z","type":"work","summary":"Shipped PR","project":"test"}`,
+      `{"ts":"${yesterday}T08:15:00Z","type":"cycle_end","summary":"Done","duration_s":900,"duration_m":15}`,
+      `{"ts":"${today}T08:00:00Z","type":"cycle_start","summary":"Scheduled wake"}`,
+      `{"ts":"${today}T08:05:00Z","type":"error","summary":"Test failed"}`,
+      `{"ts":"${today}T08:10:00Z","type":"cycle_end","summary":"Done","duration_s":600,"duration_m":10}`,
+      `{"ts":"${today}T10:00:00Z","type":"cycle_start","summary":"Scheduled wake"}`,
+      `{"ts":"${today}T10:05:00Z","type":"idle","summary":"No issues"}`,
+      `{"ts":"${today}T10:06:00Z","type":"cycle_end","summary":"Done","duration_s":360,"duration_m":6}`,
+    ];
+    fs.writeFileSync(path.join(tmpDir, 'logs', 'events.jsonl'), events.join('\n') + '\n');
+    const result = createTestServer({ agentDir: tmpDir });
+    server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    port = server.address().port;
+  });
+
+  after(() => { server.close(); fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('returns 30-day series with correct structure', async () => {
+    const { status, data } = await fetchJSON(port, '/api/events/timeseries');
+    assert.equal(status, 200);
+    assert.equal(data.days, 30);
+    assert.ok(Array.isArray(data.series));
+    assert.equal(data.series.length, 30);
+    // Each entry has expected fields
+    const entry = data.series[0];
+    assert.ok('date' in entry);
+    assert.ok('cycles' in entry);
+    assert.ok('work' in entry);
+    assert.ok('errors' in entry);
+    assert.ok('avgDuration' in entry);
+  });
+
+  it('aggregates events correctly by day', async () => {
+    const { data } = await fetchJSON(port, '/api/events/timeseries');
+    const today = new Date().toISOString().slice(0, 10);
+    const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+    const todayEntry = data.series.find(d => d.date === today);
+    const yesterdayEntry = data.series.find(d => d.date === yesterday);
+    assert.equal(todayEntry.cycles, 2);
+    assert.equal(todayEntry.errors, 1);
+    assert.equal(todayEntry.idle, 1);
+    assert.equal(todayEntry.avgDuration, 8); // (10+6)/2
+    assert.equal(yesterdayEntry.cycles, 1);
+    assert.equal(yesterdayEntry.work, 1);
+    assert.equal(yesterdayEntry.avgDuration, 15);
+  });
+
+  it('returns zeros for days with no events', async () => {
+    const { data } = await fetchJSON(port, '/api/events/timeseries');
+    const twoDaysAgo = new Date(Date.now() - 2 * 86400000).toISOString().slice(0, 10);
+    const entry = data.series.find(d => d.date === twoDaysAgo);
+    assert.equal(entry.cycles, 0);
+    assert.equal(entry.work, 0);
+    assert.equal(entry.errors, 0);
+    assert.equal(entry.avgDuration, 0);
+  });
+});
+
 describe('GET /api/wins', () => {
   let server, port;
 

--- a/test/web-portal.test.js
+++ b/test/web-portal.test.js
@@ -147,6 +147,13 @@ describe('web portal — client core JS integrity', () => {
     assert.ok(html.includes('/api/next-run'), 'Core JS should fetch /api/next-run');
   });
 
+  it('client core references timeseries API and chart builder', () => {
+    const html = buildHTML(baseConfig);
+    assert.ok(html.includes('/api/events/timeseries'), 'Core JS should fetch /api/events/timeseries');
+    assert.ok(html.includes('buildSvgChart'), 'Core JS should include SVG chart builder function');
+    assert.ok(html.includes('ts-chart'), 'Core JS should reference chart CSS classes');
+  });
+
   it('client core references correct API endpoints for cron and cycle', () => {
     const html = buildHTML(baseConfig);
     assert.ok(html.includes('/api/cron/toggle'), 'Core JS should reference /api/cron/toggle');


### PR DESCRIPTION
## Summary
- New `/api/events/timeseries` endpoint aggregates `events.jsonl` into 30-day daily buckets (cycles, work events, errors, idle, avg cycle duration)
- SVG bar charts rendered client-side with zero external dependencies — matches portal's dependency-free philosophy
- Three charts on the Status page: **Cycles per Day**, **Work Events per Day**, **Avg Cycle Duration (min)**
- Summary stats row showing 30-day totals at a glance
- Responsive grid layout (1 col mobile → 2 col tablet → 3 col desktop)
- 4 new tests (3 route + 1 web portal integrity). 242 total (240 pass, 2 pre-existing failures)
- Bumps portal to v1.4.8

Refs #92

## Test plan
- [x] All 4 new tests pass (timeseries structure, daily aggregation, zero-fill for empty days, client-side chart references)
- [x] 240/242 tests pass (2 pre-existing failures unrelated to this change)
- [ ] Visual verification: load Status tab, confirm charts render with real data

🤖 Generated with [Claude Code](https://claude.com/claude-code)