### PR TITLE
Fix orphaned flock recovery in wake.sh

### DIFF
--- a/scripts/wake.sh
+++ b/scripts/wake.sh
@@ -80,9 +80,10 @@ if ! flock -n 200; then
     step "no holder PID found — lock is orphaned, retrying"
     bash "$FRAMEWORK_DIR/scripts/log-event.sh" "$AGENT_DIR" recovery \
       "Orphaned lock detected (no holder PID), forcing cleanup"
-    # Close and reopen to clear the orphaned flock
+    # Close our fd, delete the file (unlinking the old inode that holds
+    # the orphaned flock), then create a fresh file on a new inode.
     exec 200>&-
-    sleep 1
+    rm -f "$AGENT_LOCK_FILE"
     exec 200>"$AGENT_LOCK_FILE"
     if ! flock -n 200; then
       step "lock still held after orphan cleanup — skipping"


### PR DESCRIPTION
## Summary

- Replace close-reopen strategy with delete-and-recreate for orphaned flock recovery
- Linux flock locks are held on the kernel inode — closing/reopening the same file still targets the same inode with the orphaned lock
- Adding `rm -f` between close and reopen unlinks the old inode, and the `>` redirect creates a fresh file on a new inode with no lock

## Test plan

- [ ] Verify 242 existing tests still pass
- [ ] Confirm orphan recovery works: simulate orphaned lock, verify agent recovers on next wake

Refs #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)