### PR TITLE
Agent controller: async rebuild with job tracking

### DIFF
--- a/agent-controller/lib/docker.js
+++ b/agent-controller/lib/docker.js
@@ -79,4 +79,27 @@ function cycleArgs(agent) {
   return execArgs(agent, ['bash', 'scripts/wake.sh']);
 }
 
-module.exports = { getStatus, composeFile, composeArgs, streamLogsArgs, lifecycleCommand, execArgs, cycleArgs };
+function rebuildScript(config, agent) {
+  const scriptName = agent.deployment === 'sandcat' ? 'docker-compose-create.sh' : 'docker-create.sh';
+  return {
+    command: 'bash',
+    args: [path.join(config.frameworkDir, 'scripts', scriptName), agent.dir],
+  };
+}
+
+// Simple in-memory job store for async rebuilds
+const jobs = new Map();
+let jobCounter = 0;
+
+function createJob(agentName) {
+  const id = `rb-${++jobCounter}-${Date.now()}`;
+  const job = { id, agent: agentName, status: 'running', output: [], startedAt: new Date().toISOString() };
+  jobs.set(id, job);
+  return job;
+}
+
+function getJob(id) {
+  return jobs.get(id) || null;
+}
+
+module.exports = { getStatus, composeFile, composeArgs, streamLogsArgs, lifecycleCommand, execArgs, cycleArgs, rebuildScript, createJob, getJob };

--- a/agent-controller/lib/routes.js
+++ b/agent-controller/lib/routes.js
@@ -1,7 +1,8 @@
 const { verifyCaller, AuthError } = require('./auth');
 const { checkPermission, listVisibleAgents } = require('./permissions');
-const { getStatus, streamLogsArgs, lifecycleCommand, execArgs, cycleArgs } = require('./docker');
-const { streamProcess } = require('./stream');
+const { getStatus, streamLogsArgs, lifecycleCommand, execArgs, cycleArgs, rebuildScript, createJob, getJob } = require('./docker');
+const { streamProcess, sseHeaders, sseData, sseEnd } = require('./stream');
+const { spawn } = require('child_process');
 const { getAgent } = require('./config');
 const url = require('url');
 
@@ -91,6 +92,76 @@ function createRouter(config) {
     const agent = getAgent(config, params.name);
     const args = cycleArgs(agent);
     streamProcess(res, 'docker', args);
+  });
+
+  // --- Rebuild routes ---
+
+  route('POST', '/agents/:name/rebuild', async (req, res, { caller, params }) => {
+    const perm = checkPermission(config, caller.callerId, params.name, 'rebuild');
+    if (!perm.allowed) return respond(res, perm.statusCode, { ok: false, error: perm.reason });
+
+    const agent = getAgent(config, params.name);
+    const { command, args } = rebuildScript(config, agent);
+    const job = createJob(params.name);
+
+    // Run rebuild in background, capture output
+    const proc = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+
+    function capture(stream) {
+      stream.on('data', (chunk) => {
+        const lines = chunk.toString().split('\n').filter(l => l.trim());
+        job.output.push(...lines);
+      });
+    }
+    capture(proc.stdout);
+    capture(proc.stderr);
+
+    proc.on('close', (code) => {
+      job.status = code === 0 ? 'completed' : 'failed';
+      job.exitCode = code;
+      job.completedAt = new Date().toISOString();
+    });
+
+    respond(res, 200, {
+      ok: true,
+      agent: params.name,
+      operation: 'rebuild',
+      jobId: job.id,
+      logsUrl: `/agents/${params.name}/rebuild/${job.id}`,
+    });
+  });
+
+  route('GET', '/agents/:name/rebuild/:jobId', async (req, res, { caller, params }) => {
+    const perm = checkPermission(config, caller.callerId, params.name, 'rebuild');
+    if (!perm.allowed) return respond(res, perm.statusCode, { ok: false, error: perm.reason });
+
+    const job = getJob(params.jobId);
+    if (!job) return respond(res, 404, { ok: false, error: `Job not found: ${params.jobId}` });
+
+    sseHeaders(res);
+    // Send all existing output
+    for (const line of job.output) {
+      sseData(res, { source: 'stdout', line });
+    }
+
+    if (job.status !== 'running') {
+      sseEnd(res, { status: job.status, exitCode: job.exitCode });
+      return;
+    }
+
+    // Poll for new output until job completes
+    const startIdx = job.output.length;
+    const interval = setInterval(() => {
+      for (let i = startIdx; i < job.output.length; i++) {
+        sseData(res, { source: 'stdout', line: job.output[i] });
+      }
+      if (job.status !== 'running') {
+        clearInterval(interval);
+        sseEnd(res, { status: job.status, exitCode: job.exitCode });
+      }
+    }, 500);
+
+    res.on('close', () => clearInterval(interval));
   });
 
   // --- Request handler ---

