### PR TITLE
Fix journal sorting for mixed timezone offsets

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -82,7 +82,7 @@ function getAllJournalEntries(journalsDir) {
       allEntries.push(...entries);
     }
   } catch {}
-  allEntries.sort((a, b) => a.ts.localeCompare(b.ts));
+  allEntries.sort((a, b) => new Date(a.ts) - new Date(b.ts));
   return allEntries;
 }
 

--- a/lib/routes/journal.js
+++ b/lib/routes/journal.js
@@ -23,7 +23,7 @@ function register(routes, config) {
 
     // Filter entries before the cursor, then take the last `limit` entries
     let filtered = before
-      ? allEntries.filter(e => e.ts < before)
+      ? allEntries.filter(e => new Date(e.ts) < new Date(before))
       : allEntries;
     const hasMore = filtered.length > limit;
     const entries = filtered.slice(-limit);


### PR DESCRIPTION
## Summary
- Journal entries with different timezone offsets (e.g. `-07:00` PDT vs `+00:00` UTC) were sorted by raw string comparison, placing PDT entries in the wrong chronological position and hiding them from the portal view.
- Switch to `new Date()` comparison for both sorting and pagination cursor filtering.

## Test plan
- [x] 247/247 tests pass
- [ ] Restart agent container, verify PDT entries render in correct chronological order on the journal tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)