### PR TITLE
Agent controller: HTTP server and status endpoint

### DIFF
--- a/agent-controller/index.js
+++ b/agent-controller/index.js
@@ -1,0 +1,32 @@
+const http = require('http');
+const path = require('path');
+const { load } = require('./lib/config');
+const { createRouter } = require('./lib/routes');
+
+const configPath = process.argv[2] || path.join(__dirname, 'agent-controller.yaml');
+
+let config;
+try {
+  config = load(configPath);
+} catch (err) {
+  console.error(`Failed to load config: ${err.message}`);
+  process.exit(1);
+}
+
+const handleRequest = createRouter(config);
+
+const server = http.createServer((req, res) => {
+  handleRequest(req, res).catch(err => {
+    console.error('Unhandled request error:', err);
+    if (!res.writableEnded) {
+      res.writeHead(500);
+      res.end(JSON.stringify({ ok: false, error: 'Internal server error' }));
+    }
+  });
+});
+
+const { host, port } = config.listen;
+server.listen(port, host, () => {
+  console.log(`Agent controller listening on ${host}:${port}`);
+  console.log(`Managing ${Object.keys(config.agents).length} agents`);
+});

--- a/agent-controller/lib/docker.js
+++ b/agent-controller/lib/docker.js
@@ -1,0 +1,47 @@
+const { execFile } = require('child_process');
+const path = require('path');
+const os = require('os');
+
+function composeFile(agentName, deployment) {
+  if (deployment === 'sandcat') {
+    return path.join(os.homedir(), 'sandcat-stacks', agentName, 'docker-compose.yml');
+  }
+  return null;
+}
+
+function composeArgs(agentName, deployment) {
+  const file = composeFile(agentName, deployment);
+  if (!file) return [];
+  return ['-f', file];
+}
+
+function getStatus(agent) {
+  return new Promise((resolve, reject) => {
+    const args = ['compose', ...composeArgs(agent.name, agent.deployment), 'ps', '--format', 'json'];
+    execFile('docker', args, { encoding: 'utf8', timeout: 10000 }, (err, stdout, stderr) => {
+      if (err) {
+        return resolve({ running: false, error: stderr.trim() || err.message, containers: [] });
+      }
+      try {
+        // docker compose ps --format json outputs one JSON object per line
+        const containers = stdout.trim().split('\n')
+          .filter(line => line.trim())
+          .map(line => JSON.parse(line));
+        resolve({
+          running: containers.some(c => c.State === 'running'),
+          containers: containers.map(c => ({
+            name: c.Name,
+            service: c.Service,
+            state: c.State,
+            status: c.Status,
+            health: c.Health || null,
+          })),
+        });
+      } catch (parseErr) {
+        resolve({ running: false, error: `Failed to parse docker output: ${parseErr.message}`, containers: [] });
+      }
+    });
+  });
+}
+
+module.exports = { getStatus, composeFile, composeArgs };

