### PR TITLE
fix: clipboard fallback for insecure contexts

### DIFF
--- a/lib/ui/tabs/outputs.js
+++ b/lib/ui/tabs/outputs.js
@@ -12,7 +12,18 @@ let currentOutputRaw = null;
 async function copyRawOutput() {
   if (!currentOutputRaw) return;
   try {
-    await navigator.clipboard.writeText(currentOutputRaw);
+    if (navigator.clipboard && window.isSecureContext) {
+      await navigator.clipboard.writeText(currentOutputRaw);
+    } else {
+      const textarea = document.createElement('textarea');
+      textarea.value = currentOutputRaw;
+      textarea.style.position = 'fixed';
+      textarea.style.opacity = '0';
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textarea);
+    }
     const btn = document.getElementById('copy-raw-btn');
     if (btn) { btn.textContent = 'Copied!'; setTimeout(function() { btn.textContent = 'Copy Raw'; }, 2000); }
   } catch { alert('Failed to copy to clipboard'); }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.4.14",
+  "version": "1.4.15",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -292,6 +292,9 @@ describe('buildHTML', () => {
     assert.ok(html.includes('function copyRawOutput'));
     assert.ok(html.includes('copy-raw-btn'));
     assert.ok(html.includes('Copy Raw'));
+    // Clipboard API fallback for insecure contexts
+    assert.ok(html.includes('window.isSecureContext'), 'checks isSecureContext before using Clipboard API');
+    assert.ok(html.includes('document.execCommand'), 'falls back to execCommand for insecure contexts');
   });
 
   it('excludes outputs tab JS when not configured', () => {


### PR DESCRIPTION
## Summary

Adds `document.execCommand('copy')` fallback for the Copy Raw button when `navigator.clipboard` is unavailable (HTTP on local network IPs like `http://192.168.x.x:8080`).

- Checks `window.isSecureContext` before using Clipboard API
- Falls back to hidden textarea + `execCommand('copy')` for insecure contexts
- Added test assertions for fallback presence
- Bumped to v1.4.15

Refs #130