### PR TITLE
Fix mobile UX, feedback badge refresh, and init load time (v1.4.13)

### DIFF
--- a/lib/ui/client-core.js
+++ b/lib/ui/client-core.js
@@ -67,6 +67,21 @@ function formatUptime(seconds) {
   return h + 'h ' + m + 'm';
 }
 
+// --- Jump to top ---
+(function() {
+  var btn = document.getElementById('jump-top-btn');
+  var content = document.getElementById('content');
+  if (btn && content) {
+    content.addEventListener('scroll', function() {
+      btn.style.opacity = content.scrollTop > 200 ? '1' : '0';
+      btn.style.pointerEvents = content.scrollTop > 200 ? 'auto' : 'none';
+    }, { passive: true });
+    btn.style.opacity = '0';
+    btn.style.pointerEvents = 'none';
+    btn.style.transition = 'opacity 0.2s';
+  }
+})();
+
 // --- Status dot ---
 async function updateStatusDot() {
   try {

--- a/lib/ui/shell.js
+++ b/lib/ui/shell.js
@@ -174,8 +174,7 @@ function buildHTML(config) {
   let initJS;
   if (sidebarType === 'projects') {
     initJS = `async function init() {
-  await loadProjects();
-  await Promise.all([loadNextRun(), updateStatusDot(), updateClaudeStatus()]);
+  await Promise.all([loadProjects(), loadNextRun(), updateStatusDot(), updateClaudeStatus()]);
   const params = new URLSearchParams(window.location.search);
   if (params.get('project') || params.get('view')) {
     await initFromURL();
@@ -230,6 +229,8 @@ ${getStyles(authors)}
 ${sidebarHTML}
 
 <div id="sidebar-overlay" onclick="closeSidebar()"></div>
+
+<button id="jump-top-btn" onclick="document.getElementById('content').scrollTop=0" aria-label="Jump to top">&#8679;</button>
 
 <div id="main">
   <div id="tabs">

--- a/lib/ui/styles.js
+++ b/lib/ui/styles.js
@@ -15,7 +15,7 @@ function getStyles(authors) {
 
   return `
   * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #f5f5f5; color: #222; display: flex; height: 100vh; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #f5f5f5; color: #222; display: flex; height: 100vh; height: 100dvh; }
 
   /* Sidebar */
   #sidebar { width: 280px; min-width: 280px; background: #fff; border-right: 1px solid #ddd; display: flex; flex-direction: column; }
@@ -205,15 +205,19 @@ ${authorCSS}
   #menu-btn { display: none; background: none; border: none; font-size: 22px; cursor: pointer; color: #444; padding: 8px 12px; line-height: 1; }
   #sidebar-overlay { display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.3); z-index: 9; }
 
+  /* Jump-to-top button (mobile only) */
+  #jump-top-btn { display: none; position: fixed; bottom: 20px; right: 16px; z-index: 50; width: 40px; height: 40px; border-radius: 50%; background: #1a73e8; color: #fff; border: none; font-size: 18px; cursor: pointer; box-shadow: 0 2px 8px rgba(0,0,0,0.25); align-items: center; justify-content: center; line-height: 1; }
+  #jump-top-btn:active { background: #1557b0; }
+
   /* Mobile responsive */
   @media (max-width: 768px) {
-    #sidebar { position: fixed; top: 0; left: -280px; height: 100vh; z-index: 10; transition: left 0.2s ease; box-shadow: none; }
+    #sidebar { position: fixed; top: 0; left: -280px; height: 100vh; height: 100dvh; z-index: 10; transition: left 0.2s ease; box-shadow: none; }
     #sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.15); }
     #sidebar-overlay.open { display: block; }
     #menu-btn { display: block; }
-    #tabs { padding: 0 8px; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+    #tabs { padding: 0 8px; overflow-x: auto; -webkit-overflow-scrolling: touch; position: sticky; top: 0; }
     .tab { padding: 10px 14px; font-size: 13px; white-space: nowrap; }
-    #content { padding: 16px; }
+    #content { padding: 16px; padding-bottom: 72px; }
     .journal-entry { padding: 10px 12px; }
     .journal-entry-header { font-size: 12px; gap: 6px; }
     .gh-item { flex-wrap: wrap; gap: 6px; padding: 8px 12px; }
@@ -223,6 +227,7 @@ ${authorCSS}
     #add-note-form .form-row { flex-wrap: wrap; }
     .edit-entry-form .form-row { flex-wrap: wrap; }
     #sidebar h1 { padding: 16px 16px 8px; }
+    #jump-top-btn { display: flex; }
   }
 `;
 }

--- a/lib/ui/tabs/outputs.js
+++ b/lib/ui/tabs/outputs.js
@@ -143,6 +143,8 @@ async function submitFeedback(filename, rating) {
     }
     loadFeedback(filename);
     if (notesEl) notesEl.value = '';
+    // Refresh project list so unreviewed badges update immediately
+    if (typeof loadProjects === 'function') loadProjects();
     alert('Feedback submitted!');
   } catch(e) { alert('Failed to submit feedback: ' + e.message); }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- **#126**: After submitting feedback on an output, the project list now immediately refreshes so unreviewed badge counts are accurate without requiring a page reload
- **#127**: Added a jump-to-top button on mobile — fixed bottom-right, appears after scrolling 200px, fades in/out, single click returns to top of content
- **#128**: Fixed mobile nav bar issues — `100dvh` for dynamic viewport height (resolves iOS Safari toolbar interaction), tabs are now `position: sticky` so they stay visible while scrolling, added bottom padding so content scrolls fully past the feedback section
- **#129**: Parallelized `loadProjects()` with `loadNextRun()`, `updateStatusDot()`, and `updateClaudeStatus()` in the projects sidebar init — reduces perceived load time by running all startup fetches concurrently instead of serially

## Test plan
- [ ] 247 tests pass (`node --test test/*.test.js`)
- [ ] Submit feedback on an output → sidebar badge count updates without refresh
- [ ] On mobile, scroll down in a long output → jump-to-top button appears → tap it → scrolls to top
- [ ] On mobile, scroll to bottom of output with feedback panel → feedback is fully visible
- [ ] On mobile, scroll up after scrolling down → tabs remain visible
- [ ] Portal loads visibly faster on first open (projects sidebar variant)

Refs #126
Refs #127
Refs #128
Refs #129