### PR TITLE
Fix secret substitution in Basic auth headers

### DIFF
--- a/sandcat/scripts/mitmproxy_addon.py
+++ b/sandcat/scripts/mitmproxy_addon.py
@@ -13,6 +13,7 @@ Network rules are evaluated top-to-bottom, first match wins, default deny.
 Secret placeholders are replaced with real values only for allowed hosts.
 """
 
+import base64
 import json
 import logging
 import os
@@ -141,6 +142,25 @@ class SandcatAddon:
                 )
             )
 
+            # Also check inside Base64-encoded Basic auth headers.
+            # Tools like git encode credentials as Basic base64(user:pass),
+            # hiding the placeholder from a raw byte scan.
+            basic_auth_match = False
+            if not present:
+                for k, v in flow.request.headers.fields:
+                    if k.lower() != b"authorization":
+                        continue
+                    if not v.startswith(b"Basic "):
+                        continue
+                    try:
+                        decoded = base64.b64decode(v[6:]).decode("utf-8", errors="replace")
+                    except Exception:
+                        continue
+                    if placeholder in decoded:
+                        present = True
+                        basic_auth_match = True
+                        break
+
             if not present:
                 continue
 
@@ -162,10 +182,27 @@ class SandcatAddon:
                 flow.request.url = flow.request.url.replace(placeholder, value)
             # Use .fields (raw byte tuples) to preserve multi-valued headers.
             # headers[k] = v would collapse duplicate header names.
-            flow.request.headers.fields = tuple(
-                (k, v.replace(placeholder_bytes, value_bytes)) if placeholder_bytes in v else (k, v)
-                for k, v in flow.request.headers.fields
-            )
+            if basic_auth_match:
+                # Decode Basic auth, substitute placeholder, re-encode.
+                def _sub_basic(k: bytes, v: bytes) -> tuple[bytes, bytes]:
+                    if k.lower() != b"authorization" or not v.startswith(b"Basic "):
+                        return (k, v)
+                    try:
+                        decoded = base64.b64decode(v[6:])
+                        if placeholder_bytes not in decoded:
+                            return (k, v)
+                        replaced = decoded.replace(placeholder_bytes, value_bytes)
+                        return (k, b"Basic " + base64.b64encode(replaced))
+                    except Exception:
+                        return (k, v)
+                flow.request.headers.fields = tuple(
+                    _sub_basic(k, v) for k, v in flow.request.headers.fields
+                )
+            else:
+                flow.request.headers.fields = tuple(
+                    (k, v.replace(placeholder_bytes, value_bytes)) if placeholder_bytes in v else (k, v)
+                    for k, v in flow.request.headers.fields
+                )
             if flow.request.content and placeholder_bytes in flow.request.content:
                 flow.request.content = flow.request.content.replace(
                     placeholder_bytes, value_bytes


### PR DESCRIPTION
## Summary

- Git encodes credentials as `Basic base64(user:pass)` when pushing over HTTPS. The placeholder token (e.g. `SANDCAT_PLACEHOLDER_GH_TOKEN`) gets base64-encoded inside the `Authorization` header, so the addon's raw byte scan for the literal placeholder string never finds it.
- This causes `git push`, `git clone`, and `git pull` (for private repos) to send the literal placeholder to GitHub, which rejects it with "Invalid username or token."
- Tools that send tokens as plaintext headers (like `gh` CLI using `Authorization: token <placeholder>`) are unaffected — this only impacts Basic auth.

## Fix

In `_substitute_secrets`, after the existing raw scan finds no match, also check `Authorization: Basic ...` headers by base64-decoding them. If a placeholder is found inside:
1. Decode the Basic auth value
2. Replace the placeholder with the real secret
3. Re-encode to base64

## Verification

After merging and restarting the mitmproxy container:

```bash
# Should succeed (previously failed with "Invalid username or token")
docker compose -f ~/sandcat-stacks/agent-pm/docker-compose.yml exec agent bash -c \
  'for f in /etc/profile.d/sandcat-*.sh; do source "$f"; done && \
   cd /root/agent-pm && \
   git push "https://${GH_TOKEN}@github.com/robhunter/agent-pm.git" main --dry-run 2>&1'
```

Also verify that non-Basic-auth substitution still works:
```bash
# Should still work (plaintext token in header)
docker compose -f ~/sandcat-stacks/agent-pm/docker-compose.yml exec agent bash -c \
  'for f in /etc/profile.d/sandcat-*.sh; do source "$f"; done && \
   curl -s -H "Authorization: Bearer ${GH_TOKEN}" https://api.github.com/user | head -3'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)