### PR TITLE
Make .env optional and source sandcat profile in cron context

### DIFF
--- a/scripts/commit.sh
+++ b/scripts/commit.sh
@@ -10,7 +10,12 @@ MSG="${2:-agent state update}"
 
 cd "$AGENT_DIR"
 
-# Source .env if GH_TOKEN not already set (cron doesn't inherit Docker env vars)
+# Source sandcat profile scripts if available (cron doesn't inherit container env)
+for _f in /etc/profile.d/sandcat-*.sh; do
+  [ -r "$_f" ] && . "$_f"
+done
+
+# Source .env if GH_TOKEN still not set (pre-Sandcat fallback)
 if [ -z "$GH_TOKEN" ] && [ -f "$AGENT_DIR/.env" ]; then
   set -a; . "$AGENT_DIR/.env"; set +a
 fi

--- a/scripts/cron-setup.sh
+++ b/scripts/cron-setup.sh
@@ -14,11 +14,13 @@ cd "$AGENT_DIR"
 # Read agent config
 eval "$(node "$FRAMEWORK_DIR/scripts/read-config.js" "$AGENT_DIR/agent.yaml")"
 
-# nvm sourcing prefix so claude is on PATH in cron
-NVM_SOURCE='export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" &&'
+# Environment sourcing prefix for cron jobs:
+# - Sandcat profile scripts (env vars + NODE_EXTRA_CA_CERTS)
+# - nvm so claude/node are on PATH
+CRON_ENV='for f in /etc/profile.d/sandcat-*.sh; do [ -r "$f" ] && . "$f"; done; export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" &&'
 
 # Main wake entry from agent.yaml
-WAKE_LINE="${AGENT_CRON_SCHEDULE} root ${NVM_SOURCE} cd ${AGENT_DIR} && bash ${FRAMEWORK_DIR}/scripts/wake.sh ${AGENT_DIR} >> logs/cycles/cron-wake.log 2>&1"
+WAKE_LINE="${AGENT_CRON_SCHEDULE} root ${CRON_ENV} cd ${AGENT_DIR} && bash ${FRAMEWORK_DIR}/scripts/wake.sh ${AGENT_DIR} >> logs/cycles/cron-wake.log 2>&1"
 
 # Build all cron lines
 CRON_LINES="$WAKE_LINE"
@@ -31,7 +33,7 @@ if [ "$EXTRA_CRON_COUNT" -gt 0 ] 2>/dev/null; then
     log_var="EXTRA_CRON_${i}_LOG"
     schedule="${!sched_var}"; command="${!cmd_var}"; logfile="${!log_var}"
 
-    EXTRA_LINE="${schedule} root ${NVM_SOURCE} cd ${AGENT_DIR} && ${command} >> ${logfile} 2>&1"
+    EXTRA_LINE="${schedule} root ${CRON_ENV} cd ${AGENT_DIR} && ${command} >> ${logfile} 2>&1"
     CRON_LINES="$CRON_LINES
 $EXTRA_LINE"
   done

--- a/scripts/wake.sh
+++ b/scripts/wake.sh
@@ -24,12 +24,18 @@ step() {
 
 step "wake.sh started (framework=$FRAMEWORK_DIR, agent=$AGENT_DIR)"
 
-# Source .env for GH_TOKEN, Telegram tokens, git identity
+# Source sandcat profile scripts if available (Sandcat containers inject
+# env vars via /etc/profile.d/ but cron doesn't inherit them)
+for _f in /etc/profile.d/sandcat-*.sh; do
+  [ -r "$_f" ] && . "$_f"
+done
+
+# Source .env if present (pre-Sandcat containers use .env for secrets)
 if [ -f "$AGENT_DIR/.env" ]; then
   set -a; . "$AGENT_DIR/.env"; set +a
   step ".env sourced (GH_TOKEN=${GH_TOKEN:+set}${GH_TOKEN:-MISSING})"
 else
-  step ".env not found at $AGENT_DIR/.env"
+  step ".env not found at $AGENT_DIR/.env (skipping — using container environment)"
 fi
 
 # Read agent config


### PR DESCRIPTION
## Summary

Cron jobs don't inherit container environment variables. In Sandcat containers, env vars (GH_TOKEN placeholder, NODE_EXTRA_CA_CERTS, git identity) are set by `app-init.sh` via `/etc/profile.d/sandcat-*.sh`, but cron starts with a fresh environment. This caused the agent-pm 23:00 UTC cycle on March 16 to fail — no GH_TOKEN, workspace clones failed, Claude exited with code 1.

- **`wake.sh`**: Source sandcat profile scripts before `.env`; update log message when `.env` is missing to clarify it's non-fatal
- **`commit.sh`**: Same sandcat profile sourcing before `.env` fallback (fixes silent push skip due to missing GH_TOKEN)
- **`cron-setup.sh`**: Include sandcat profile sourcing in cron entry prefix alongside nvm sourcing

## Test plan

- [ ] Remove `.env` from a Sandcat agent container, run `bash wake.sh` manually — cycle completes using container env
- [ ] Cron-triggered cycle works without `.env` on disk
- [ ] Pre-Sandcat containers with `.env` still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)