### PR TITLE
Add Sandcat setup documentation and create-settings script

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ You should see JSON status from the first and `<!DOCTYPE html>` from the second.
 
 Once verified, the old `scripts/portal-server.js` can be removed. It is no longer needed.
 
+## Secrets Isolation
+
+For production deployments, agents can run behind a Sandcat proxy that keeps real credentials out of the agent container. See [`sandcat/README.md`](sandcat/README.md) for setup instructions.
+
 ## Updating
 
 To update the portal, pull the latest code in the workspace:

--- a/sandcat/README.md
+++ b/sandcat/README.md
@@ -14,7 +14,7 @@ Sandcat runs each agent in a three-container Docker Compose stack so the agent n
 From your agent repo directory (the one containing `agent.yaml`):
 
 ```bash
-bash ../agent-portal/sandcat/scripts/create-settings.sh .
+bash /path/to/agent-portal/sandcat/scripts/create-settings.sh .
 ```
 
 This creates `~/sandcat-secrets/<agent-name>/settings.json` with a template. If the agent has a `.env` file, tokens and API keys are placed in the secrets section and git identity vars are carried over to the env section.
@@ -24,7 +24,7 @@ Edit the file and replace placeholder values with real credentials.
 ### 2. Launch the stack
 
 ```bash
-bash ../agent-portal/scripts/docker-compose-create.sh .
+bash /path/to/agent-portal/scripts/docker-compose-create.sh .
 ```
 
 This generates a Docker Compose stack at `~/sandcat-stacks/<agent-name>/`, builds the containers, installs dependencies, and starts everything.

