### PR TITLE
Fix web portal unreachable through Docker port forwarding

### DIFF
--- a/sandcat/scripts/wg-client-init.sh
+++ b/sandcat/scripts/wg-client-init.sh
@@ -78,6 +78,20 @@ ip -6 route add ::/0 dev wg0 table 51820
 ip -6 rule add not fwmark 51820 table 51820
 ip -6 rule add table main suppress_prefixlength 0
 
+# ── Route Docker port-forwarded responses back via eth0 ───────────────────
+# Docker port mapping forwards host TCP connections to eth0, but the policy
+# routing above sends ALL outbound traffic through wg0 — including response
+# packets. This breaks inbound connections (e.g. the web portal). Use
+# connmark to track inbound TCP connections on eth0 and route their
+# responses through the main table (which goes via eth0).
+# Scoped to TCP to avoid interfering with WireGuard's UDP fwmark (51820).
+iptables -t mangle -A INPUT -i eth0 -p tcp -m conntrack --ctstate NEW -j CONNMARK --set-mark 0x1
+iptables -t mangle -A OUTPUT -p tcp -m connmark --mark 0x1 -j MARK --set-mark 0x1
+ip -4 rule add fwmark 0x1 table main priority 100
+ip6tables -t mangle -A INPUT -i eth0 -p tcp -m conntrack --ctstate NEW -j CONNMARK --set-mark 0x1
+ip6tables -t mangle -A OUTPUT -p tcp -m connmark --mark 0x1 -j MARK --set-mark 0x1
+ip -6 rule add fwmark 0x1 table main priority 100
+
 # ── Override DNS ──────────────────────────────────────────────────────────
 # Docker's embedded DNS at 127.0.0.11 resolves queries on the host,
 # bypassing the WireGuard tunnel. Point resolv.conf at an external


### PR DESCRIPTION
## Summary

- The web portal listens on 8081 inside the agent container (confirmed via `curl localhost:8081` from within the container) but is unreachable from the host
- Root cause: wg-client's policy routing sends ALL non-WireGuard outbound traffic through wg0, including TCP response packets for Docker port-forwarded connections — the response goes into the WireGuard tunnel instead of back out eth0
- The existing `suppress_prefixlength 0` rule doesn't help when the port-forwarded connection's source IP is outside the Docker network subnet (e.g. Docker Desktop for Mac)
- Fix: use connmark to track inbound TCP connections on eth0 and add a high-priority ip rule to route their responses through the main table (eth0). Scoped to TCP to avoid interfering with WireGuard's UDP fwmark

## Test plan

- [ ] Rebuild stack: `docker compose down && docker-compose-create.sh .`
- [ ] `curl http://localhost:8081/api/status` from host — returns JSON
- [ ] Web portal accessible in browser
- [ ] Outbound HTTPS still goes through the tunnel (verify with `gh auth status` inside container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)