### PR TITLE
Symlink vestauth identity on container boot

### DIFF
--- a/sandcat/scripts/app-init.sh
+++ b/sandcat/scripts/app-init.sh
@@ -78,5 +78,11 @@ unset _f
 BASHRC_EOF
 fi
 
+# ── Symlink vestauth identity if present ──────────────────────────────────
+if [ -d "${AGENT_DIR}/.vestauth" ] && [ ! -e /root/.vestauth ]; then
+    ln -sfn "${AGENT_DIR}/.vestauth" /root/.vestauth
+    echo "Linked vestauth identity from ${AGENT_DIR}/.vestauth"
+fi
+
 # ── Delegate to the agent's existing start.sh ────────────────────────────
 exec bash "${AGENT_DIR}/scripts/start.sh"


### PR DESCRIPTION
## Summary
- On Sandcat container startup, symlink `$AGENT_DIR/.vestauth` to `/root/.vestauth` if it exists
- Survives stack regenerations since the agent directory is bind-mounted
- No-op for agents that don't have a `.vestauth/` directory

## Test plan
- [ ] Regenerate a stack for an agent with `.vestauth/identity.json` — verify `/root/.vestauth/identity.json` is accessible after boot
- [ ] Regenerate a stack for an agent without `.vestauth/` — verify no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)