### PR TITLE
Agent controller: lifecycle, exec, and cycle endpoints

### DIFF
--- a/agent-controller/lib/docker.js
+++ b/agent-controller/lib/docker.js
@@ -51,4 +51,32 @@ function streamLogsArgs(agent, service, tail) {
   return args;
 }
 
-module.exports = { getStatus, composeFile, composeArgs, streamLogsArgs };
+function lifecycleCommand(agent, operation) {
+  return new Promise((resolve, reject) => {
+    const ops = {
+      restart: ['restart', 'agent'],
+      stop: ['down'],
+      start: ['up', '-d'],
+    };
+    const opArgs = ops[operation];
+    if (!opArgs) return reject(new Error(`Unknown lifecycle operation: ${operation}`));
+
+    const args = ['compose', ...composeArgs(agent.name, agent.deployment), ...opArgs];
+    execFile('docker', args, { encoding: 'utf8', timeout: 60000 }, (err, stdout, stderr) => {
+      if (err) {
+        return resolve({ ok: false, error: stderr.trim() || err.message });
+      }
+      resolve({ ok: true, output: (stdout + stderr).trim() });
+    });
+  });
+}
+
+function execArgs(agent, cmd) {
+  return ['compose', ...composeArgs(agent.name, agent.deployment), 'exec', '-T', 'agent', ...cmd];
+}
+
+function cycleArgs(agent) {
+  return execArgs(agent, ['bash', 'scripts/wake.sh']);
+}
+
+module.exports = { getStatus, composeFile, composeArgs, streamLogsArgs, lifecycleCommand, execArgs, cycleArgs };

--- a/agent-controller/lib/routes.js
+++ b/agent-controller/lib/routes.js
@@ -1,6 +1,6 @@
 const { verifyCaller, AuthError } = require('./auth');
 const { checkPermission, listVisibleAgents } = require('./permissions');
-const { getStatus, streamLogsArgs } = require('./docker');
+const { getStatus, streamLogsArgs, lifecycleCommand, execArgs, cycleArgs } = require('./docker');
 const { streamProcess } = require('./stream');
 const { getAgent } = require('./config');
 const url = require('url');
@@ -53,6 +53,46 @@ function createRouter(config) {
     streamProcess(res, 'docker', args);
   });
 
+  // --- Lifecycle routes (restart, stop, start) ---
+
+  for (const op of ['restart', 'stop', 'start']) {
+    route('POST', `/agents/:name/${op}`, async (req, res, { caller, params }) => {
+      const perm = checkPermission(config, caller.callerId, params.name, op);
+      if (!perm.allowed) return respond(res, perm.statusCode, { ok: false, error: perm.reason });
+
+      const agent = getAgent(config, params.name);
+      const result = await lifecycleCommand(agent, op);
+      respond(res, result.ok ? 200 : 500, { ...result, agent: params.name, operation: op });
+    });
+  }
+
+  // --- Exec route ---
+
+  route('POST', '/agents/:name/exec', async (req, res, { caller, params }) => {
+    const perm = checkPermission(config, caller.callerId, params.name, 'exec');
+    if (!perm.allowed) return respond(res, perm.statusCode, { ok: false, error: perm.reason });
+
+    const body = await readBody(req);
+    if (!body.cmd || !Array.isArray(body.cmd) || body.cmd.length === 0) {
+      return respond(res, 400, { ok: false, error: 'Request body must include cmd as a non-empty array' });
+    }
+
+    const agent = getAgent(config, params.name);
+    const args = execArgs(agent, body.cmd);
+    streamProcess(res, 'docker', args);
+  });
+
+  // --- Cycle route ---
+
+  route('POST', '/agents/:name/cycle', async (req, res, { caller, params }) => {
+    const perm = checkPermission(config, caller.callerId, params.name, 'cycle');
+    if (!perm.allowed) return respond(res, perm.statusCode, { ok: false, error: perm.reason });
+
+    const agent = getAgent(config, params.name);
+    const args = cycleArgs(agent);
+    streamProcess(res, 'docker', args);
+  });
+
   // --- Request handler ---
 
   async function handleRequest(req, res) {
@@ -83,6 +123,21 @@ function respond(res, statusCode, body) {
   if (res.writableEnded) return;
   res.writeHead(statusCode);
   res.end(JSON.stringify(body));
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.on('data', chunk => body += chunk);
+    req.on('end', () => {
+      try {
+        resolve(body ? JSON.parse(body) : {});
+      } catch {
+        reject(new Error('Invalid JSON body'));
+      }
+    });
+    req.on('error', reject);
+  });
 }
 
 module.exports = { createRouter };