--- a/sandcat/README.md
+++ b/sandcat/README.md
@@ -1,0 +1,129 @@
+# Sandcat Secrets Isolation
+
+Sandcat runs each agent in a three-container Docker Compose stack so the agent never holds real credentials. A mitmproxy sidecar holds secrets and substitutes placeholder values at the network layer, scoped to allowed destination hosts. A WireGuard tunnel with an iptables kill switch ensures all traffic goes through the proxy.
+
+## Prerequisites
+
+- Docker and Docker Compose v2.20+
+- An agent repo with `agent.yaml` (see `agent.yaml.example` in the framework root)
+
+## Quick Start
+
+### 1. Create the settings file
+
+```bash
+bash sandcat/scripts/create-settings.sh /path/to/agent-repo
+```
+
+This creates `~/sandcat-secrets/<agent-name>/settings.json` with a template. If the agent has a `.env` file, tokens and API keys are placed in the secrets section and git identity vars are carried over to the env section.
+
+Edit the file and replace placeholder values with real credentials.
+
+### 2. Launch the stack
+
+```bash
+bash scripts/docker-compose-create.sh /path/to/agent-repo
+```
+
+This generates a Docker Compose stack at `~/sandcat-stacks/<agent-name>/`, builds the containers, installs dependencies, and starts everything.
+
+### 3. Authenticate Claude
+
+```bash
+docker compose -f ~/sandcat-stacks/<agent-name>/docker-compose.yml \
+  exec agent bash -c 'source ~/.nvm/nvm.sh && claude'
+```
+
+## settings.json Reference
+
+The settings file lives on the host at `~/sandcat-secrets/<agent-name>/settings.json`. It is mounted read-only into the mitmproxy container and never into the agent container.
+
+```json
+{
+  "env": {
+    "GIT_AUTHOR_NAME": "my-agent",
+    "GIT_AUTHOR_EMAIL": "my-agent@example.com",
+    "GIT_COMMITTER_NAME": "my-agent",
+    "GIT_COMMITTER_EMAIL": "my-agent@example.com"
+  },
+  "secrets": {
+    "GH_TOKEN": {
+      "value": "ghp_real_token_here",
+      "hosts": ["github.com", "*.github.com"]
+    }
+  },
+  "network": [
+    {"action": "allow", "host": "github.com"},
+    {"action": "allow", "host": "*.github.com"},
+    {"action": "allow", "host": "*.anthropic.com"},
+    {"action": "allow", "host": "*.claude.ai"},
+    {"action": "allow", "host": "*", "method": "GET"}
+  ]
+}
+```
+
+### env
+
+Non-secret environment variables passed through to the agent as-is. Git identity is not a secret — it is public in every commit.
+
+### secrets
+
+Each key is an env var name. `value` is the real credential. `hosts` is a list of glob patterns for destination hosts that may receive this credential. The agent sees `SANDCAT_PLACEHOLDER_<NAME>` instead of the real value.
+
+### network
+
+Outbound HTTP/S firewall rules. Evaluated top-to-bottom, first match wins, default deny. `host` supports glob patterns. Optional `method` field restricts to a specific HTTP method. The `GET *` rule lets the agent read any website while restricting writes to explicitly allowed hosts.
+
+## Verification
+
+After launching, verify the setup from inside the agent container:
+
+```bash
+COMPOSE="docker compose -f ~/sandcat-stacks/<agent-name>/docker-compose.yml"
+
+# All three containers healthy
+$COMPOSE ps
+
+# Env var is a placeholder, not a real token
+$COMPOSE exec agent bash -c 'source /etc/profile.d/sandcat-env.sh && echo $GH_TOKEN'
+# Expected: SANDCAT_PLACEHOLDER_GH_TOKEN
+
+# GitHub auth works through the proxy
+$COMPOSE exec agent bash -c 'source /etc/profile.d/sandcat-env.sh && source ~/.nvm/nvm.sh && gh auth status'
+
+# Leak detection blocks secrets to unauthorized hosts
+$COMPOSE exec agent bash -c 'source /etc/profile.d/sandcat-env.sh && curl -s -H "Authorization: token $GH_TOKEN" https://httpbin.org/headers'
+# Expected: 403 Blocked
+
+# Portal accessible
+curl -s http://localhost:<agent-port>/api/status | head -c 200
+```
+
+## Credential Rotation
+
+1. Edit `~/sandcat-secrets/<agent-name>/settings.json` with the new value
+2. Restart mitmproxy: `docker compose -f ~/sandcat-stacks/<agent-name>/docker-compose.yml restart mitmproxy`
+3. The agent container does not need a restart — it still has the same placeholder and mitmproxy now substitutes the new value
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| `gh auth status` fails | GH_TOKEN not in secrets, or github.com not in hosts | Check settings.json |
+| `curl` to external site returns 403 | Host not in network rules | Add host to network rules, restart mitmproxy |
+| Agent container won't start | wg-client not healthy | Check `docker compose logs wg-client` |
+| Portal not accessible | Port exposed on wg-client, not agent | Check compose file port mapping |
+| `git push` fails | github.com not in GH_TOKEN hosts | Fix settings.json, restart mitmproxy |
+| npm install fails | registry.npmjs.org not allowed | Add `*.npmjs.org` to network rules or rely on the GET * rule |
+| Claude auth fails | *.anthropic.com not in network rules | Add to network rules |
+
+## Rollback
+
+To return to the single-container setup:
+
+```bash
+# Stop the Sandcat stack
+docker compose -f ~/sandcat-stacks/<agent-name>/docker-compose.yml down
+
+# Restore the .env file and use the pre-Sandcat docker-create.sh from git history
+```

--- a/sandcat/README.md
+++ b/sandcat/README.md
@@ -14,7 +14,7 @@ Sandcat runs each agent in a three-container Docker Compose stack so the agent n
 From your agent repo directory (the one containing `agent.yaml`):
 
 ```bash
-bash /path/to/agent-portal/sandcat/scripts/create-settings.sh .
+bash ../agent-portal/sandcat/scripts/create-settings.sh .
 ```
 
 This creates `~/sandcat-secrets/<agent-name>/settings.json` with a template. If the agent has a `.env` file, tokens and API keys are placed in the secrets section and git identity vars are carried over to the env section.
@@ -24,7 +24,7 @@ Edit the file and replace placeholder values with real credentials.
 ### 2. Launch the stack
 
 ```bash
-bash /path/to/agent-portal/scripts/docker-compose-create.sh .
+bash ../agent-portal/scripts/docker-compose-create.sh .
 ```
 
 This generates a Docker Compose stack at `~/sandcat-stacks/<agent-name>/`, builds the containers, installs dependencies, and starts everything.

--- a/sandcat/README.md
+++ b/sandcat/README.md
@@ -11,8 +11,10 @@ Sandcat runs each agent in a three-container Docker Compose stack so the agent n
 
 ### 1. Create the settings file
 
