### PR TITLE
Fix Output badge to show project-scoped count

### DIFF
--- a/lib/routes/badges.js
+++ b/lib/routes/badges.js
@@ -11,6 +11,8 @@ function register(routes, config) {
 
   routes['GET /api/badges'] = (req, res) => {
     const badges = {};
+    const parsed = new URL(req.url, 'http://localhost');
+    const projectSlug = parsed.searchParams.get('project') || null;
 
     // Outputs: count unreviewed
     if (tabs.includes('outputs') && config.features && config.features.outputs) {
@@ -18,8 +20,11 @@ function register(routes, config) {
         const outputDir = path.join(agentDir, 'output');
         const feedbackDir = path.join(agentDir, 'input', 'feedback');
         const processedDir = path.join(feedbackDir, 'processed');
-        const files = fs.readdirSync(outputDir)
+        let files = fs.readdirSync(outputDir)
           .filter(f => f.endsWith('.md') && f !== '.gitkeep');
+        if (projectSlug) {
+          files = files.filter(f => f.startsWith(projectSlug));
+        }
         let unreviewed = 0;
         for (const f of files) {
           const feedbackFile = f.replace('.md', '.feedback.yaml');

--- a/lib/ui/client-core.js
+++ b/lib/ui/client-core.js
@@ -253,7 +253,11 @@ async function runRespond() {
 // --- Tab badges ---
 async function loadBadges() {
   try {
-    const res = await fetch('/api/badges');
+    var badgeUrl = '/api/badges';
+    if (typeof currentSlug !== 'undefined' && currentSlug) {
+      badgeUrl += '?project=' + encodeURIComponent(currentSlug);
+    }
+    const res = await fetch(badgeUrl);
     const badges = await res.json();
     ['outputs', 'requests', 'todos'].forEach(function(tab) {
       const el = document.getElementById('badge-' + tab);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.4.18",
+  "version": "1.4.19",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/test/badges.test.js
+++ b/test/badges.test.js
@@ -126,6 +126,25 @@ describe('GET /api/badges', () => {
     assert.equal(data.requests, 1);
     assert.equal(data.todos, 1);
   });
+
+  it('filters outputs by project slug when ?project= is provided', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'output', 'proj-a-report1.md'), '# A1');
+    fs.writeFileSync(path.join(tmpDir, 'output', 'proj-a-report2.md'), '# A2');
+    fs.writeFileSync(path.join(tmpDir, 'output', 'proj-b-report1.md'), '# B1');
+    fs.writeFileSync(path.join(tmpDir, 'output', 'orphan.md'), '# Orphan');
+
+    // All unreviewed globally
+    const all = await fetchJSON(port, '/api/badges');
+    assert.equal(all.outputs, 4);
+
+    // Filter to proj-a
+    const projA = await fetchJSON(port, '/api/badges?project=proj-a');
+    assert.equal(projA.outputs, 2);
+
+    // Filter to proj-b
+    const projB = await fetchJSON(port, '/api/badges?project=proj-b');
+    assert.equal(projB.outputs, 1);
+  });
 });
 
 describe('GET /api/badges — disabled features', () => {


### PR DESCRIPTION
## Summary

- When a project is selected in the sidebar, the Outputs tab badge now shows the unreviewed count for that project only (not the global count)
- `GET /api/badges` accepts optional `?project=slug` param to filter output files by project slug prefix
- Falls back to global count when no project is selected
- 1 new test verifying project-scoped filtering

Refs #144