### PR TITLE
Fix secret substitution in URLs for wireguard mode

### DIFF
--- a/sandcat/scripts/create-settings.sh
+++ b/sandcat/scripts/create-settings.sh
@@ -67,9 +67,11 @@ _is_secret_name() {
 
 _default_hosts() {
     case "$1" in
-        GH_TOKEN)       echo '["github.com", "*.github.com"]' ;;
-        GEMINI_API_KEY) echo '["*.googleapis.com", "generativelanguage.googleapis.com"]' ;;
-        *)              echo '[]' ;;
+        GH_TOKEN)         echo '["github.com", "*.github.com"]' ;;
+        GEMINI_API_KEY)   echo '["*.googleapis.com", "generativelanguage.googleapis.com"]' ;;
+        TELEGRAM_TOKEN)   echo '["api.telegram.org"]' ;;
+        TELEGRAM_CHAT_ID) echo '["api.telegram.org"]' ;;
+        *)                echo '[]' ;;
     esac
 }
 

--- a/sandcat/scripts/mitmproxy_addon.py
+++ b/sandcat/scripts/mitmproxy_addon.py
@@ -179,7 +179,11 @@ class SandcatAddon:
             value_bytes = value.encode()
 
             if placeholder in flow.request.url:
-                flow.request.url = flow.request.url.replace(placeholder, value)
+                # Substitute in .path (which includes query string) rather than
+                # .url to avoid the url setter triggering host= which calls
+                # _update_host_and_authority() and overwrites the Host header
+                # with the raw IP in transparent/wireguard mode.
+                flow.request.path = flow.request.path.replace(placeholder, value)
             # Use .fields (raw byte tuples) to preserve multi-valued headers.
             # headers[k] = v would collapse duplicate header names.
             if basic_auth_match:


### PR DESCRIPTION
## Summary
- In wireguard/transparent mode, `flow.request.url` contains the resolved IP (e.g. `149.154.166.110`) instead of the hostname. Setting `flow.request.url` triggers the `.host` property setter → `_update_host_and_authority()`, which overwrites the `Host` header (e.g. `api.telegram.org` → `149.154.166.110`). This caused Telegram API calls to fail with 302 redirects.
- Fix: substitute in `flow.request.path` instead of `flow.request.url` to avoid triggering the host setter. The path includes the query string, so all path-level substitutions still work.
- Added `TELEGRAM_TOKEN` and `TELEGRAM_CHAT_ID` to `create-settings.sh` default host mappings so future settings generation includes the correct allowed hosts.

## Test plan
- [x] Restarted mitmproxy container with the fix
- [x] Verified `curl https://api.telegram.org/bot${TELEGRAM_TOKEN}/getMe` returns `{"ok":true}` from inside the agent container
- [ ] Verify GH_TOKEN substitution (Basic auth path) still works after change

🤖 Generated with [Claude Code](https://claude.com/claude-code)