### PR TITLE
feat: session continuation for Telegram respond cycles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/scripts/telegram-respond.sh
+++ b/scripts/telegram-respond.sh
@@ -57,11 +57,55 @@ CRITICAL: Your ENTIRE output will be sent directly as a Telegram message. Do NOT
 
 If the message implies actions (reprioritize, new project, dig deeper on something), do them using tools, then confirm what you did in your response."
 
+# Session continuation: reuse session if last human message was within 24 hours
+SESSION_FILE="logs/telegram_session_id"
+SESSION_ARGS=""
+
+PREV_HUMAN_TS=$(grep '"role":"human"' logs/conversation.jsonl | tail -2 | head -1 | jq -r '.ts // ""')
+if [ -n "$PREV_HUMAN_TS" ] && [ -f "$SESSION_FILE" ]; then
+  PREV_EPOCH=$(date -d "$PREV_HUMAN_TS" +%s 2>/dev/null || echo 0)
+  NOW_EPOCH=$(date +%s)
+  AGE=$((NOW_EPOCH - PREV_EPOCH))
+  SAVED_SESSION=$(cat "$SESSION_FILE")
+  if [ "$AGE" -lt 86400 ] && [ "$AGE" -ge 0 ] && [ -n "$SAVED_SESSION" ]; then
+    SESSION_ARGS="--resume $SAVED_SESSION"
+    echo "Continuing session $SAVED_SESSION (last message ${AGE}s ago)"
+  fi
+fi
+
+# Start a new session if not continuing
+if [ -z "$SESSION_ARGS" ]; then
+  NEW_SESSION=$(cat /proc/sys/kernel/random/uuid)
+  SESSION_ARGS="--session-id $NEW_SESSION"
+  echo "$NEW_SESSION" > "$SESSION_FILE"
+  echo "Starting new session $NEW_SESSION"
+fi
+
+run_claude() {
+  echo "$FULL_PROMPT" | claude --print \
+    "$@" \
+    --allowedTools "Edit" "Write" "Read" "Bash(grep:*)" "Bash(jq:*)" "Bash(cat:*)" "Bash(head:*)" "Bash(tail:*)" "Bash(wc:*)" "Bash(date:*)" "Bash(git:*)" \
+    2>>logs/respond_errors.log
+}
+
 set +e
-RESPONSE=$(echo "$FULL_PROMPT" | claude --print \
-  --allowedTools "Edit" "Write" "Read" "Bash(grep:*)" "Bash(jq:*)" "Bash(cat:*)" "Bash(head:*)" "Bash(tail:*)" "Bash(wc:*)" "Bash(date:*)" "Bash(git:*)" \
-  2>>logs/respond_errors.log)
-CLAUDE_EXIT=$?
+if echo "$SESSION_ARGS" | grep -q -- '--resume'; then
+  SAVED_SESSION=$(echo "$SESSION_ARGS" | awk '{print $2}')
+  RESPONSE=$(run_claude --resume "$SAVED_SESSION")
+  CLAUDE_EXIT=$?
+  # Fallback: if --resume failed, start a fresh session
+  if [ "$CLAUDE_EXIT" -ne 0 ]; then
+    echo "Resume failed (exit $CLAUDE_EXIT), starting fresh session"
+    NEW_SESSION=$(cat /proc/sys/kernel/random/uuid)
+    echo "$NEW_SESSION" > "$SESSION_FILE"
+    RESPONSE=$(run_claude --session-id "$NEW_SESSION")
+    CLAUDE_EXIT=$?
+  fi
+else
+  NEW_SESSION=$(echo "$SESSION_ARGS" | awk '{print $2}')
+  RESPONSE=$(run_claude --session-id "$NEW_SESSION")
+  CLAUDE_EXIT=$?
+fi
 set -e
 
 if [ "$CLAUDE_EXIT" -ne 0 ]; then

