### PR TITLE
Source sandcat CA cert in docker exec setup steps

### DIFF
--- a/scripts/docker-compose-create.sh
+++ b/scripts/docker-compose-create.sh
@@ -231,13 +231,14 @@ $COMPOSE exec -T agent bash -c \
 
 echo "Running vm-setup.sh..."
 $COMPOSE exec -T agent bash -c \
-    "source /etc/profile.d/sandcat-env.sh 2>/dev/null; \
+    "for f in /etc/profile.d/sandcat-*.sh; do [ -r \"\$f\" ] && source \"\$f\"; done; \
      cd $CONTAINER_AGENT_DIR && \
      bash $CONTAINER_FRAMEWORK_DIR/scripts/vm-setup.sh"
 
 echo "Installing framework dependencies..."
 $COMPOSE exec -T agent bash -c \
-    "source ~/.nvm/nvm.sh && \
+    "for f in /etc/profile.d/sandcat-*.sh; do [ -r \"\$f\" ] && source \"\$f\"; done; \
+     source ~/.nvm/nvm.sh && \
      cd $CONTAINER_FRAMEWORK_DIR && \
      npm install --production"
 


### PR DESCRIPTION
## Summary

- `npm install` during setup fails with `UNABLE_TO_VERIFY_LEAF_SIGNATURE` because `docker exec` doesn't inherit the entrypoint's `NODE_EXTRA_CA_CERTS` environment variable
- `app-init.sh` sets `NODE_EXTRA_CA_CERTS` and writes it to `/etc/profile.d/sandcat-node-ca.sh`, but `docker exec` starts a separate process tree
- Fix: source all `/etc/profile.d/sandcat-*.sh` scripts before running `vm-setup.sh` and `npm install`

## Test plan

- [ ] Run `docker-compose-create.sh` — `npm install -g @anthropic-ai/claude-code` succeeds without cert errors
- [ ] Framework `npm install --production` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)