### PR TITLE
Agent controller: SSE streaming and logs endpoint

### DIFF
--- a/agent-controller/lib/docker.js
+++ b/agent-controller/lib/docker.js
@@ -44,4 +44,11 @@ function getStatus(agent) {
   });
 }
 
-module.exports = { getStatus, composeFile, composeArgs };
+function streamLogsArgs(agent, service, tail) {
+  const args = ['compose', ...composeArgs(agent.name, agent.deployment), 'logs', '--follow'];
+  if (tail) args.push('--tail', String(tail));
+  if (service) args.push(service);
+  return args;
+}
+
+module.exports = { getStatus, composeFile, composeArgs, streamLogsArgs };

--- a/agent-controller/lib/routes.js
+++ b/agent-controller/lib/routes.js
@@ -1,7 +1,9 @@
 const { verifyCaller, AuthError } = require('./auth');
 const { checkPermission, listVisibleAgents } = require('./permissions');
-const { getStatus } = require('./docker');
+const { getStatus, streamLogsArgs } = require('./docker');
+const { streamProcess } = require('./stream');
 const { getAgent } = require('./config');
+const url = require('url');
 
 function createRouter(config) {
   const routes = {};
@@ -37,6 +39,18 @@ function createRouter(config) {
     const agent = getAgent(config, params.name);
     const status = await getStatus(agent);
     respond(res, 200, { ok: true, agent: params.name, status });
+  });
+
+  route('GET', '/agents/:name/logs', async (req, res, { caller, params }) => {
+    const perm = checkPermission(config, caller.callerId, params.name, 'logs');
+    if (!perm.allowed) return respond(res, perm.statusCode, { ok: false, error: perm.reason });
+
+    const agent = getAgent(config, params.name);
+    const parsed = url.parse(req.url, true);
+    const service = parsed.query.service || null;
+    const tail = parsed.query.tail || '100';
+    const args = streamLogsArgs(agent, service, tail);
+    streamProcess(res, 'docker', args);
   });
 
   // --- Request handler ---

--- a/agent-controller/lib/stream.js
+++ b/agent-controller/lib/stream.js
@@ -1,0 +1,75 @@
+const { spawn } = require('child_process');
+
+function sseHeaders(res) {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    'Connection': 'keep-alive',
+  });
+}
+
+function sseData(res, data) {
+  if (res.writableEnded) return;
+  res.write(`data: ${JSON.stringify(data)}\n\n`);
+}
+
+function sseEnd(res, data) {
+  if (res.writableEnded) return;
+  if (data) res.write(`event: done\ndata: ${JSON.stringify(data)}\n\n`);
+  res.end();
+}
+
+function streamProcess(res, command, args, opts = {}) {
+  sseHeaders(res);
+
+  const proc = spawn(command, args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    ...opts,
+  });
+
+  let killed = false;
+
+  function onLine(stream, source) {
+    let buffer = '';
+    stream.on('data', (chunk) => {
+      buffer += chunk.toString();
+      const lines = buffer.split('\n');
+      buffer = lines.pop(); // keep incomplete line in buffer
+      for (const line of lines) {
+        if (line.trim()) sseData(res, { source, line });
+      }
+    });
+    stream.on('end', () => {
+      if (buffer.trim()) sseData(res, { source, line: buffer });
+    });
+  }
+
+  onLine(proc.stdout, 'stdout');
+  onLine(proc.stderr, 'stderr');
+
+  proc.on('close', (code) => {
+    sseEnd(res, { exitCode: code });
+  });
+
+  proc.on('error', (err) => {
+    sseData(res, { source: 'error', line: err.message });
+    sseEnd(res, { exitCode: -1 });
+  });
+
+  // Clean up on client disconnect
+  res.on('close', () => {
+    if (!killed && !proc.killed) {
+      killed = true;
+      proc.kill('SIGTERM');
+      // Force kill after 2 seconds if SIGTERM didn't work
+      setTimeout(() => {
+        if (!proc.killed) proc.kill('SIGKILL');
+      }, 2000).unref();
+    }
+  });
+
+  return proc;
+}
+
+module.exports = { sseHeaders, sseData, sseEnd, streamProcess };

