### PR TITLE
Enable agent-coder access to dev-agent

### DIFF
--- a/agent-controller/agent-controller.yaml
+++ b/agent-controller/agent-controller.yaml
@@ -1,0 +1,45 @@
+# Agent Controller configuration
+#
+# Copy this file to agent-controller.yaml and edit for your setup.
+
+listen: 0.0.0.0:9090
+
+# Where agent directories live on the host
+agents_root: /Users/robhunter/code/agents
+
+# Where the framework lives on the host
+framework_dir: /Users/robhunter/code/agents/agent-portal
+
+# VestAuth caller identities
+# Each caller needs a vestauth keypair (run: vestauth agent init)
+# Register the UID and public JWK here.
+auth:
+  callers:
+    agentbox:
+      uid: "agent-5756aa30326fd115c21fa46b"
+      public_jwk: '{"crv":"Ed25519","x":"if7UOd_tqoBu4BL20Cz_zQptbjnYu5mH4o_Zo7NS94U","kty":"OKP","kid":"Zzu24YjuMOmNwxCXNLpb7rnNXYfu8cMbvZgEot5qcSE"}'
+    agent-coder:
+      uid: "agent-4a5f1d20a7b6d60bdd572417"
+      public_jwk: ''  # TODO: extract from agent-coder container: cat /root/.vestauth/identity.json
+
+# Agent stacks managed by this controller
+agents:
+  dev-agent:
+    dir: dev-agent
+    controllable: true
+    deployment: sandcat
+    permissions:
+      agentbox: [rebuild, restart, stop, start, logs, status, exec, cycle]
+      agent-coder: [rebuild, restart, stop, start, logs, status, exec, cycle]
+
+  bobbo:
+    dir: bobbo-agent
+    controllable: false
+
+  agent-coder:
+    dir: agent-coder
+    controllable: false
+
+  agent-pm:
+    dir: agent-pm
+    controllable: false

--- a/scripts/docker-compose-create.sh
+++ b/scripts/docker-compose-create.sh
@@ -160,6 +160,8 @@ services:
   agent:
     image: ubuntu:24.04
     network_mode: "service:wg-client"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - $AGENT_DIR:$CONTAINER_AGENT_DIR
       - $FRAMEWORK_DIR:$CONTAINER_FRAMEWORK_DIR


### PR DESCRIPTION
## Summary
- Add `extra_hosts: ["host.docker.internal:host-gateway"]` to the agent service in `docker-compose-create.sh` so Sandcat containers can reach the host network
- Register agent-coder's vestauth UID (`agent-4a5f1d20a7b6d60bdd572417`) in `agent-controller.yaml`
- Grant agent-coder full permissions on dev-agent (rebuild, restart, stop, start, logs, status, exec, cycle)

## Remaining manual steps
- Extract agent-coder's public JWK from the container (`cat /root/.vestauth/identity.json`) and add it to `agent-controller.yaml`
- Regenerate agent-coder's Sandcat stack (`docker-compose-create.sh`) to pick up the `extra_hosts` change
- Start the agent-controller: `cd agent-controller && npm start`

## Test plan
- [ ] Regenerate agent-coder stack and verify `host.docker.internal` resolves inside the container
- [ ] Verify agent-coder can reach agent-controller on port 9090
- [ ] Verify vestauth handshake succeeds with populated public_jwk

🤖 Generated with [Claude Code](https://claude.com/claude-code)