--- a/agent-controller/lib/routes.js
+++ b/agent-controller/lib/routes.js
@@ -1,0 +1,74 @@
+const { verifyCaller, AuthError } = require('./auth');
+const { checkPermission, listVisibleAgents } = require('./permissions');
+const { getStatus } = require('./docker');
+const { getAgent } = require('./config');
+
+function createRouter(config) {
+  const routes = {};
+
+  function route(method, pattern, handler) {
+    if (!routes[method]) routes[method] = [];
+    // Convert :param patterns to regex
+    const regex = new RegExp('^' + pattern.replace(/:([a-zA-Z]+)/g, '(?<$1>[^/]+)') + '$');
+    routes[method].push({ regex, handler });
+  }
+
+  function match(method, url) {
+    const pathname = url.split('?')[0];
+    const methodRoutes = routes[method] || [];
+    for (const { regex, handler } of methodRoutes) {
+      const m = pathname.match(regex);
+      if (m) return { handler, params: m.groups || {} };
+    }
+    return null;
+  }
+
+  // --- Routes ---
+
+  route('GET', '/agents', async (req, res, { caller }) => {
+    const visible = listVisibleAgents(config, caller.callerId);
+    respond(res, 200, { ok: true, agents: visible });
+  });
+
+  route('GET', '/agents/:name/status', async (req, res, { caller, params }) => {
+    const perm = checkPermission(config, caller.callerId, params.name, 'status');
+    if (!perm.allowed) return respond(res, perm.statusCode, { ok: false, error: perm.reason });
+
+    const agent = getAgent(config, params.name);
+    const status = await getStatus(agent);
+    respond(res, 200, { ok: true, agent: params.name, status });
+  });
+
+  // --- Request handler ---
+
+  async function handleRequest(req, res) {
+    // CORS and content type
+    res.setHeader('Content-Type', 'application/json');
+
+    const matched = match(req.method, req.url);
+    if (!matched) {
+      return respond(res, 404, { ok: false, error: 'Not found' });
+    }
+
+    try {
+      const caller = await verifyCaller(req, config);
+      await matched.handler(req, res, { caller, params: matched.params });
+    } catch (err) {
+      if (err instanceof AuthError) {
+        return respond(res, err.statusCode, { ok: false, error: err.message });
+      }
+      console.error('Unhandled error:', err);
+      respond(res, 500, { ok: false, error: 'Internal server error' });
+    }
+  }
+
+  return handleRequest;
+}
+
+function respond(res, statusCode, body) {
+  if (res.writableEnded) return;
+  res.writeHead(statusCode);
+  res.end(JSON.stringify(body));
+}
+
+module.exports = { createRouter };