--- a/agent-controller/test/docker.test.js
+++ b/agent-controller/test/docker.test.js
@@ -1,6 +1,6 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
-const { composeArgs, streamLogsArgs, execArgs, cycleArgs } = require('../lib/docker');
+const { composeArgs, streamLogsArgs, execArgs, cycleArgs, rebuildScript, createJob, getJob } = require('../lib/docker');
 
 const testAgent = {
   name: 'test-agent',
@@ -48,5 +48,39 @@ describe('docker command construction', () => {
     assert.ok(args.includes('exec'));
     assert.ok(args.includes('bash'));
     assert.ok(args.includes('scripts/wake.sh'));
+  });
+
+  it('rebuildScript returns sandcat script for sandcat deployment', () => {
+    const config = { frameworkDir: '/tmp/framework' };
+    const agent = { ...testAgent, dir: '/tmp/agents/test-agent' };
+    const { command, args } = rebuildScript(config, agent);
+    assert.equal(command, 'bash');
+    assert.ok(args[0].includes('docker-compose-create.sh'));
+    assert.equal(args[1], '/tmp/agents/test-agent');
+  });
+
+  it('rebuildScript returns simple script for simple deployment', () => {
+    const config = { frameworkDir: '/tmp/framework' };
+    const agent = { name: 'test', deployment: 'simple', dir: '/tmp/agents/test' };
+    const { command, args } = rebuildScript(config, agent);
+    assert.ok(args[0].includes('docker-create.sh'));
+  });
+
+  it('createJob returns unique job IDs', () => {
+    const job1 = createJob('agent-a');
+    const job2 = createJob('agent-b');
+    assert.notEqual(job1.id, job2.id);
+    assert.equal(job1.status, 'running');
+    assert.equal(job1.agent, 'agent-a');
+  });
+
+  it('getJob returns job by ID', () => {
+    const job = createJob('agent-c');
+    const found = getJob(job.id);
+    assert.equal(found.id, job.id);
+  });
+
+  it('getJob returns null for unknown ID', () => {
+    assert.equal(getJob('rb-nonexistent'), null);
   });
 });

--- a/agent-controller/test/routes.test.js
+++ b/agent-controller/test/routes.test.js
@@ -23,7 +23,7 @@ function makeTestConfig() {
         controllable: true,
         deployment: 'sandcat',
         permissions: {
-          agentbox: new Set(['status', 'restart', 'stop', 'start', 'logs', 'exec', 'cycle']),
+          agentbox: new Set(['status', 'restart', 'stop', 'start', 'logs', 'exec', 'cycle', 'rebuild']),
         },
       },
       'locked-agent': {
@@ -202,5 +202,26 @@ describe('routes', () => {
   it('returns 403 for cycle on non-controllable agent', async () => {
     const res = await request(server, 'POST', '/agents/locked-agent/cycle', 'sign');
     assert.equal(res.status, 403);
+  });
+
+  // --- Rebuild route ---
+
+  it('returns 403 for rebuild on non-controllable agent', async () => {
+    const res = await request(server, 'POST', '/agents/locked-agent/rebuild', 'sign');
+    assert.equal(res.status, 403);
+  });
+
+  it('returns 200 with job ID for rebuild', async () => {
+    const res = await request(server, 'POST', '/agents/test-agent/rebuild', 'sign');
+    assert.equal(res.status, 200);
+    assert.equal(res.body.ok, true);
+    assert.ok(res.body.jobId);
+    assert.ok(res.body.logsUrl);
+    assert.match(res.body.logsUrl, /rebuild/);
+  });
+
+  it('returns 404 for unknown rebuild job ID', async () => {
+    const res = await request(server, 'GET', '/agents/test-agent/rebuild/rb-nonexistent', 'sign');
+    assert.equal(res.status, 404);
   });
 });


### PR DESCRIPTION
## Summary
- `POST /agents/:name/rebuild`: Starts rebuild in background, returns job ID immediately
- `GET /agents/:name/rebuild/:jobId`: Streams rebuild output via SSE (existing + live)
- In-memory job store tracks status, output, exit code, timestamps
- Uses `docker-compose-create.sh` (sandcat) or `docker-create.sh` (simple)
- 8 new tests (76 total)

## Test plan
- [x] `npm test` passes (76/76)
- [x] Rebuild returns job ID without blocking
- [x] Job log endpoint returns 404 for unknown jobs
- [x] Permission checks on both POST and GET rebuild endpoints
- [x] Correct script selected per deployment type

🤖 Generated with [Claude Code](https://claude.com/claude-code)