--- a/agent-controller/test/docker.test.js
+++ b/agent-controller/test/docker.test.js
@@ -1,0 +1,52 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { composeArgs, streamLogsArgs, execArgs, cycleArgs } = require('../lib/docker');
+
+const testAgent = {
+  name: 'test-agent',
+  deployment: 'sandcat',
+};
+
+describe('docker command construction', () => {
+  it('composeArgs returns -f flag for sandcat deployment', () => {
+    const args = composeArgs('test-agent', 'sandcat');
+    assert.equal(args[0], '-f');
+    assert.ok(args[1].includes('sandcat-stacks/test-agent/docker-compose.yml'));
+  });
+
+  it('composeArgs returns empty for non-sandcat', () => {
+    const args = composeArgs('test-agent', 'simple');
+    assert.equal(args.length, 0);
+  });
+
+  it('streamLogsArgs includes --follow', () => {
+    const args = streamLogsArgs(testAgent, null, null);
+    assert.ok(args.includes('--follow'));
+    assert.ok(args.includes('logs'));
+  });
+
+  it('streamLogsArgs includes service and tail', () => {
+    const args = streamLogsArgs(testAgent, 'agent', '50');
+    assert.ok(args.includes('agent'));
+    assert.ok(args.includes('--tail'));
+    assert.ok(args.includes('50'));
+  });
+
+  it('execArgs passes command as array (no shell interpolation)', () => {
+    const args = execArgs(testAgent, ['echo', 'hello world']);
+    assert.ok(args.includes('exec'));
+    assert.ok(args.includes('-T'));
+    assert.ok(args.includes('agent'));
+    // Command should be the last elements
+    const echoIdx = args.indexOf('echo');
+    assert.ok(echoIdx > 0);
+    assert.equal(args[echoIdx + 1], 'hello world');
+  });
+
+  it('cycleArgs runs bash scripts/wake.sh', () => {
+    const args = cycleArgs(testAgent);
+    assert.ok(args.includes('exec'));
+    assert.ok(args.includes('bash'));
+    assert.ok(args.includes('scripts/wake.sh'));
+  });
+});

--- a/agent-controller/test/routes.test.js
+++ b/agent-controller/test/routes.test.js
@@ -23,7 +23,7 @@ function makeTestConfig() {
         controllable: true,
         deployment: 'sandcat',
         permissions: {
-          agentbox: new Set(['status', 'restart', 'logs']),
+          agentbox: new Set(['status', 'restart', 'stop', 'start', 'logs', 'exec', 'cycle']),
         },
       },
       'locked-agent': {
@@ -49,7 +49,7 @@ function signHeaders(method, url) {
   return headers;
 }
 
-function request(server, method, path, signedHeaders) {
+function request(server, method, path, signedHeaders, jsonBody) {
   return new Promise((resolve, reject) => {
     const addr = server.address();
     const url = `http://127.0.0.1:${addr.port}${path}`;
@@ -58,6 +58,10 @@ function request(server, method, path, signedHeaders) {
     let headers = signedHeaders;
     if (signedHeaders === 'sign') {
       headers = signHeaders(method, url);
+    }
+
+    if (jsonBody) {
+      headers = { ...headers, 'content-type': 'application/json' };
     }
 
     const opts = {
@@ -80,6 +84,9 @@ function request(server, method, path, signedHeaders) {
       });
     });
     req.on('error', reject);
+    if (jsonBody) {
+      req.write(JSON.stringify(jsonBody));
+    }
     req.end();
   });
 }
@@ -152,5 +159,48 @@ describe('routes', () => {
     assert.equal(res.body.ok, true);
     assert.equal(res.body.agent, 'test-agent');
     assert.ok('status' in res.body);
+  });
+
+  // --- Lifecycle routes ---
+
+  it('returns 403 for restart on non-controllable agent', async () => {
+    const res = await request(server, 'POST', '/agents/locked-agent/restart', 'sign');
+    assert.equal(res.status, 403);
+  });
+
+  it('returns 404 for restart on unknown agent', async () => {
+    const res = await request(server, 'POST', '/agents/nonexistent/restart', 'sign');
+    assert.equal(res.status, 404);
+  });
+
+  // --- Exec route ---
+
+  it('returns 400 for exec with missing cmd', async () => {
+    const res = await request(server, 'POST', '/agents/test-agent/exec', 'sign', {});
+    assert.equal(res.status, 400);
+    assert.match(res.body.error, /cmd/);
+  });
+
+  it('returns 400 for exec with non-array cmd', async () => {
+    const res = await request(server, 'POST', '/agents/test-agent/exec', 'sign', { cmd: 'echo hello' });
+    assert.equal(res.status, 400);
+    assert.match(res.body.error, /array/);
+  });
+
+  it('returns 400 for exec with empty cmd array', async () => {
+    const res = await request(server, 'POST', '/agents/test-agent/exec', 'sign', { cmd: [] });
+    assert.equal(res.status, 400);
+  });
+
+  it('returns 403 for exec on non-controllable agent', async () => {
+    const res = await request(server, 'POST', '/agents/locked-agent/exec', 'sign', { cmd: ['echo', 'hi'] });
+    assert.equal(res.status, 403);
+  });
+
+  // --- Cycle route ---
+
+  it('returns 403 for cycle on non-controllable agent', async () => {
+    const res = await request(server, 'POST', '/agents/locked-agent/cycle', 'sign');
+    assert.equal(res.status, 403);
   });
 });


### PR DESCRIPTION
## Summary
- `POST /agents/:name/restart` — restart agent container
- `POST /agents/:name/stop` — stop entire stack
- `POST /agents/:name/start` — start stack
- `POST /agents/:name/exec` — run command in agent container (SSE-streamed, cmd must be non-empty array)
- `POST /agents/:name/cycle` — trigger wake.sh cycle (SSE-streamed)
- Docker command construction unit tests
- 13 new tests (68 total)

## Test plan
- [x] `npm test` passes (68/68)
- [x] Exec validates cmd as non-empty array (400 on missing/invalid)
- [x] Permission checks enforced on all new endpoints
- [x] Docker command construction tested (compose args, exec args, cycle args)

🤖 Generated with [Claude Code](https://claude.com/claude-code)