--- a/agent-controller/test/stream.test.js
+++ b/agent-controller/test/stream.test.js
@@ -1,0 +1,117 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('http');
+const { sseHeaders, sseData, sseEnd, streamProcess } = require('../lib/stream');
+
+describe('stream helpers', () => {
+  it('sseHeaders sets correct content type', (_, done) => {
+    const server = http.createServer((req, res) => {
+      sseHeaders(res);
+      res.end();
+    });
+    server.listen(0, '127.0.0.1', () => {
+      http.get(`http://127.0.0.1:${server.address().port}`, (res) => {
+        assert.equal(res.headers['content-type'], 'text/event-stream');
+        assert.equal(res.headers['cache-control'], 'no-cache');
+        res.resume();
+        res.on('end', () => server.close(done));
+      });
+    });
+  });
+
+  it('sseData produces correct SSE framing', (_, done) => {
+    const server = http.createServer((req, res) => {
+      sseHeaders(res);
+      sseData(res, { line: 'hello' });
+      sseData(res, { line: 'world' });
+      res.end();
+    });
+    server.listen(0, '127.0.0.1', () => {
+      http.get(`http://127.0.0.1:${server.address().port}`, (res) => {
+        let body = '';
+        res.on('data', chunk => body += chunk);
+        res.on('end', () => {
+          const events = body.split('\n\n').filter(e => e.trim());
+          assert.equal(events.length, 2);
+          assert.ok(events[0].startsWith('data: '));
+          const parsed = JSON.parse(events[0].replace('data: ', ''));
+          assert.equal(parsed.line, 'hello');
+          server.close(done);
+        });
+      });
+    });
+  });
+
+  it('sseEnd sends done event', (_, done) => {
+    const server = http.createServer((req, res) => {
+      sseHeaders(res);
+      sseEnd(res, { exitCode: 0 });
+    });
+    server.listen(0, '127.0.0.1', () => {
+      http.get(`http://127.0.0.1:${server.address().port}`, (res) => {
+        let body = '';
+        res.on('data', chunk => body += chunk);
+        res.on('end', () => {
+          assert.ok(body.includes('event: done'));
+          assert.ok(body.includes('"exitCode":0'));
+          server.close(done);
+        });
+      });
+    });
+  });
+
+  it('streamProcess streams command output and exits', (_, done) => {
+    const server = http.createServer((req, res) => {
+      streamProcess(res, 'echo', ['hello world']);
+    });
+    server.listen(0, '127.0.0.1', () => {
+      http.get(`http://127.0.0.1:${server.address().port}`, (res) => {
+        assert.equal(res.headers['content-type'], 'text/event-stream');
+        let body = '';
+        res.on('data', chunk => body += chunk);
+        res.on('end', () => {
+          assert.ok(body.includes('hello world'));
+          assert.ok(body.includes('event: done'));
+          assert.ok(body.includes('"exitCode":0'));
+          server.close(done);
+        });
+      });
+    });
+  });
+
+  it('streamProcess kills child on client disconnect', (_, done) => {
+    const server = http.createServer((req, res) => {
+      // Start a process that outputs continuously
+      const proc = streamProcess(res, 'sh', ['-c', 'while true; do echo ping; sleep 0.1; done']);
+      proc.on('close', () => {
+        server.close(done);
+      });
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const req = http.get(`http://127.0.0.1:${server.address().port}`, (res) => {
+        // Wait for first data, then disconnect
+        res.once('data', () => {
+          res.destroy();
+        });
+      });
+      req.on('error', () => {}); // ignore connection reset error
+    });
+  });
+
+  it('streamProcess captures stderr', (_, done) => {
+    const server = http.createServer((req, res) => {
+      streamProcess(res, 'sh', ['-c', 'echo err >&2']);
+    });
+    server.listen(0, '127.0.0.1', () => {
+      http.get(`http://127.0.0.1:${server.address().port}`, (res) => {
+        let body = '';
+        res.on('data', chunk => body += chunk);
+        res.on('end', () => {
+          assert.ok(body.includes('"source":"stderr"'));
+          assert.ok(body.includes('err'));
+          server.close(done);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `lib/stream.js`: SSE helpers and `streamProcess` — pipes child process stdout/stderr to SSE events, kills child on client disconnect, sends `done` event with exit code
- `lib/docker.js`: Added `streamLogsArgs` for `docker compose logs --follow`
- `GET /agents/:name/logs?service=agent&tail=100`: Streams container logs via SSE
- 6 new tests (55 total)

## Test plan
- [x] `npm test` passes (55/55)
- [x] SSE framing correct (`data: ...\n\n`)
- [x] `Content-Type: text/event-stream`
- [x] Client disconnect kills child process (no zombies)
- [x] stderr captured separately from stdout
- [x] Exit code in `done` event

🤖 Generated with [Claude Code](https://claude.com/claude-code)