### PR TITLE
Add NODE_EXTRA_CA_CERTS to agent container environment

### DIFF
--- a/scripts/docker-compose-create.sh
+++ b/scripts/docker-compose-create.sh
@@ -168,6 +168,7 @@ services:
     entrypoint: ["bash", "$CONTAINER_FRAMEWORK_DIR/sandcat/scripts/app-init.sh", "$CONTAINER_AGENT_DIR"]
     environment:
       - CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
+      - NODE_EXTRA_CA_CERTS=/sandcat-certs/mitmproxy-ca-cert.pem
     restart: unless-stopped
     depends_on:
       wg-client:


### PR DESCRIPTION
## Summary

- Claude fails with `UNABLE_TO_VERIFY_LEAF_SIGNATURE` when launched via `docker exec` because the mitmproxy CA cert isn't trusted
- `app-init.sh` sets `NODE_EXTRA_CA_CERTS` in the entrypoint process and writes it to `/etc/bash.bashrc`, but `docker exec ... bash -c '...'` is non-interactive and doesn't source bashrc
- Fix: add `NODE_EXTRA_CA_CERTS=/sandcat-certs/mitmproxy-ca-cert.pem` to the agent service's `environment` in the generated compose file
- Container-level env vars are inherited by all `docker exec` commands, making the cert available everywhere

## Test plan

- [ ] Rebuild stack: `docker compose down && docker-compose-create.sh .`
- [ ] `docker exec ... bash -c 'source ~/.nvm/nvm.sh && claude'` — connects without cert errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)