### PR TITLE
Fix sandcat README to use sibling directory paths

### DIFF
--- a/sandcat/README.md
+++ b/sandcat/README.md
@@ -11,10 +11,10 @@ Sandcat runs each agent in a three-container Docker Compose stack so the agent n
 
 ### 1. Create the settings file
 
-From your agent repo directory (the one containing `agent.yaml`):
+From your agent repo directory (the one containing `agent.yaml`), with agent-portal cloned as a sibling directory:
 
 ```bash
-bash /path/to/agent-portal/sandcat/scripts/create-settings.sh .
+bash ../agent-portal/sandcat/scripts/create-settings.sh .
 ```
 
 This creates `~/sandcat-secrets/<agent-name>/settings.json` with a template. If the agent has a `.env` file, tokens and API keys are placed in the secrets section and git identity vars are carried over to the env section.
@@ -24,7 +24,7 @@ Edit the file and replace placeholder values with real credentials.
 ### 2. Launch the stack
 
 ```bash
-bash /path/to/agent-portal/scripts/docker-compose-create.sh .
+bash ../agent-portal/scripts/docker-compose-create.sh .
 ```
 
 This generates a Docker Compose stack at `~/sandcat-stacks/<agent-name>/`, builds the containers, installs dependencies, and starts everything.


### PR DESCRIPTION
## Summary

- Replace placeholder `/path/to/agent-portal/` with `../agent-portal/` in sandcat README so commands are copy-pastable
- Assumes agent-portal is cloned as a sibling directory to the agent repo

This is a stopgap — longer term the scripts should be copied into agent repos so users don't need to clone agent-portal on the host at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)