+From your agent repo directory (the one containing `agent.yaml`):
+
 ```bash
-bash sandcat/scripts/create-settings.sh /path/to/agent-repo
+bash /path/to/agent-portal/sandcat/scripts/create-settings.sh .
 ```
 
 This creates `~/sandcat-secrets/<agent-name>/settings.json` with a template. If the agent has a `.env` file, tokens and API keys are placed in the secrets section and git identity vars are carried over to the env section.
@@ -22,7 +24,7 @@ Edit the file and replace placeholder values with real credentials.
 ### 2. Launch the stack
 
 ```bash
-bash scripts/docker-compose-create.sh /path/to/agent-repo
+bash /path/to/agent-portal/scripts/docker-compose-create.sh .
 ```
 
 This generates a Docker Compose stack at `~/sandcat-stacks/<agent-name>/`, builds the containers, installs dependencies, and starts everything.

--- a/sandcat/scripts/create-settings.sh
+++ b/sandcat/scripts/create-settings.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+#
+# sandcat/scripts/create-settings.sh — Create a template settings.json for
+# Sandcat secrets isolation.
+#
+# Usage: create-settings.sh <agent-dir>
+#
+# Reads agent.yaml to determine the agent name, then creates
+# ~/sandcat-secrets/<agent-name>/settings.json with a template that you
+# fill in with real secret values.
+#
+# If the agent directory contains a .env file, secret-shaped variables
+# (tokens, API keys) are placed in the secrets section and non-secret
+# variables (git identity, config flags) go in the env section.
+#
+set -e
+
+AGENT_DIR="${1:?Usage: create-settings.sh <agent-dir>}"
+AGENT_DIR="$(cd "$AGENT_DIR" && pwd)"
+
+if [ ! -f "$AGENT_DIR/agent.yaml" ]; then
+    echo "ERROR: No agent.yaml found in $AGENT_DIR" >&2
+    exit 1
+fi
+
+# ── Read agent name from agent.yaml ──────────────────────────────────────
+_yaml_value() {
+    grep "^${1}:" "$AGENT_DIR/agent.yaml" \
+        | sed 's/^[^:]*:[[:space:]]*//' \
+        | sed "s/[[:space:]]*#.*//" \
+        | sed "s/^[\"']//" \
+        | sed "s/[\"']$//" \
+        | sed 's/[[:space:]]*$//'
+}
+
+AGENT_NAME=$(_yaml_value name)
+
+if [ -z "$AGENT_NAME" ]; then
+    echo "ERROR: Could not read 'name' from $AGENT_DIR/agent.yaml" >&2
+    exit 1
+fi
+
+SETTINGS_DIR="$HOME/sandcat-secrets/$AGENT_NAME"
+SETTINGS_FILE="$SETTINGS_DIR/settings.json"
+
+if [ -f "$SETTINGS_FILE" ]; then
+    echo "ERROR: $SETTINGS_FILE already exists." >&2
+    echo "  Remove it first if you want to regenerate." >&2
+    exit 1
+fi
+
+# ── Parse .env if it exists ──────────────────────────────────────────────
+ENV_VARS=""      # JSON object entries for "env" section
+SECRET_VARS=""   # JSON object entries for "secrets" section
+SECRETS_TO_FILL=()
+
+_json_escape() {
+    printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+_is_secret_name() {
+    case "$1" in
+        *_TOKEN|*_KEY|*_SECRET|*_PASSWORD) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+_default_hosts() {
+    case "$1" in
+        GH_TOKEN)       echo '["github.com", "*.github.com"]' ;;
+        GEMINI_API_KEY) echo '["*.googleapis.com", "generativelanguage.googleapis.com"]' ;;
+        *)              echo '[]' ;;
+    esac
+}
+
+_is_git_identity() {
+    case "$1" in
+        GIT_AUTHOR_NAME|GIT_AUTHOR_EMAIL|GIT_COMMITTER_NAME|GIT_COMMITTER_EMAIL) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+ENV_FILE="$AGENT_DIR/.env"
+if [ -f "$ENV_FILE" ]; then
+    echo "Found $ENV_FILE — extracting variables..."
+    echo ""
+
+    while IFS= read -r line; do
+        # Skip comments and blank lines
+        case "$line" in
+            \#*|"") continue ;;
+        esac
+
+        key="${line%%=*}"
+        value="${line#*=}"
+        # Strip surrounding quotes from value
+        value=$(echo "$value" | sed "s/^[\"']//" | sed "s/[\"']$//")
+
+        if _is_secret_name "$key"; then
+            hosts=$(_default_hosts "$key")
+            if [ -n "$SECRET_VARS" ]; then SECRET_VARS="$SECRET_VARS,"; fi
+            SECRET_VARS="$SECRET_VARS
+    \"$key\": {
+      \"value\": \"<paste $key value from .env>\",
+      \"hosts\": $hosts
+    }"
+            SECRETS_TO_FILL+=("$key")
+        else
+            escaped=$(_json_escape "$value")
+            if [ -n "$ENV_VARS" ]; then ENV_VARS="$ENV_VARS,"; fi
+            ENV_VARS="$ENV_VARS
+    \"$key\": \"$escaped\""
+        fi
+    done < "$ENV_FILE"
+else
+    echo "No .env file found — writing generic template."
+    echo ""
+
+    ENV_VARS='
+    "GIT_AUTHOR_NAME": "<your-git-username>",
+    "GIT_AUTHOR_EMAIL": "<your-git-email>",
+    "GIT_COMMITTER_NAME": "<your-git-username>",
+    "GIT_COMMITTER_EMAIL": "<your-git-email>"'
+
+    SECRET_VARS='
+    "GH_TOKEN": {
+      "value": "<paste your GitHub token here>",
+      "hosts": ["github.com", "*.github.com"]
+    }'
+    SECRETS_TO_FILL+=("GH_TOKEN")
+fi
+
+# ── Write settings.json ─────────────────────────────────────────────────
+mkdir -p "$SETTINGS_DIR"
+chmod 700 "$SETTINGS_DIR"
+
+cat > "$SETTINGS_FILE" << JSONEOF
+{
+  "env": {$ENV_VARS
+  },
+  "secrets": {$SECRET_VARS
+  },
+  "network": [
+    {"action": "allow", "host": "github.com"},
+    {"action": "allow", "host": "*.github.com"},
+    {"action": "allow", "host": "*.anthropic.com"},
+    {"action": "allow", "host": "*.claude.ai"},
+    {"action": "allow", "host": "*", "method": "GET"}
+  ]
+}
+JSONEOF
+
+chmod 600 "$SETTINGS_FILE"
+
+# ── Summary ──────────────────────────────────────────────────────────────
+echo "Created $SETTINGS_FILE"
+echo ""
+
+if [ ${#SECRETS_TO_FILL[@]} -gt 0 ]; then
+    echo "NEXT: Edit the file and replace placeholder values for:"
+    for s in "${SECRETS_TO_FILL[@]}"; do
+        echo "  - $s"
+    done
+    echo ""
+fi
+
+echo "  If your agent needs additional secrets (API keys, tokens), add them"
+echo "  to the \"secrets\" section with their allowed hosts."
+echo ""
+echo "  If your agent needs to POST/PUT to hosts beyond github.com, add"
+echo "  rules to the \"network\" section. GET requests to any host are"
+echo "  allowed by default."
+echo ""
+echo "Then run the stack:"
+echo "  bash scripts/docker-compose-create.sh $AGENT_DIR"


### PR DESCRIPTION
## Summary

- **`sandcat/README.md`**: Setup guide covering quick start (create settings → launch stack → authenticate), settings.json reference (env/secrets/network sections), verification checklist, credential rotation, troubleshooting table, and rollback
- **`sandcat/scripts/create-settings.sh`**: Scaffolds `~/sandcat-secrets/<agent>/settings.json` from `agent.yaml`. If the agent has a `.env`, it extracts token-shaped vars into the secrets section (with placeholder values and pre-populated hosts) and git identity vars into the env section. Refuses to overwrite existing settings, sets 700/600 permissions
- **`README.md`**: One-liner pointing to `sandcat/README.md`

## Test plan

- [x] `create-settings.sh` with agent dir that has `.env` → secrets extracted, git identity in env section
- [x] `create-settings.sh` without `.env` → generic template with GH_TOKEN example
- [x] Re-running refuses to overwrite
- [x] Directory permissions 700, file permissions 600
- [ ] Review sandcat/README.md reads clearly end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)