### PR TITLE
Add step-logged git push after commit in wake.sh

### DIFF
--- a/scripts/wake.sh
+++ b/scripts/wake.sh
@@ -282,10 +282,23 @@ rm -f "$CYCLE_FAILED_MARKER"
 node "$FRAMEWORK_DIR/scripts/read-config.js" "$AGENT_DIR/agent.yaml" \
   --set "framework-last-known-good=$FRAMEWORK_COMMIT"
 
-# Git commit
+# Git commit and push
 step "commit starting"
 bash "$FRAMEWORK_DIR/scripts/commit.sh" "$AGENT_DIR" "autonomous cycle" 200>&-
 step "commit done"
+
+# Push (commit.sh pushes too, but log it explicitly for visibility)
+if [ -n "$GH_TOKEN" ] && [ -n "$AGENT_REPO" ]; then
+  step "push starting"
+  if git -C "$AGENT_DIR" push "https://${GH_TOKEN}@github.com/${AGENT_REPO}.git" \
+       "$(git -C "$AGENT_DIR" branch --show-current)" 200>&- 2>&1; then
+    step "push done"
+  else
+    step "push failed (non-fatal)"
+  fi
+else
+  step "push skipped (GH_TOKEN=${GH_TOKEN:+set}${GH_TOKEN:-MISSING}, AGENT_REPO=${AGENT_REPO:-MISSING})"
+fi
 
 # Explicit lock release (trap will also fire, but be explicit)
 flock -u 200 2>/dev/null


### PR DESCRIPTION
## Summary

- `commit.sh` already pushes after committing, but its output is invisible in `wake-steps.log` — the step log only shows `commit starting` / `commit done`
- Add an explicit push step in wake.sh with step logging: `push starting` / `push done` / `push failed (non-fatal)` / `push skipped`
- Push failure is non-fatal — network blips shouldn't break the cycle
- Uses `AGENT_REPO` from agent.yaml and `GH_TOKEN` for auth (works with both real tokens and Sandcat placeholders via mitmproxy)

Note: depends on PR #123 for sandcat profile sourcing so GH_TOKEN is available in cron context.

## Test plan

- [ ] Run a manual cycle — `push starting` / `push done` appear in wake-steps.log
- [ ] Commit appears on GitHub after cycle
- [ ] Push failure logs `push failed (non-fatal)` without breaking the cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)