### PR TITLE
Add nav ribbon badges for outputs, requests, todos

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,7 @@ require('./lib/routes/deploy').register(routes, config);
 require('./lib/routes/claude').register(routes, config);
 require('./lib/routes/uploads').register(routes, config);
 require('./lib/routes/todos').register(routes, config);
+require('./lib/routes/badges').register(routes, config);
 
 // Build HTML page (cached — config doesn't change at runtime)
 let cachedHTML;

--- a/lib/routes/badges.js
+++ b/lib/routes/badges.js
@@ -1,0 +1,74 @@
+// routes/badges.js — Badge counts for nav tabs
+// Returns unreviewed/pending/open counts for outputs, requests, todos
+
+const fs = require('fs');
+const path = require('path');
+const { sendJSON } = require('../helpers');
+
+function register(routes, config) {
+  const agentDir = config.agentDir || '.';
+  const tabs = (config.features && config.features.tabs) || [];
+
+  routes['GET /api/badges'] = (req, res) => {
+    const badges = {};
+
+    // Outputs: count unreviewed
+    if (tabs.includes('outputs') && config.features && config.features.outputs) {
+      try {
+        const outputDir = path.join(agentDir, 'output');
+        const feedbackDir = path.join(agentDir, 'input', 'feedback');
+        const processedDir = path.join(feedbackDir, 'processed');
+        const files = fs.readdirSync(outputDir)
+          .filter(f => f.endsWith('.md') && f !== '.gitkeep');
+        let unreviewed = 0;
+        for (const f of files) {
+          const feedbackFile = f.replace('.md', '.feedback.yaml');
+          const hasFeedback = fs.existsSync(path.join(feedbackDir, feedbackFile))
+            || fs.existsSync(path.join(processedDir, feedbackFile));
+          if (!hasFeedback) unreviewed++;
+        }
+        if (unreviewed > 0) badges.outputs = unreviewed;
+      } catch {}
+    }
+
+    // Requests: count pending
+    if (tabs.includes('requests') && config.features && config.features.requests) {
+      try {
+        const requestsDir = path.join(agentDir, 'requests');
+        const files = fs.readdirSync(requestsDir)
+          .filter(f => f.endsWith('.md') && f !== '_template.md');
+        let pending = 0;
+        for (const file of files) {
+          const content = fs.readFileSync(path.join(requestsDir, file), 'utf-8');
+          const statusMatch = content.match(/\*\*Status:\*\*\s*(\w+)/);
+          if (statusMatch && statusMatch[1].toLowerCase() === 'pending') pending++;
+        }
+        if (pending > 0) badges.requests = pending;
+      } catch {}
+    }
+
+    // Todos: count open (not done)
+    if (tabs.includes('todos')) {
+      try {
+        const todosFile = path.join(agentDir, 'human_todos.md');
+        const content = fs.readFileSync(todosFile, 'utf-8');
+        const lines = content.split('\n');
+        let open = 0;
+        let inTodos = false;
+        for (const line of lines) {
+          if (/^## Todos/i.test(line)) { inTodos = true; continue; }
+          if (/^## /i.test(line) && inTodos) break;
+          if (inTodos) {
+            const match = line.match(/^- \[([ ])\] /);
+            if (match) open++;
+          }
+        }
+        if (open > 0) badges.todos = open;
+      } catch {}
+    }
+
+    sendJSON(res, 200, badges);
+  };
+}
+
+module.exports = { register };

--- a/lib/ui/client-core.js
+++ b/lib/ui/client-core.js
@@ -250,6 +250,25 @@ async function runRespond() {
   updateStatusDot();
 }
 
+// --- Tab badges ---
+async function loadBadges() {
+  try {
+    const res = await fetch('/api/badges');
+    const badges = await res.json();
+    ['outputs', 'requests', 'todos'].forEach(function(tab) {
+      const el = document.getElementById('badge-' + tab);
+      if (!el) return;
+      if (badges[tab] && badges[tab] > 0) {
+        el.textContent = badges[tab] > 99 ? '99+' : badges[tab];
+        el.classList.add('visible');
+      } else {
+        el.textContent = '';
+        el.classList.remove('visible');
+      }
+    });
+  } catch {}
+}
+
 // --- Quick stats ---
 async function loadQuickStats() {
   if (!PORTAL_CONFIG.hasGitHub) return;
@@ -290,7 +309,11 @@ function switchTab(tab) {
   history.replaceState(null, '', qs ? '?' + qs : window.location.pathname);
 
   const loader = TAB_LOADERS[tab];
-  if (loader) loader();
+  if (loader) {
+    var result = loader();
+    if (result && typeof result.then === 'function') result.then(loadBadges);
+    else loadBadges();
+  }
   else document.getElementById('content').innerHTML = '<div class="empty">Unknown tab: ' + escapeHtml(tab) + '</div>';
 }
 

--- a/lib/ui/shell.js
+++ b/lib/ui/shell.js
@@ -69,10 +69,12 @@ function buildHTML(config) {
   }
   const tabs = (config.features && config.features.tabs) || defaultTabs;
 
-  // Build tab HTML
-  const tabsHTML = tabs.map((t, i) =>
-    `<div class="tab${i === 0 ? ' active' : ''}" data-tab="${t}" onclick="switchTab('${t}')">${t.charAt(0).toUpperCase() + t.slice(1)}</div>`
-  ).join('\n    ');
+  // Build tab HTML (with badge placeholder spans for outputs, requests, todos)
+  const badgeTabs = ['outputs', 'requests', 'todos'];
+  const tabsHTML = tabs.map((t, i) => {
+    const badge = badgeTabs.includes(t) ? `<span class="tab-badge" id="badge-${t}"></span>` : '';
+    return `<div class="tab${i === 0 ? ' active' : ''}" data-tab="${t}" onclick="switchTab('${t}')">${t.charAt(0).toUpperCase() + t.slice(1)}${badge}</div>`;
+  }).join('\n    ');
 
   // Collect tab JS modules — only include JS for tabs that are enabled
   let tabJS = '';
@@ -174,7 +176,7 @@ function buildHTML(config) {
   let initJS;
   if (sidebarType === 'projects') {
     initJS = `async function init() {
-  await Promise.all([loadProjects(), loadNextRun(), updateStatusDot(), updateClaudeStatus()]);
+  await Promise.all([loadProjects(), loadNextRun(), updateStatusDot(), updateClaudeStatus(), loadBadges()]);
   const params = new URLSearchParams(window.location.search);
   if (params.get('project') || params.get('view')) {
     await initFromURL();
@@ -189,6 +191,7 @@ function buildHTML(config) {
     loadNextRun(),
     loadQuickStats(),
     updateClaudeStatus(),
+    loadBadges(),
   ]);
   // Check URL params for deep linking
   var params = new URLSearchParams(window.location.search);
@@ -255,6 +258,7 @@ init();
 setInterval(loadNextRun, 60000);
 setInterval(updateStatusDot, 10000);
 setInterval(updateClaudeStatus, 60000);
+setInterval(loadBadges, 30000);
 <\/script>
 </body>
 </html>`;

--- a/lib/ui/styles.js
+++ b/lib/ui/styles.js
@@ -39,6 +39,9 @@ function getStyles(authors) {
   .tab { padding: 12px 20px; font-size: 14px; font-weight: 500; color: #666; cursor: pointer; border-bottom: 2px solid transparent; transition: all 0.15s; }
   .tab:hover { color: #333; }
   .tab.active { color: #1a73e8; border-bottom-color: #1a73e8; }
+  .tab { position: relative; }
+  .tab-badge { display: none; min-width: 16px; height: 16px; line-height: 16px; padding: 0 5px; border-radius: 8px; background: #e53935; color: #fff; font-size: 10px; font-weight: 700; text-align: center; margin-left: 6px; vertical-align: middle; }
+  .tab-badge.visible { display: inline-block; }
 
   /* Content area */
   #content { flex: 1; overflow-y: auto; padding: 24px 32px; }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.4.16",
+  "version": "1.4.17",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/test/badges.test.js
+++ b/test/badges.test.js
@@ -1,0 +1,160 @@
+const { describe, it, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { createServer } = require('../lib/server');
+
+function createBadgeServer(tmpDir, configOverrides = {}) {
+  const config = {
+    name: 'Test',
+    port: 0,
+    agentDir: tmpDir,
+    _serverStartTime: Date.now(),
+    authors: {},
+    features: {
+      outputs: true,
+      requests: true,
+      tabs: ['journal', 'status', 'outputs', 'requests', 'todos'],
+    },
+    ...configOverrides,
+  };
+
+  const routes = {};
+  require('../lib/routes/badges').register(routes, config);
+  return { server: createServer(config, { routes, getHTML: () => '<html>test</html>' }), config };
+}
+
+async function fetchJSON(port, urlPath) {
+  const res = await fetch(`http://localhost:${port}${urlPath}`);
+  return res.json();
+}
+
+describe('GET /api/badges', () => {
+  let tmpDir, server, port;
+
+  before((_, done) => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'badges-test-'));
+    // Create directory structure
+    fs.mkdirSync(path.join(tmpDir, 'output'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, 'input', 'feedback', 'processed'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, 'requests'), { recursive: true });
+
+    const { server: s } = createBadgeServer(tmpDir);
+    server = s;
+    server.listen(0, () => {
+      port = server.address().port;
+      done();
+    });
+  });
+
+  after((_, done) => {
+    server.close(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      done();
+    });
+  });
+
+  beforeEach(() => {
+    // Clean output files
+    for (const f of fs.readdirSync(path.join(tmpDir, 'output'))) {
+      fs.unlinkSync(path.join(tmpDir, 'output', f));
+    }
+    for (const f of fs.readdirSync(path.join(tmpDir, 'requests'))) {
+      fs.unlinkSync(path.join(tmpDir, 'requests', f));
+    }
+    // Remove todos file if present
+    try { fs.unlinkSync(path.join(tmpDir, 'human_todos.md')); } catch {}
+    // Clean feedback
+    for (const f of fs.readdirSync(path.join(tmpDir, 'input', 'feedback'))) {
+      const fp = path.join(tmpDir, 'input', 'feedback', f);
+      if (fs.statSync(fp).isFile()) fs.unlinkSync(fp);
+    }
+  });
+
+  it('returns empty object when nothing is pending', async () => {
+    const data = await fetchJSON(port, '/api/badges');
+    assert.deepEqual(data, {});
+  });
+
+  it('counts unreviewed outputs', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'output', 'report1.md'), '# Report 1');
+    fs.writeFileSync(path.join(tmpDir, 'output', 'report2.md'), '# Report 2');
+    fs.writeFileSync(path.join(tmpDir, 'output', 'report3.md'), '# Report 3');
+    // Mark one as reviewed
+    fs.writeFileSync(path.join(tmpDir, 'input', 'feedback', 'report1.feedback.yaml'), 'rating: up');
+
+    const data = await fetchJSON(port, '/api/badges');
+    assert.equal(data.outputs, 2);
+  });
+
+  it('counts pending requests', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'requests', 'req1.md'), '# Request: Test\n**Status:** pending\n');
+    fs.writeFileSync(path.join(tmpDir, 'requests', 'req2.md'), '# Request: Done\n**Status:** completed\n');
+    fs.writeFileSync(path.join(tmpDir, 'requests', 'req3.md'), '# Request: Also pending\n**Status:** pending\n');
+
+    const data = await fetchJSON(port, '/api/badges');
+    assert.equal(data.requests, 2);
+  });
+
+  it('counts open todos', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'human_todos.md'),
+      '## Todos\n\n- [ ] Open 1\n- [x] Done 1\n- [ ] Open 2\n- [ ] Open 3\n\n## Notes\n');
+
+    const data = await fetchJSON(port, '/api/badges');
+    assert.equal(data.todos, 3);
+  });
+
+  it('omits tabs with zero counts', async () => {
+    // Only outputs has items, but all are reviewed
+    fs.writeFileSync(path.join(tmpDir, 'output', 'report.md'), '# Report');
+    fs.writeFileSync(path.join(tmpDir, 'input', 'feedback', 'report.feedback.yaml'), 'rating: up');
+
+    const data = await fetchJSON(port, '/api/badges');
+    assert.equal(data.outputs, undefined);
+    assert.equal(data.requests, undefined);
+    assert.equal(data.todos, undefined);
+  });
+
+  it('returns all badge counts together', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'output', 'r1.md'), '# R1');
+    fs.writeFileSync(path.join(tmpDir, 'requests', 'req1.md'), '# Req\n**Status:** pending\n');
+    fs.writeFileSync(path.join(tmpDir, 'human_todos.md'), '## Todos\n\n- [ ] Do thing\n\n## Notes\n');
+
+    const data = await fetchJSON(port, '/api/badges');
+    assert.equal(data.outputs, 1);
+    assert.equal(data.requests, 1);
+    assert.equal(data.todos, 1);
+  });
+});
+
+describe('GET /api/badges — disabled features', () => {
+  let tmpDir, server, port;
+
+  before((_, done) => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'badges-disabled-'));
+    fs.mkdirSync(path.join(tmpDir, 'output'), { recursive: true });
+
+    const { server: s } = createBadgeServer(tmpDir, {
+      features: { tabs: ['journal', 'status'] },
+    });
+    server = s;
+    server.listen(0, () => {
+      port = server.address().port;
+      done();
+    });
+  });
+
+  after((_, done) => {
+    server.close(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      done();
+    });
+  });
+
+  it('returns empty when badge tabs are not configured', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'output', 'r1.md'), '# R1');
+    const data = await fetchJSON(port, '/api/badges');
+    assert.deepEqual(data, {});
+  });
+});


### PR DESCRIPTION
## Summary

Refs #138

- New `/api/badges` endpoint returns counts of unreviewed outputs, pending requests, and open todos
- Tab headers now show red numeric badges when there are actionable items
- Badges refresh every 30s and after each tab switch (so reviewing an output immediately clears its badge)
- Badges are hidden when count is 0 — no visual noise for tabs with nothing pending
- 7 new tests covering all badge scenarios (254 total)
- v1.4.17

## Implementation

- `lib/routes/badges.js` — lightweight endpoint that reads output/feedback/requests/todos files and returns `{ outputs?: N, requests?: N, todos?: N }`
- `lib/ui/shell.js` — badge `<span>` elements added to tab HTML for outputs, requests, todos tabs
- `lib/ui/styles.js` — red pill badge CSS (hidden by default, shown via `.visible` class)
- `lib/ui/client-core.js` — `loadBadges()` function fetches `/api/badges` and toggles badge visibility

## Test plan

- [x] All 254 tests pass (7 new badge tests)
- [ ] Verify badges appear when outputs/requests/todos have actionable items
- [ ] Verify badges disappear after reviewing/completing items
- [ ] Verify badges refresh automatically every 30s