### PR TITLE
Fix stats overlay SyntaxError preventing portal load

### DIFF
--- a/lib/ui/client-core.js
+++ b/lib/ui/client-core.js
@@ -839,7 +839,7 @@ function showStats() {
   var navTiming = performance.getEntriesByType('navigation')[0];
   var html = '<div id="stats-overlay">';
   html += '<div class="stats-panel">';
-  html += '<div class="stats-header"><h3>Performance Stats</h3><button onclick="document.getElementById(\'stats-overlay\').remove()" class="stats-close">&times;</button></div>';
+  html += '<div class="stats-header"><h3>Performance Stats</h3><button onclick="document.getElementById(\\\'stats-overlay\\\').remove()" class="stats-close">&times;</button></div>';
 
   // Initial page load
   html += '<div class="stats-section"><h4>Page Load</h4>';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.4.20",
+  "version": "1.4.21",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -391,4 +391,23 @@ describe('buildHTML', () => {
     assert.ok(html.includes('init().then'), 'should wrap init() with .then for timing');
     assert.ok(html.includes('_perfStats.initialLoad'), 'should set initialLoad in init callback');
   });
+
+  it('generates syntactically valid JavaScript for simple sidebar', () => {
+    const html = buildHTML(baseConfig);
+    const scriptMatch = html.match(/<script>([\s\S]*?)<\/script>/);
+    assert.ok(scriptMatch, 'should contain a script tag');
+    assert.doesNotThrow(() => new Function(scriptMatch[1]), 'embedded JS must be syntactically valid');
+  });
+
+  it('generates syntactically valid JavaScript for projects sidebar', () => {
+    const config = {
+      ...baseConfig,
+      sidebar: { type: 'projects', runningLog: true },
+      features: { github: { repos: ['org/repo'] }, tabs: ['journal', 'github', 'project', 'status', 'outputs', 'requests', 'todos'] },
+    };
+    const html = buildHTML(config);
+    const scriptMatch = html.match(/<script>([\s\S]*?)<\/script>/);
+    assert.ok(scriptMatch, 'should contain a script tag');
+    assert.doesNotThrow(() => new Function(scriptMatch[1]), 'embedded JS must be syntactically valid');
+  });
 });


### PR DESCRIPTION
## Summary
- Fixed JS SyntaxError in `showStats()` function that prevented the entire portal from loading
- Root cause: `\'` inside a template literal was consumed by the template, producing bare single quotes that broke the string on line 842 of client-core.js
- Added 2 regression tests validating generated JS syntax for both simple and projects sidebar types

## Test plan
- [x] `node --check` on extracted script — passes (was failing before fix)
- [x] 260/260 tests pass (2 new syntax validation tests)
- [x] Verified generated HTML onclick handler renders correctly

Refs #154