### PR TITLE
Fix apt-get hanging on tzdata prompt during compose setup

### DIFF
--- a/scripts/docker-compose-create.sh
+++ b/scripts/docker-compose-create.sh
@@ -225,8 +225,9 @@ COMPOSE="docker compose -f $STACK_DIR/docker-compose.yml"
 echo ""
 echo "Installing system packages..."
 $COMPOSE exec -T agent bash -c \
-    "apt-get update -qq && apt-get install -y -qq curl jq git cron ca-certificates > /dev/null 2>&1 \
-     && update-ca-certificates 2>/dev/null"
+    "DEBIAN_FRONTEND=noninteractive apt-get update -qq && \
+     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq curl jq git cron ca-certificates > /dev/null 2>&1 && \
+     update-ca-certificates 2>/dev/null"
 
 echo "Running vm-setup.sh..."
 $COMPOSE exec -T agent bash -c \


### PR DESCRIPTION
## Summary

- `docker-compose-create.sh` hangs during "Installing system packages..." because `dpkg` configuring `tzdata` prompts for timezone input interactively
- Fix: set `DEBIAN_FRONTEND=noninteractive` on the `apt-get` commands
- Note: PR #118 (`docker-create.sh`) will need the same fix when it lands

## Test plan

- [ ] Run `docker-compose-create.sh` — package install completes without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)