### PR TITLE
Default sandcat network rules to allow-all

### DIFF
--- a/sandcat/README.md
+++ b/sandcat/README.md
@@ -55,11 +55,7 @@ The settings file lives on the host at `~/sandcat-secrets/<agent-name>/settings.
     }
   },
   "network": [
-    {"action": "allow", "host": "github.com"},
-    {"action": "allow", "host": "*.github.com"},
-    {"action": "allow", "host": "*.anthropic.com"},
-    {"action": "allow", "host": "*.claude.ai"},
-    {"action": "allow", "host": "*", "method": "GET"}
+    {"action": "allow", "host": "*"}
   ]
 }
 ```
@@ -74,7 +70,7 @@ Each key is an env var name. `value` is the real credential. `hosts` is a list o
 
 ### network
 
-Outbound HTTP/S firewall rules. Evaluated top-to-bottom, first match wins, default deny. `host` supports glob patterns. Optional `method` field restricts to a specific HTTP method. The `GET *` rule lets the agent read any website while restricting writes to explicitly allowed hosts.
+Outbound HTTP/S firewall rules. Evaluated top-to-bottom, first match wins, default deny. `host` supports glob patterns. Optional `method` field restricts to a specific HTTP method. The default `allow *` rule permits all outbound traffic — secrets are still protected by the per-secret `hosts` scoping. Replace with specific host rules to restrict network access.
 
 ## Verification
 

--- a/sandcat/scripts/create-settings.sh
+++ b/sandcat/scripts/create-settings.sh
@@ -141,11 +141,7 @@ cat > "$SETTINGS_FILE" << JSONEOF
   "secrets": {$SECRET_VARS
   },
   "network": [
-    {"action": "allow", "host": "github.com"},
-    {"action": "allow", "host": "*.github.com"},
-    {"action": "allow", "host": "*.anthropic.com"},
-    {"action": "allow", "host": "*.claude.ai"},
-    {"action": "allow", "host": "*", "method": "GET"}
+    {"action": "allow", "host": "*"}
   ]
 }
 JSONEOF
@@ -167,9 +163,8 @@ fi
 echo "  If your agent needs additional secrets (API keys, tokens), add them"
 echo "  to the \"secrets\" section with their allowed hosts."
 echo ""
-echo "  If your agent needs to POST/PUT to hosts beyond github.com, add"
-echo "  rules to the \"network\" section. GET requests to any host are"
-echo "  allowed by default."
+echo "  Network rules default to allow-all. To restrict outbound access,"
+echo "  replace the wildcard rule with specific host allowlists."
 echo ""
 echo "Then run the stack:"
 echo "  bash scripts/docker-compose-create.sh $AGENT_DIR"


### PR DESCRIPTION
## Summary

- Change default network rules from restrictive (allow GitHub + Anthropic + GET-only) to `allow *`
- Agents should not lose any network capability when migrating to Sandcat
- Secret scoping (tokens only sent to allowed hosts) is enforced by the per-secret `hosts` field, independent of network rules
- Update README and create-settings.sh summary output to match

## Test plan

- [ ] Run `create-settings.sh` with a `.env` file — network section should be `[{"action": "allow", "host": "*"}]`
- [ ] Run `create-settings.sh` without a `.env` file — same
- [ ] Verify secret host scoping still works (token only substituted for matching hosts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)