### PR TITLE
Agent controller: scaffold and config parsing

### DIFF
--- a/agent-controller/agent-controller.yaml.example
+++ b/agent-controller/agent-controller.yaml.example
@@ -1,0 +1,37 @@
+# Agent Controller configuration
+#
+# Copy this file to agent-controller.yaml and edit for your setup.
+
+listen: 0.0.0.0:9090
+
+# Where agent directories live on the host
+agents_root: /Users/robhunter/code/agents
+
+# Where the framework lives on the host
+framework_dir: /Users/robhunter/code/agents/agent-portal
+
+# VestAuth caller identities
+# Each caller needs a vestauth keypair (run: vestauth agent init)
+# Register the UID and public JWK here.
+auth:
+  callers:
+    agentbox:
+      uid: "agent-REPLACE_ME"
+      public_jwk: '{"crv":"Ed25519","x":"REPLACE_ME","kty":"OKP","kid":"REPLACE_ME"}'
+
+# Agent stacks managed by this controller
+agents:
+  agent-coder:
+    dir: agent-coder
+    controllable: true
+    deployment: sandcat
+    permissions:
+      agentbox: [rebuild, restart, stop, start, logs, status, exec, cycle]
+
+  bobbo:
+    dir: bobbo-agent
+    controllable: false
+
+  agent-pm:
+    dir: agent-pm
+    controllable: false

--- a/agent-controller/lib/config.js
+++ b/agent-controller/lib/config.js
@@ -1,0 +1,124 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const VALID_PERMISSIONS = new Set([
+  'rebuild', 'restart', 'stop', 'start', 'logs', 'status', 'exec', 'cycle',
+]);
+
+const VALID_DEPLOYMENTS = new Set(['sandcat', 'simple']);
+
+function load(configPath) {
+  if (!fs.existsSync(configPath)) {
+    throw new Error(`Config file not found: ${configPath}`);
+  }
+
+  const raw = yaml.load(fs.readFileSync(configPath, 'utf8'));
+  return validate(raw, configPath);
+}
+
+function validate(raw, configPath) {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('Config must be a YAML object');
+  }
+
+  if (!raw.agents_root || typeof raw.agents_root !== 'string') {
+    throw new Error('Config missing required field: agents_root');
+  }
+
+  if (!raw.framework_dir || typeof raw.framework_dir !== 'string') {
+    throw new Error('Config missing required field: framework_dir');
+  }
+
+  if (!raw.listen || typeof raw.listen !== 'string') {
+    throw new Error('Config missing required field: listen');
+  }
+
+  const listenMatch = raw.listen.match(/^(.+):(\d+)$/);
+  if (!listenMatch) {
+    throw new Error(`Invalid listen format: ${raw.listen} (expected host:port)`);
+  }
+
+  if (!raw.auth || !raw.auth.callers || typeof raw.auth.callers !== 'object') {
+    throw new Error('Config missing required field: auth.callers');
+  }
+
+  for (const [callerId, caller] of Object.entries(raw.auth.callers)) {
+    if (!caller.uid || typeof caller.uid !== 'string') {
+      throw new Error(`Caller '${callerId}' missing required field: uid`);
+    }
+    if (!caller.public_jwk) {
+      throw new Error(`Caller '${callerId}' missing required field: public_jwk`);
+    }
+  }
+
+  if (!raw.agents || typeof raw.agents !== 'object') {
+    throw new Error('Config missing required field: agents');
+  }
+
+  const agents = {};
+  for (const [name, agent] of Object.entries(raw.agents)) {
+    if (!agent.dir || typeof agent.dir !== 'string') {
+      throw new Error(`Agent '${name}' missing required field: dir`);
+    }
+
+    const controllable = agent.controllable !== false;
+
+    if (agent.deployment && !VALID_DEPLOYMENTS.has(agent.deployment)) {
+      throw new Error(`Agent '${name}' has invalid deployment: ${agent.deployment} (expected: ${[...VALID_DEPLOYMENTS].join(', ')})`);
+    }
+
+    if (controllable && (!agent.permissions || typeof agent.permissions !== 'object')) {
+      throw new Error(`Agent '${name}' is controllable but has no permissions defined`);
+    }
+
+    const permissions = {};
+    if (agent.permissions) {
+      for (const [callerId, perms] of Object.entries(agent.permissions)) {
+        if (!Array.isArray(perms)) {
+          throw new Error(`Agent '${name}' permissions for '${callerId}' must be an array`);
+        }
+        for (const perm of perms) {
+          if (!VALID_PERMISSIONS.has(perm)) {
+            throw new Error(`Agent '${name}' has unknown permission '${perm}' for caller '${callerId}' (valid: ${[...VALID_PERMISSIONS].join(', ')})`);
+          }
+        }
+        permissions[callerId] = new Set(perms);
+      }
+    }
+
+    agents[name] = {
+      name,
+      dir: path.resolve(raw.agents_root, agent.dir),
+      controllable,
+      deployment: agent.deployment || 'sandcat',
+      permissions,
+    };
+  }
+
+  const callers = {};
+  for (const [callerId, caller] of Object.entries(raw.auth.callers)) {
+    const publicJwk = typeof caller.public_jwk === 'string'
+      ? JSON.parse(caller.public_jwk)
+      : caller.public_jwk;
+    callers[caller.uid] = { callerId, uid: caller.uid, publicJwk };
+  }
+
+  return {
+    listen: { host: listenMatch[1], port: parseInt(listenMatch[2], 10) },
+    agentsRoot: raw.agents_root,
+    frameworkDir: raw.framework_dir,
+    agents,
+    callers,
+  };
+}
+
+function getAgent(config, name) {
+  return config.agents[name] || null;
+}
+
+function getCallerByUid(config, uid) {
+  return config.callers[uid] || null;
+}
+
+module.exports = { load, validate, getAgent, getCallerByUid, VALID_PERMISSIONS };

