### PR TITLE
feat: collapsible completed todos with reverse order

### DIFF
--- a/lib/ui/tabs/todos.js
+++ b/lib/ui/tabs/todos.js
@@ -35,11 +35,17 @@ async function loadTodos() {
           + '</div>';
       });
 
-      // Done todos
+      // Completed todos — collapsible, starts collapsed, reverse order (newest first)
       if (doneTodos.length > 0) {
+        var collapsed = localStorage.getItem('todosCompletedCollapsed') !== 'false';
         html += '<div class="todo-done-section">';
-        html += '<div style="color:#999;font-size:12px;padding:8px 0;border-top:1px solid #eee;margin-top:8px">Completed</div>';
-        doneTodos.forEach(function(t) {
+        html += '<div class="todo-done-header" onclick="toggleCompletedSection()" style="color:#999;font-size:12px;padding:8px 0;border-top:1px solid #eee;margin-top:8px;cursor:pointer;user-select:none;display:flex;align-items:center;gap:6px">'
+          + '<span class="todo-collapse-arrow" style="font-size:10px;transition:transform 0.2s;display:inline-block;transform:rotate(' + (collapsed ? '0' : '90') + 'deg)">\\u25b6</span>'
+          + 'Completed (' + doneTodos.length + ')'
+          + '</div>';
+        html += '<div id="completed-todos" style="' + (collapsed ? 'display:none' : '') + '">';
+        var reversedDone = doneTodos.slice().reverse();
+        reversedDone.forEach(function(t) {
           var idx = todos.indexOf(t);
           html += '<div class="todo-item todo-completed">'
             + '<label class="todo-checkbox">'
@@ -49,7 +55,7 @@ async function loadTodos() {
             + '<button class="todo-delete" onclick="deleteTodo(' + idx + ')" title="Delete">\\u00d7</button>'
             + '</div>';
         });
-        html += '</div>';
+        html += '</div></div>';
       }
     }
 
@@ -134,6 +140,20 @@ async function deleteTodo(index) {
     });
   } catch {}
   await loadTodos();
+}
+
+function toggleCompletedSection() {
+  var el = document.getElementById('completed-todos');
+  var arrow = document.querySelector('.todo-collapse-arrow');
+  if (el.style.display === 'none') {
+    el.style.display = '';
+    arrow.style.transform = 'rotate(90deg)';
+    localStorage.setItem('todosCompletedCollapsed', 'false');
+  } else {
+    el.style.display = 'none';
+    arrow.style.transform = 'rotate(0deg)';
+    localStorage.setItem('todosCompletedCollapsed', 'true');
+  }
 }
 
 async function addTodoNote() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Refs #106

- Completed todos section is now collapsible with a triangle arrow, starts collapsed by default
- Collapse state persists via localStorage across page loads
- Completed todos displayed in reverse chronological order (newest completed at top)
- Open todos remain in chronological order (oldest at top)
- Shows completed count in header: "Completed (N)"
- Version bump to 1.4.9

242 tests pass.