--- a/test/telegram-session.test.sh
+++ b/test/telegram-session.test.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# Test session continuation logic in telegram-respond.sh
+# Tests the decision logic for --resume vs --session-id without calling claude
+set -e
+
+PASS=0
+FAIL=0
+TESTS=0
+
+assert_eq() {
+  TESTS=$((TESTS + 1))
+  if [ "$1" = "$2" ]; then
+    PASS=$((PASS + 1))
+    echo "  ok - $3"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL - $3 (expected '$1', got '$2')"
+  fi
+}
+
+assert_contains() {
+  TESTS=$((TESTS + 1))
+  if echo "$2" | grep -qF -- "$1"; then
+    PASS=$((PASS + 1))
+    echo "  ok - $3"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL - $3 (expected '$2' to contain '$1')"
+  fi
+}
+
+echo "# telegram session continuation tests"
+
+# Setup temp dir
+TMPDIR=$(mktemp -d)
+mkdir -p "$TMPDIR/logs"
+touch "$TMPDIR/logs/conversation.jsonl"
+
+# --- Test 1: No previous messages → new session ---
+echo "## Test 1: First message starts new session"
+SESSION_FILE="$TMPDIR/logs/telegram_session_id"
+SESSION_ARGS=""
+
+PREV_HUMAN_TS=$(grep '"role":"human"' "$TMPDIR/logs/conversation.jsonl" | tail -2 | head -1 | jq -r '.ts // ""' 2>/dev/null || echo "")
+if [ -n "$PREV_HUMAN_TS" ] && [ -f "$SESSION_FILE" ]; then
+  SESSION_ARGS="--resume test"
+fi
+if [ -z "$SESSION_ARGS" ]; then
+  SESSION_ARGS="--session-id new"
+fi
+assert_contains "--session-id" "$SESSION_ARGS" "new session when no history"
+
+# --- Test 2: Recent message (5 min ago) + session file → resume ---
+echo "## Test 2: Recent message continues session"
+FIVE_MIN_AGO=$(date -d "5 minutes ago" -Iseconds)
+echo "{\"ts\":\"$FIVE_MIN_AGO\",\"role\":\"human\",\"text\":\"hello\"}" > "$TMPDIR/logs/conversation.jsonl"
+echo "{\"ts\":\"$FIVE_MIN_AGO\",\"role\":\"agent\",\"text\":\"hi\"}" >> "$TMPDIR/logs/conversation.jsonl"
+echo "{\"ts\":\"$(date -Iseconds)\",\"role\":\"human\",\"text\":\"how are you\"}" >> "$TMPDIR/logs/conversation.jsonl"
+echo "test-session-id-123" > "$SESSION_FILE"
+
+SESSION_ARGS=""
+PREV_HUMAN_TS=$(grep '"role":"human"' "$TMPDIR/logs/conversation.jsonl" | tail -2 | head -1 | jq -r '.ts // ""')
+if [ -n "$PREV_HUMAN_TS" ] && [ -f "$SESSION_FILE" ]; then
+  PREV_EPOCH=$(date -d "$PREV_HUMAN_TS" +%s 2>/dev/null || echo 0)
+  NOW_EPOCH=$(date +%s)
+  AGE=$((NOW_EPOCH - PREV_EPOCH))
+  SAVED_SESSION=$(cat "$SESSION_FILE")
+  if [ "$AGE" -lt 86400 ] && [ "$AGE" -ge 0 ] && [ -n "$SAVED_SESSION" ]; then
+    SESSION_ARGS="--resume $SAVED_SESSION"
+  fi
+fi
+if [ -z "$SESSION_ARGS" ]; then
+  SESSION_ARGS="--session-id new"
+fi
+assert_contains "--resume" "$SESSION_ARGS" "resumes when last message is recent"
+assert_contains "test-session-id-123" "$SESSION_ARGS" "uses saved session ID"
+
+# --- Test 3: Old message (25 hours ago) → new session ---
+echo "## Test 3: Old message starts new session"
+OLD_TS=$(date -d "25 hours ago" -Iseconds)
+echo "{\"ts\":\"$OLD_TS\",\"role\":\"human\",\"text\":\"hello\"}" > "$TMPDIR/logs/conversation.jsonl"
+echo "{\"ts\":\"$(date -Iseconds)\",\"role\":\"human\",\"text\":\"hi again\"}" >> "$TMPDIR/logs/conversation.jsonl"
+
+SESSION_ARGS=""
+PREV_HUMAN_TS=$(grep '"role":"human"' "$TMPDIR/logs/conversation.jsonl" | tail -2 | head -1 | jq -r '.ts // ""')
+if [ -n "$PREV_HUMAN_TS" ] && [ -f "$SESSION_FILE" ]; then
+  PREV_EPOCH=$(date -d "$PREV_HUMAN_TS" +%s 2>/dev/null || echo 0)
+  NOW_EPOCH=$(date +%s)
+  AGE=$((NOW_EPOCH - PREV_EPOCH))
+  SAVED_SESSION=$(cat "$SESSION_FILE")
+  if [ "$AGE" -lt 86400 ] && [ "$AGE" -ge 0 ] && [ -n "$SAVED_SESSION" ]; then
+    SESSION_ARGS="--resume $SAVED_SESSION"
+  fi
+fi
+if [ -z "$SESSION_ARGS" ]; then
+  SESSION_ARGS="--session-id new"
+fi
+assert_contains "--session-id" "$SESSION_ARGS" "new session when last message > 24h"
+
+# --- Test 4: Recent message but no session file → new session ---
+echo "## Test 4: Recent message but missing session file"
+RECENT_TS=$(date -d "1 minute ago" -Iseconds)
+echo "{\"ts\":\"$RECENT_TS\",\"role\":\"human\",\"text\":\"hello\"}" > "$TMPDIR/logs/conversation.jsonl"
+echo "{\"ts\":\"$(date -Iseconds)\",\"role\":\"human\",\"text\":\"again\"}" >> "$TMPDIR/logs/conversation.jsonl"
+rm -f "$SESSION_FILE"
+
+SESSION_ARGS=""
+PREV_HUMAN_TS=$(grep '"role":"human"' "$TMPDIR/logs/conversation.jsonl" | tail -2 | head -1 | jq -r '.ts // ""')
+if [ -n "$PREV_HUMAN_TS" ] && [ -f "$SESSION_FILE" ]; then
+  SESSION_ARGS="--resume test"
+fi
+if [ -z "$SESSION_ARGS" ]; then
+  SESSION_ARGS="--session-id new"
+fi
+assert_contains "--session-id" "$SESSION_ARGS" "new session when no session file"
+
+# Cleanup
+rm -rf "$TMPDIR"
+
+echo ""
+echo "# Results: $PASS/$TESTS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

- Reuses Claude sessions across Telegram messages when the previous human message was within 24 hours, reducing latency and token consumption
- Uses `--resume <session-id>` for continuation, `--session-id <uuid>` for new sessions
- Falls back to a fresh session if `--resume` fails (session expired, cleaned up, etc.)
- Session ID persisted in `logs/telegram_session_id`
- v1.4.14

Refs #132

## How it works

1. When a Telegram message arrives, check the timestamp of the *previous* human message in `conversation.jsonl`
2. If that message is < 24 hours old AND a session file exists → `--resume <saved-session-id>`
3. Otherwise → generate new UUID, `--session-id <new-uuid>`, save to file
4. If `--resume` fails (non-zero exit) → automatic fallback to fresh session

## Test plan

- [x] 5 new shell tests covering: first message, recent continuation, 24h expiry, missing session file
- [x] 247 existing Node.js tests still pass
- [x] Verified `claude --print --resume` and `claude --print --session-id` work correctly via manual testing