--- a/agent-controller/package.json
+++ b/agent-controller/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "agent-controller",
+  "version": "0.1.0",
+  "description": "Constrained API for managing agent Docker stacks",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "node --test test/*.test.js"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "js-yaml": "^4.1.0",
+    "vestauth": "^0.23.0"
+  }
+}

--- a/agent-controller/test/config.test.js
+++ b/agent-controller/test/config.test.js
@@ -1,0 +1,193 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { load, validate, getAgent, getCallerByUid } = require('../lib/config');
+
+function writeConfig(dir, config) {
+  const yaml = require('js-yaml');
+  const p = path.join(dir, 'agent-controller.yaml');
+  fs.writeFileSync(p, yaml.dump(config));
+  return p;
+}
+
+function baseConfig() {
+  return {
+    listen: '0.0.0.0:9090',
+    agents_root: '/tmp/agents',
+    framework_dir: '/tmp/framework',
+    auth: {
+      callers: {
+        agentbox: {
+          uid: 'agent-test123',
+          public_jwk: '{"crv":"Ed25519","x":"abc","kty":"OKP","kid":"def"}',
+        },
+      },
+    },
+    agents: {
+      'test-agent': {
+        dir: 'test-agent',
+        controllable: true,
+        deployment: 'sandcat',
+        permissions: {
+          agentbox: ['restart', 'logs', 'status'],
+        },
+      },
+    },
+  };
+}
+
+describe('config', () => {
+  let tmpDir;
+
+  it('parses a valid config file', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ctrl-test-'));
+    const configPath = writeConfig(tmpDir, baseConfig());
+    const config = load(configPath);
+
+    assert.equal(config.listen.host, '0.0.0.0');
+    assert.equal(config.listen.port, 9090);
+    assert.equal(config.agentsRoot, '/tmp/agents');
+    assert.equal(config.frameworkDir, '/tmp/framework');
+    assert.ok(config.agents['test-agent']);
+    assert.equal(config.agents['test-agent'].controllable, true);
+    assert.equal(config.agents['test-agent'].dir, '/tmp/agents/test-agent');
+    assert.ok(config.agents['test-agent'].permissions.agentbox instanceof Set);
+    assert.ok(config.agents['test-agent'].permissions.agentbox.has('restart'));
+  });
+
+  it('rejects config with missing agents_root', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ctrl-test-'));
+    const raw = baseConfig();
+    delete raw.agents_root;
+    const configPath = writeConfig(tmpDir, raw);
+    assert.throws(() => load(configPath), /agents_root/);
+  });
+
+  it('rejects config with missing framework_dir', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ctrl-test-'));
+    const raw = baseConfig();
+    delete raw.framework_dir;
+    const configPath = writeConfig(tmpDir, raw);
+    assert.throws(() => load(configPath), /framework_dir/);
+  });
+
+  it('rejects config with missing listen', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ctrl-test-'));
+    const raw = baseConfig();
+    delete raw.listen;
+    const configPath = writeConfig(tmpDir, raw);
+    assert.throws(() => load(configPath), /listen/);
+  });
+
+  it('rejects config with invalid listen format', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ctrl-test-'));
+    const raw = baseConfig();
+    raw.listen = 'invalid';
+    const configPath = writeConfig(tmpDir, raw);
+    assert.throws(() => load(configPath), /Invalid listen format/);
+  });
+
+  it('rejects config with missing auth.callers', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ctrl-test-'));
+    const raw = baseConfig();
+    delete raw.auth;
+    const configPath = writeConfig(tmpDir, raw);
+    assert.throws(() => load(configPath), /auth\.callers/);
+  });
+
+  it('rejects caller with missing uid', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ctrl-test-'));
+    const raw = baseConfig();
+    delete raw.auth.callers.agentbox.uid;
+    const configPath = writeConfig(tmpDir, raw);
+    assert.throws(() => load(configPath), /uid/);
+  });
+
+  it('rejects caller with missing public_jwk', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ctrl-test-'));
+    const raw = baseConfig();
+    delete raw.auth.callers.agentbox.public_jwk;
+    const configPath = writeConfig(tmpDir, raw);
+    assert.throws(() => load(configPath), /public_jwk/);
+  });
+
+  it('rejects controllable agent with no permissions', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ctrl-test-'));
+    const raw = baseConfig();
+    delete raw.agents['test-agent'].permissions;
+    const configPath = writeConfig(tmpDir, raw);
+    assert.throws(() => load(configPath), /controllable but has no permissions/);
+  });
+
+  it('rejects unknown permission names', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ctrl-test-'));
+    const raw = baseConfig();
+    raw.agents['test-agent'].permissions.agentbox = ['restart', 'destroy'];
+    const configPath = writeConfig(tmpDir, raw);
+    assert.throws(() => load(configPath), /unknown permission 'destroy'/);
+  });
+
+  it('rejects invalid deployment type', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ctrl-test-'));
+    const raw = baseConfig();
+    raw.agents['test-agent'].deployment = 'kubernetes';
+    const configPath = writeConfig(tmpDir, raw);
+    assert.throws(() => load(configPath), /invalid deployment/);
+  });
+
+  it('handles controllable: false agents without permissions', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ctrl-test-'));
+    const raw = baseConfig();
+    raw.agents['locked-agent'] = { dir: 'locked', controllable: false };
+    const configPath = writeConfig(tmpDir, raw);
+    const config = load(configPath);
+    assert.equal(config.agents['locked-agent'].controllable, false);
+  });
+
+  it('returns null for unknown agent names', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ctrl-test-'));
+    const configPath = writeConfig(tmpDir, baseConfig());
+    const config = load(configPath);
+    assert.equal(getAgent(config, 'nonexistent'), null);
+  });
+
+  it('returns agent for known names', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ctrl-test-'));
+    const configPath = writeConfig(tmpDir, baseConfig());
+    const config = load(configPath);
+    const agent = getAgent(config, 'test-agent');
+    assert.equal(agent.name, 'test-agent');
+  });
+
+  it('maps caller UID to caller identity', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ctrl-test-'));
+    const configPath = writeConfig(tmpDir, baseConfig());
+    const config = load(configPath);
+    const caller = getCallerByUid(config, 'agent-test123');
+    assert.equal(caller.callerId, 'agentbox');
+    assert.deepEqual(caller.publicJwk, { crv: 'Ed25519', x: 'abc', kty: 'OKP', kid: 'def' });
+  });
+
+  it('returns null for unknown caller UID', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ctrl-test-'));
+    const configPath = writeConfig(tmpDir, baseConfig());
+    const config = load(configPath);
+    assert.equal(getCallerByUid(config, 'agent-unknown'), null);
+  });
+
+  it('rejects nonexistent config file', () => {
+    assert.throws(() => load('/nonexistent/config.yaml'), /not found/);
+  });
+
+  it('parses public_jwk as object when provided as object', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ctrl-test-'));
+    const raw = baseConfig();
+    raw.auth.callers.agentbox.public_jwk = { crv: 'Ed25519', x: 'abc', kty: 'OKP', kid: 'def' };
+    const configPath = writeConfig(tmpDir, raw);
+    const config = load(configPath);
+    const caller = getCallerByUid(config, 'agent-test123');
+    assert.deepEqual(caller.publicJwk, { crv: 'Ed25519', x: 'abc', kty: 'OKP', kid: 'def' });
+  });
+});


### PR DESCRIPTION
## Summary
- New `agent-controller/` directory with project scaffold
- Config loader (`lib/config.js`) that parses and validates `agent-controller.yaml`
- Validates: agents_root, framework_dir, listen address, auth callers (VestAuth UIDs + public JWKs), agent definitions, controllable flag, permission names, deployment types
- Example config file
- 18 unit tests covering valid parsing and all rejection paths

## Test plan
- [x] `npm test` passes (18/18)
- [ ] Manual: copy example config, modify, verify validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)