### PR TITLE
Detect and restart stale portal after local merges

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.4.17",
+  "version": "1.4.18",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/scripts/framework-update.sh
+++ b/scripts/framework-update.sh
@@ -75,5 +75,28 @@ if [ -f "$CYCLE_FAILED_MARKER" ] && [ -n "$FRAMEWORK_LAST_KNOWN_GOOD" ] && [ "$F
   fi
 fi
 
+# Detect stale portal process — covers local merges, not just remote pulls.
+# The pre-pull/post-pull check above only catches remote changes. If portal
+# code is merged locally (e.g. agent merges its own PR), HEAD changes but the
+# portal process keeps serving old code. This section compares the running
+# portal's commit (stored when last started) with current HEAD.
+PORTAL_COMMIT_FILE="/tmp/${AGENT_NAME}-portal-commit"
+CURRENT_PORTAL_COMMIT="$(git -C "$FRAMEWORK_DIR" rev-parse HEAD 2>/dev/null || echo "unknown")"
+
+if [ -f "$PORTAL_COMMIT_FILE" ]; then
+  RUNNING_PORTAL_COMMIT=$(cat "$PORTAL_COMMIT_FILE" 2>/dev/null || echo "unknown")
+  if [ "$RUNNING_PORTAL_COMMIT" != "$CURRENT_PORTAL_COMMIT" ] && [ "$RUNNING_PORTAL_COMMIT" != "unknown" ]; then
+    echo "Portal code is stale ($RUNNING_PORTAL_COMMIT → $CURRENT_PORTAL_COMMIT) — restarting portal" >&2
+    if [ -f "$PORTAL_PID_FILE" ]; then
+      PORTAL_PID=$(cat "$PORTAL_PID_FILE" 2>/dev/null)
+      if [ -n "$PORTAL_PID" ] && kill -0 "$PORTAL_PID" 2>/dev/null; then
+        kill "$PORTAL_PID" 2>/dev/null
+        echo "Killed stale portal process (PID $PORTAL_PID) — supervisor will restart" >&2
+      fi
+    fi
+  fi
+fi
+echo "$CURRENT_PORTAL_COMMIT" > "$PORTAL_COMMIT_FILE"
+
 # Export for wake.sh to use after a successful cycle
 echo "FRAMEWORK_COMMIT='$FRAMEWORK_COMMIT'"

--- a/test/framework-update.test.sh
+++ b/test/framework-update.test.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# Test stale portal detection logic in framework-update.sh
+# Tests the commit-tracking mechanism that detects local merges
+set -e
+
+PASS=0
+FAIL=0
+TESTS=0
+
+assert_eq() {
+  TESTS=$((TESTS + 1))
+  if [ "$1" = "$2" ]; then
+    PASS=$((PASS + 1))
+    echo "  ok - $3"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL - $3 (expected '$1', got '$2')"
+  fi
+}
+
+echo "# framework-update stale portal detection tests"
+
+# Setup temp dir simulating agent environment
+TMPDIR=$(mktemp -d)
+AGENT_NAME="test-agent-$$"
+PORTAL_COMMIT_FILE="/tmp/${AGENT_NAME}-portal-commit"
+PORTAL_PID_FILE="/tmp/${AGENT_NAME}-portal.pid"
+KILL_LOG="$TMPDIR/kill.log"
+
+# Clean up on exit
+cleanup() {
+  rm -rf "$TMPDIR"
+  rm -f "$PORTAL_COMMIT_FILE" "$PORTAL_PID_FILE"
+}
+trap cleanup EXIT
+
+# Helper: simulate the stale portal detection logic (extracted from framework-update.sh)
+check_stale_portal() {
+  local current_commit="$1"
+
+  if [ -f "$PORTAL_COMMIT_FILE" ]; then
+    local running_commit
+    running_commit=$(cat "$PORTAL_COMMIT_FILE" 2>/dev/null || echo "unknown")
+    if [ "$running_commit" != "$current_commit" ] && [ "$running_commit" != "unknown" ]; then
+      echo "would-restart" >> "$KILL_LOG"
+    fi
+  fi
+  echo "$current_commit" > "$PORTAL_COMMIT_FILE"
+}
+
+# --- Test 1: First run — no commit file exists, no restart ---
+echo "## Test 1: First run stores commit without restart"
+rm -f "$PORTAL_COMMIT_FILE" "$KILL_LOG"
+check_stale_portal "abc123"
+assert_eq "abc123" "$(cat "$PORTAL_COMMIT_FILE")" "stores initial commit"
+assert_eq "" "$(cat "$KILL_LOG" 2>/dev/null)" "no restart on first run"
+
+# --- Test 2: Same commit — no restart ---
+echo "## Test 2: Same commit does not restart"
+rm -f "$KILL_LOG"
+check_stale_portal "abc123"
+assert_eq "abc123" "$(cat "$PORTAL_COMMIT_FILE")" "commit unchanged"
+assert_eq "" "$(cat "$KILL_LOG" 2>/dev/null)" "no restart when commit matches"
+
+# --- Test 3: Different commit (local merge) — restart ---
+echo "## Test 3: Different commit triggers restart"
+rm -f "$KILL_LOG"
+check_stale_portal "def456"
+assert_eq "def456" "$(cat "$PORTAL_COMMIT_FILE")" "stores new commit"
+assert_eq "would-restart" "$(cat "$KILL_LOG" 2>/dev/null)" "restart triggered on commit change"
+
+# --- Test 4: Unknown stored commit — no restart ---
+echo "## Test 4: Unknown stored commit does not restart"
+rm -f "$KILL_LOG"
+echo "unknown" > "$PORTAL_COMMIT_FILE"
+check_stale_portal "ghi789"
+assert_eq "ghi789" "$(cat "$PORTAL_COMMIT_FILE")" "stores new commit"
+assert_eq "" "$(cat "$KILL_LOG" 2>/dev/null)" "no restart when stored is unknown"
+
+# --- Test 5: Multiple cycles with same commit — no restart ---
+echo "## Test 5: Multiple stable cycles"
+rm -f "$KILL_LOG" "$PORTAL_COMMIT_FILE"
+check_stale_portal "stable1"
+check_stale_portal "stable1"
+check_stale_portal "stable1"
+assert_eq "" "$(cat "$KILL_LOG" 2>/dev/null)" "no restarts across stable cycles"
+
+# --- Test 6: Commit changes then stabilizes ---
+echo "## Test 6: One restart then stable"
+rm -f "$KILL_LOG"
+echo "old-commit" > "$PORTAL_COMMIT_FILE"
+check_stale_portal "new-commit"
+FIRST_RESULT=$(cat "$KILL_LOG" 2>/dev/null)
+rm -f "$KILL_LOG"
+check_stale_portal "new-commit"
+SECOND_RESULT=$(cat "$KILL_LOG" 2>/dev/null || true)
+assert_eq "would-restart" "$FIRST_RESULT" "restart on first change"
+assert_eq "" "$SECOND_RESULT" "no restart after stabilizing"
+
+echo ""
+echo "# Results: $PASS/$TESTS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- framework-update.sh now tracks which commit the portal was started with via `/tmp/<agent>-portal-commit`
- On each cycle, compares current HEAD with stored commit — if different (e.g. after a local merge), kills the portal so the supervisor restarts with new code
- Previously only remote `git pull` changes triggered portal restarts; local merges left the portal serving stale code

This is a proper script-level fix replacing the manual workaround documented in CLAUDE.md.

Refs robhunter/agent-portal#136

## Changes
- `scripts/framework-update.sh`: Added stale portal detection section after existing framework update logic
- `test/framework-update.test.sh`: 11 shell tests covering first run, same commit, different commit, unknown commit, multi-cycle stability
- `package.json`: Bumped version to 1.4.18

## Test plan
- [x] 254 JS tests pass
- [x] 5 telegram session shell tests pass
- [x] 11 new framework-update shell tests pass (270 total)