### PR TITLE
Add timezone config for agent timestamps

### DIFF
--- a/agent.yaml.example
+++ b/agent.yaml.example
@@ -8,6 +8,7 @@ port: 8080                           # portal server port
 lock-file: /tmp/my-agent.lock         # mutex file path
 cron-file: /etc/cron.d/my-agent      # cron file path
 cron-schedule: "0 */2 * * *"         # cron schedule expression
+timezone: America/Los_Angeles        # optional: TZ for timestamps (default: container's TZ)
 
 # Prompts — multi-line text piped to Claude on each cycle type.
 # read-config.js writes these to temp files and outputs the file path.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.4.15",
+  "version": "1.4.16",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/scripts/read-config.js
+++ b/scripts/read-config.js
@@ -64,6 +64,7 @@ const scalars = {
   AGENT_LOCK_FILE: doc['lock-file'],
   AGENT_CRON_FILE: doc['cron-file'],
   AGENT_CRON_SCHEDULE: doc['cron-schedule'],
+  AGENT_TIMEZONE: doc.timezone,
   FRAMEWORK_LAST_KNOWN_GOOD: doc['framework-last-known-good'],
 };
 

--- a/scripts/wake.sh
+++ b/scripts/wake.sh
@@ -42,6 +42,12 @@ fi
 eval "$(node "$FRAMEWORK_DIR/scripts/read-config.js" "$AGENT_DIR/agent.yaml")"
 step "config loaded (name=$AGENT_NAME)"
 
+# Set timezone if configured
+if [ -n "$AGENT_TIMEZONE" ]; then
+  export TZ="$AGENT_TIMEZONE"
+  step "timezone set to $TZ"
+fi
+
 # ── LOCK ACQUISITION ──
 
 # Stale lock timeout in seconds (default: 90 minutes)


### PR DESCRIPTION
## Summary
- New `timezone` field in agent.yaml (e.g., `timezone: America/Los_Angeles`)
- wake.sh exports `TZ` from config before any timestamps are generated
- Added to agent.yaml.example with documentation
- Bumped to v1.4.16

Agents set `timezone: America/Los_Angeles` in their agent.yaml and all journal entries, event logs, and step logs will use PST/PDT timestamps instead of UTC.

## Test plan
- [x] 247/247 tests pass
- [x] Verified `node scripts/read-config.js` outputs `AGENT_TIMEZONE` correctly
- [ ] After merge, each agent adds `timezone: America/Los_Angeles` to their agent.yaml

Refs #135