### PR TITLE
feat: expandable todo details with info badge

### DIFF
--- a/lib/routes/todos.js
+++ b/lib/routes/todos.js
@@ -42,7 +42,11 @@ function parseTodos(content) {
         todos.push({
           text: match[2].trim(),
           done: match[1] !== ' ',
+          details: '',
         });
+      } else if (todos.length > 0 && line.match(/^\s+> /) && !line.match(/^- \[/)) {
+        // Details line (indented blockquote) — append to details
+        todos[todos.length - 1].details += (todos[todos.length - 1].details ? '\n' : '') + line.replace(/^\s+> /, '');
       } else if (todos.length > 0 && line.match(/^\s+\S/) && !line.match(/^- \[/)) {
         // Continuation line (indented, not a new checkbox) — append to previous todo
         todos[todos.length - 1].text += '\n' + line.trimStart();
@@ -75,6 +79,12 @@ function serializeTodos(todos, notes) {
     md += `- [${t.done ? 'x' : ' '}] ${lines[0]}\n`;
     for (let i = 1; i < lines.length; i++) {
       md += `  ${lines[i]}\n`;
+    }
+    if (t.details) {
+      const detailLines = t.details.split('\n');
+      for (const dl of detailLines) {
+        md += `  > ${dl}\n`;
+      }
     }
   }
   md += '\n## Notes\n\n';
@@ -115,7 +125,7 @@ function register(routes, config) {
 
       const content = readTodosFile();
       const { todos, notes } = parseTodos(content);
-      todos.push({ text: body.text.trim(), done: false });
+      todos.push({ text: body.text.trim(), done: false, details: (body.details || '').trim() });
       fs.writeFileSync(todosFile, serializeTodos(todos, notes));
       sendJSON(res, 200, { ok: true });
     } catch (err) {
@@ -139,6 +149,9 @@ function register(routes, config) {
       }
       if (typeof body.text === 'string' && body.text.trim()) {
         todos[body.index].text = body.text.trim();
+      }
+      if (typeof body.details === 'string') {
+        todos[body.index].details = body.details.trim();
       }
 
       fs.writeFileSync(todosFile, serializeTodos(todos, notes));

--- a/lib/ui/styles.js
+++ b/lib/ui/styles.js
@@ -173,20 +173,30 @@ ${authorCSS}
   .md-content th, .md-content td { border: 1px solid #ddd; padding: 8px 12px; text-align: left; }
   .md-content th { background: #f5f5f5; }
 
-  /* Todo items — clear association between checkbox and text */
+  /* Todo items */
   .todo-item { display: flex; align-items: flex-start; gap: 8px; padding: 6px 0; border-bottom: 1px solid #f0f0f0; }
   .todo-item:last-child { border-bottom: none; }
-  .todo-checkbox { display: flex; align-items: flex-start; gap: 8px; flex: 1; cursor: pointer; margin: 0; }
-  .todo-checkbox input[type="checkbox"] { flex-shrink: 0; margin-top: 3px; width: 16px; height: 16px; cursor: pointer; }
+  .todo-cb { flex-shrink: 0; margin-top: 3px; width: 16px; height: 16px; cursor: pointer; }
+  .todo-body { flex: 1; cursor: default; display: flex; align-items: baseline; gap: 6px; }
+  .todo-body[onclick] { cursor: pointer; }
   .todo-text { flex: 1; font-size: 14px; line-height: 1.5; }
+  .todo-info-badge { display: inline-flex; align-items: center; justify-content: center; width: 16px; height: 16px; border-radius: 50%; background: #1a73e8; color: #fff; font-size: 10px; font-weight: 700; font-style: italic; flex-shrink: 0; cursor: pointer; }
+  .todo-edit { flex-shrink: 0; background: none; border: none; color: #ccc; font-size: 14px; cursor: pointer; padding: 0 2px; line-height: 1; }
+  .todo-edit:hover { color: #1a73e8; }
   .todo-delete { flex-shrink: 0; background: none; border: none; color: #ccc; font-size: 18px; cursor: pointer; padding: 0 4px; line-height: 1; }
   .todo-delete:hover { color: #e53e3e; }
   .todo-completed .todo-text { text-decoration: line-through; color: #999; }
+  .todo-details { margin: 0 0 8px 24px; padding: 8px 12px; background: #f8f9fa; border-left: 3px solid #1a73e8; border-radius: 0 6px 6px 0; font-size: 14px; line-height: 1.6; }
 
-  /* Todo text markdown — compact rendering inside checkboxes */
+  /* Todo text markdown — compact rendering */
   .todo-text.md-content p { margin: 0; }
   .todo-text.md-content ul, .todo-text.md-content ol { margin: 0 0 4px 16px; }
   .todo-text.md-content > p + p { margin-top: 4px; }
+
+  /* Todo edit modal */
+  .todo-edit-overlay { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.3); z-index: 100; display: flex; align-items: center; justify-content: center; }
+  .todo-edit-modal { background: #fff; border-radius: 8px; padding: 16px 20px; width: 90%; max-width: 500px; box-shadow: 0 4px 16px rgba(0,0,0,0.15); }
+  .todo-edit-modal h3 { font-size: 15px; color: #444; margin-bottom: 10px; }
 
   /* Tabs hidden (running log mode) — hide tab buttons but keep menu btn */
   #tabs.tabs-hidden .tab { display: none; }

--- a/lib/ui/tabs/todos.js
+++ b/lib/ui/tabs/todos.js
@@ -26,13 +26,20 @@ async function loadTodos() {
       // Open todos first
       openTodos.forEach(function(t) {
         var idx = todos.indexOf(t);
+        var hasDetails = t.details && t.details.trim();
         html += '<div class="todo-item">'
-          + '<label class="todo-checkbox">'
-          + '<input type="checkbox" onchange="toggleTodo(' + idx + ', this.checked)">'
+          + '<input type="checkbox" class="todo-cb" onchange="toggleTodo(' + idx + ', this.checked)">'
+          + '<div class="todo-body" ' + (hasDetails ? 'onclick="toggleDetails(' + idx + ')"' : '') + '>'
           + '<span class="todo-text md-content">' + marked.parse(t.text).trim() + '</span>'
-          + '</label>'
+          + (hasDetails ? ' <span class="todo-info-badge" title="Has additional info">i</span>' : '')
+          + '</div>'
+          + '<button class="todo-edit" onclick="editTodoDetails(' + idx + ')" title="Edit details">\\u270e</button>'
           + '<button class="todo-delete" onclick="deleteTodo(' + idx + ')" title="Delete">\\u00d7</button>'
           + '</div>';
+        if (hasDetails) {
+          html += '<div class="todo-details md-content" id="todo-details-' + idx + '" style="display:none">'
+            + marked.parse(t.details) + '</div>';
+        }
       });
 
       // Completed todos — collapsible, starts collapsed, reverse order (newest first)
@@ -47,13 +54,19 @@ async function loadTodos() {
         var reversedDone = doneTodos.slice().reverse();
         reversedDone.forEach(function(t) {
           var idx = todos.indexOf(t);
+          var hasDetails = t.details && t.details.trim();
           html += '<div class="todo-item todo-completed">'
-            + '<label class="todo-checkbox">'
-            + '<input type="checkbox" checked onchange="toggleTodo(' + idx + ', this.checked)">'
+            + '<input type="checkbox" class="todo-cb" checked onchange="toggleTodo(' + idx + ', this.checked)">'
+            + '<div class="todo-body" ' + (hasDetails ? 'onclick="toggleDetails(' + idx + ')"' : '') + '>'
             + '<span class="todo-text md-content">' + marked.parse(t.text).trim() + '</span>'
-            + '</label>'
+            + (hasDetails ? ' <span class="todo-info-badge" title="Has additional info">i</span>' : '')
+            + '</div>'
             + '<button class="todo-delete" onclick="deleteTodo(' + idx + ')" title="Delete">\\u00d7</button>'
             + '</div>';
+          if (hasDetails) {
+            html += '<div class="todo-details md-content" id="todo-details-' + idx + '" style="display:none">'
+              + marked.parse(t.details) + '</div>';
+          }
         });
         html += '</div></div>';
       }
@@ -139,6 +152,49 @@ async function deleteTodo(index) {
       body: JSON.stringify({ index: index })
     });
   } catch {}
+  await loadTodos();
+}
+
+function toggleDetails(idx) {
+  var el = document.getElementById('todo-details-' + idx);
+  if (!el) return;
+  el.style.display = el.style.display === 'none' ? '' : 'none';
+}
+
+function editTodoDetails(idx) {
+  var overlay = document.createElement('div');
+  overlay.className = 'todo-edit-overlay';
+  overlay.onclick = function(e) { if (e.target === overlay) overlay.remove(); };
+  var modal = document.createElement('div');
+  modal.className = 'todo-edit-modal';
+  modal.innerHTML = '<h3>Edit Details</h3>'
+    + '<textarea id="edit-details-text" placeholder="Additional information (supports markdown, lists, code blocks...)" style="width:100%;min-height:120px;border:1px solid #ddd;border-radius:6px;padding:8px;font-family:inherit;font-size:14px;resize:vertical;box-sizing:border-box"></textarea>'
+    + '<div style="display:flex;gap:8px;margin-top:8px;justify-content:flex-end">'
+    + '<button onclick="this.closest(\\'.todo-edit-overlay\\').remove()" style="padding:6px 16px;background:#fff;color:#555;border:1px solid #ddd;border-radius:6px;cursor:pointer;font-size:13px">Cancel</button>'
+    + '<button onclick="saveTodoDetails(' + idx + ')" style="padding:6px 16px;background:#1a73e8;color:#fff;border:none;border-radius:6px;cursor:pointer;font-size:13px">Save</button>'
+    + '</div>';
+  overlay.appendChild(modal);
+  document.body.appendChild(overlay);
+  // Load current details
+  fetch('/api/todos').then(function(r) { return r.json(); }).then(function(data) {
+    var ta = document.getElementById('edit-details-text');
+    if (ta && data.todos[idx]) ta.value = data.todos[idx].details || '';
+    if (ta) ta.focus();
+  });
+}
+
+async function saveTodoDetails(idx) {
+  var ta = document.getElementById('edit-details-text');
+  if (!ta) return;
+  try {
+    await fetch('/api/todos', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ index: idx, details: ta.value })
+    });
+  } catch {}
+  var overlay = ta.closest('.todo-edit-overlay');
+  if (overlay) overlay.remove();
   await loadTodos();
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/test/todos.test.js
+++ b/test/todos.test.js
@@ -26,9 +26,9 @@ describe('parseTodos', () => {
 `;
     const { todos } = parseTodos(content);
     assert.equal(todos.length, 3);
-    assert.deepEqual(todos[0], { text: 'Buy milk', done: false });
-    assert.deepEqual(todos[1], { text: 'Write tests', done: true });
-    assert.deepEqual(todos[2], { text: 'Deploy', done: false });
+    assert.deepEqual(todos[0], { text: 'Buy milk', done: false, details: '' });
+    assert.deepEqual(todos[1], { text: 'Write tests', done: true, details: '' });
+    assert.deepEqual(todos[2], { text: 'Deploy', done: false, details: '' });
   });
 
   it('parses notes section', () => {
@@ -84,6 +84,54 @@ Agent response.
     const parsed = parseTodos(md);
     assert.equal(parsed.todos[0].text, 'Multi line\nwith detail');
     assert.equal(parsed.todos[1].text, 'Simple');
+  });
+  it('parses todos with details (blockquote lines)', () => {
+    const content = `## Todos
+
+- [ ] Email mcpserverfinder.com
+  > Copy the following text:
+  > Hello, we would like to list agentdeals.
+  > - bullet one
+  > - bullet two
+- [ ] Simple todo
+
+## Notes
+`;
+    const { todos } = parseTodos(content);
+    assert.equal(todos.length, 2);
+    assert.equal(todos[0].text, 'Email mcpserverfinder.com');
+    assert.equal(todos[0].details, 'Copy the following text:\nHello, we would like to list agentdeals.\n- bullet one\n- bullet two');
+    assert.equal(todos[1].text, 'Simple todo');
+    assert.equal(todos[1].details, '');
+  });
+
+  it('round-trips todos with details', () => {
+    const todos = [
+      { text: 'Todo with info', done: false, details: 'Line 1\nLine 2\n- bullet' },
+      { text: 'No info', done: true, details: '' },
+    ];
+    const md = serializeTodos(todos, []);
+    assert.ok(md.includes('  > Line 1'));
+    assert.ok(md.includes('  > Line 2'));
+    assert.ok(md.includes('  > - bullet'));
+    const parsed = parseTodos(md);
+    assert.equal(parsed.todos[0].details, 'Line 1\nLine 2\n- bullet');
+    assert.equal(parsed.todos[1].details, '');
+  });
+
+  it('parses todos with both continuation text and details', () => {
+    const content = `## Todos
+
+- [ ] Multi line todo
+  continued here
+  > Detail info
+  > More detail
+
+## Notes
+`;
+    const { todos } = parseTodos(content);
+    assert.equal(todos[0].text, 'Multi line todo\ncontinued here');
+    assert.equal(todos[0].details, 'Detail info\nMore detail');
   });
 });
 
@@ -251,6 +299,35 @@ describe('Todos API', () => {
       body: JSON.stringify({ index: 99, done: true }),
     });
     assert.equal(status, 400);
+  });
+
+  it('POST /api/todos with details', async () => {
+    await fetchJSON(port, '/api/todos', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: 'With details', details: 'Extra info here' }),
+    });
+
+    const { data } = await fetchJSON(port, '/api/todos');
+    assert.equal(data.todos[0].text, 'With details');
+    assert.equal(data.todos[0].details, 'Extra info here');
+  });
+
+  it('PUT /api/todos updates details', async () => {
+    await fetchJSON(port, '/api/todos', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: 'Update me' }),
+    });
+
+    await fetchJSON(port, '/api/todos', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ index: 0, details: 'New details\n- with bullets' }),
+    });
+
+    const { data } = await fetchJSON(port, '/api/todos');
+    assert.equal(data.todos[0].details, 'New details\n- with bullets');
   });
 
   it('does not register routes when todos not in tabs', () => {


### PR DESCRIPTION
## Summary
- Todos now support expandable additional information (details field)
- Blue "i" badge indicates a todo has additional info — click the todo text or badge to expand/collapse
- Edit pencil icon opens a modal for adding/editing details with markdown support
- Clicking text no longer toggles the checkbox — only the checkbox itself toggles done state
- Details stored as indented blockquote (`> `) lines in the markdown file
- 5 new tests (247 total), bumped to v1.4.12

## Test plan
- [x] Unit tests: parse todos with details, round-trip details, continuation + details combo
- [x] Integration tests: POST with details, PUT to update details
- [x] Full test suite: 247/247 pass

Refs #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)