--- a/agent-controller/test/routes.test.js
+++ b/agent-controller/test/routes.test.js
@@ -1,0 +1,156 @@
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('http');
+const { execFileSync } = require('child_process');
+const { createRouter } = require('../lib/routes');
+
+// Generate a test keypair
+const keypair = JSON.parse(execFileSync('vestauth', ['primitives', 'keypair', '--pp'], { encoding: 'utf8' }));
+const testUid = 'agent-routetest001';
+
+function makeTestConfig() {
+  return {
+    listen: { host: '127.0.0.1', port: 0 },
+    agentsRoot: '/tmp/agents',
+    frameworkDir: '/tmp/framework',
+    callers: {
+      [testUid]: { callerId: 'agentbox', uid: testUid, publicJwk: keypair.public_jwk },
+    },
+    agents: {
+      'test-agent': {
+        name: 'test-agent',
+        dir: '/tmp/agents/test-agent',
+        controllable: true,
+        deployment: 'sandcat',
+        permissions: {
+          agentbox: new Set(['status', 'restart', 'logs']),
+        },
+      },
+      'locked-agent': {
+        name: 'locked-agent',
+        dir: '/tmp/agents/locked-agent',
+        controllable: false,
+        deployment: 'sandcat',
+        permissions: {},
+      },
+    },
+  };
+}
+
+function signHeaders(method, url) {
+  const out = execFileSync('vestauth', [
+    'primitives', 'headers', method, url,
+    '--uid', testUid,
+    '--private-jwk', JSON.stringify(keypair.private_jwk),
+  ], { encoding: 'utf8' });
+  const raw = JSON.parse(out);
+  const headers = {};
+  for (const [k, v] of Object.entries(raw)) headers[k.toLowerCase()] = v;
+  return headers;
+}
+
+function request(server, method, path, signedHeaders) {
+  return new Promise((resolve, reject) => {
+    const addr = server.address();
+    const url = `http://127.0.0.1:${addr.port}${path}`;
+
+    // If we need signed headers, generate them for the full URL
+    let headers = signedHeaders;
+    if (signedHeaders === 'sign') {
+      headers = signHeaders(method, url);
+    }
+
+    const opts = {
+      hostname: '127.0.0.1',
+      port: addr.port,
+      path,
+      method,
+      headers: headers || {},
+    };
+
+    const req = http.request(opts, (res) => {
+      let body = '';
+      res.on('data', chunk => body += chunk);
+      res.on('end', () => {
+        try {
+          resolve({ status: res.statusCode, body: JSON.parse(body), headers: res.headers });
+        } catch {
+          resolve({ status: res.statusCode, body, headers: res.headers });
+        }
+      });
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+describe('routes', () => {
+  let server;
+
+  before((_, done) => {
+    const config = makeTestConfig();
+    const handleRequest = createRouter(config);
+    server = http.createServer((req, res) => {
+      handleRequest(req, res).catch(() => {
+        if (!res.writableEnded) { res.writeHead(500); res.end('{}'); }
+      });
+    });
+    server.listen(0, '127.0.0.1', done);
+  });
+
+  after((_, done) => {
+    server.close(done);
+  });
+
+  it('returns 401 for unauthenticated request to /agents', async () => {
+    const res = await request(server, 'GET', '/agents');
+    assert.equal(res.status, 401);
+    assert.equal(res.body.ok, false);
+  });
+
+  it('returns 200 with agent list for authenticated request to /agents', async () => {
+    const res = await request(server, 'GET', '/agents', 'sign');
+    assert.equal(res.status, 200);
+    assert.equal(res.body.ok, true);
+    assert.ok(Array.isArray(res.body.agents));
+    assert.equal(res.body.agents.length, 1);
+    assert.equal(res.body.agents[0].name, 'test-agent');
+  });
+
+  it('hides non-controllable agents from /agents list', async () => {
+    const res = await request(server, 'GET', '/agents', 'sign');
+    const names = res.body.agents.map(a => a.name);
+    assert.ok(!names.includes('locked-agent'));
+  });
+
+  it('returns 403 for status of non-controllable agent', async () => {
+    const res = await request(server, 'GET', '/agents/locked-agent/status', 'sign');
+    assert.equal(res.status, 403);
+    assert.equal(res.body.ok, false);
+  });
+
+  it('returns 404 for unknown agent', async () => {
+    const res = await request(server, 'GET', '/agents/nonexistent/status', 'sign');
+    assert.equal(res.status, 404);
+    assert.equal(res.body.ok, false);
+  });
+
+  it('returns 404 for unknown route', async () => {
+    const res = await request(server, 'GET', '/unknown', 'sign');
+    assert.equal(res.status, 404);
+  });
+
+  it('returns application/json content type', async () => {
+    const res = await request(server, 'GET', '/agents', 'sign');
+    assert.match(res.headers['content-type'], /application\/json/);
+  });
+
+  // Status endpoint returns data (may show error if Docker not running, that's ok)
+  it('returns 200 for status of controllable agent', async () => {
+    const res = await request(server, 'GET', '/agents/test-agent/status', 'sign');
+    assert.equal(res.status, 200);
+    assert.equal(res.body.ok, true);
+    assert.equal(res.body.agent, 'test-agent');
+    assert.ok('status' in res.body);
+  });
+});


### PR DESCRIPTION
## Summary
- `index.js`: Entry point — loads config, starts HTTP server
- `lib/routes.js`: Router with VestAuth middleware and permission checks for all endpoints
- `lib/docker.js`: Docker Compose operations (status via `docker compose ps --format json`)
- `GET /agents`: Returns agents visible to the authenticated caller
- `GET /agents/:name/status`: Returns container state for a controllable agent
- 8 new integration tests (49 total) against a live HTTP server with real VestAuth signing

## Test plan
- [x] `npm test` passes (49/49)
- [x] Tests spin up real HTTP server, sign requests with VestAuth, verify responses
- [x] Covers: 401 unauthenticated, 200 agent list, 403 non-controllable, 404 unknown agent/route, JSON content type

🤖 Generated with [Claude Code](https://claude.com/claude-code)