### PR TITLE
Fix page load timeouts with response cache + lazy loading

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -70,13 +70,15 @@ function parseJournal(content) {
  * Read all monthly journal files (YYYY-MM.md) from a directory and return
  * combined entries sorted by timestamp.
  */
-function getAllJournalEntries(journalsDir) {
+function getAllJournalEntries(journalsDir, maxMonths) {
   const allEntries = [];
   try {
     const files = fs.readdirSync(journalsDir)
       .filter(f => /^\d{4}-\d{2}\.md$/.test(f))
       .sort();
-    for (const file of files) {
+    // If maxMonths specified, only read the most recent N months for performance
+    const filesToRead = maxMonths ? files.slice(-maxMonths) : files;
+    for (const file of filesToRead) {
       const content = fs.readFileSync(path.join(journalsDir, file), 'utf-8');
       const entries = parseJournal(content);
       allEntries.push(...entries);

--- a/lib/routes/events.js
+++ b/lib/routes/events.js
@@ -30,9 +30,10 @@ function register(routes, config) {
     }
 
     try {
-      const content = fs.readFileSync(eventsPath, 'utf-8').trim();
-      if (content) {
-        for (const line of content.split('\n')) {
+      // Read last 3000 lines instead of entire file — covers ~30 days of typical activity
+      const lines = readLastLines(eventsPath, 3000);
+      if (lines.length > 0) {
+        for (const line of lines) {
           try {
             const evt = JSON.parse(line);
             const evtDate = new Date(evt.ts);

--- a/lib/routes/journal.js
+++ b/lib/routes/journal.js
@@ -14,11 +14,13 @@ function register(routes, config) {
     const limit = Math.min(parseInt(url.searchParams.get('limit')) || 0, 200);
     const before = url.searchParams.get('before') || '';
 
-    const allEntries = getAllJournalEntries(journalsDir);
+    // Read only last 3 months by default for performance (cache + TTL handles the rest)
+    const allEntries = getAllJournalEntries(journalsDir, limit ? undefined : 3);
 
     if (!limit) {
-      // No pagination requested — return all (backwards compat)
-      return sendJSON(res, 200, { entries: allEntries });
+      // Default to last 100 entries for performance — clients can request more
+      const defaultEntries = allEntries.slice(-100);
+      return sendJSON(res, 200, { entries: defaultEntries, hasMore: allEntries.length > 100 });
     }
 
     // Filter entries before the cursor, then take the last `limit` entries

--- a/lib/server.js
+++ b/lib/server.js
@@ -5,6 +5,35 @@ const http = require('http');
 const fs = require('fs');
 const { sendJSON } = require('./helpers');
 
+// --- Response cache for GET /api/ routes ---
+// Short TTL cache to avoid redundant file I/O on rapid/parallel requests
+const CACHE_TTL_MS = 10000; // 10 seconds
+
+function createResponseCache() {
+  const store = {};
+
+  return {
+    get(key) {
+      const entry = store[key];
+      if (entry && (Date.now() - entry.ts) < CACHE_TTL_MS) {
+        return entry;
+      }
+      delete store[key];
+      return null;
+    },
+    set(key, statusCode, body) {
+      store[key] = { ts: Date.now(), statusCode, body };
+    },
+    invalidate(pathname) {
+      for (const key of Object.keys(store)) {
+        if (key.startsWith(pathname) || pathname.startsWith(key)) {
+          delete store[key];
+        }
+      }
+    },
+  };
+}
+
 /**
  * Create and configure the portal HTTP server.
  *
@@ -15,12 +44,43 @@ const { sendJSON } = require('./helpers');
  * @returns {http.Server}
  */
 function createServer(config, { routes, getHTML }) {
+  const cache = createResponseCache();
+
   const server = http.createServer(async (req, res) => {
     const url = new URL(req.url, `http://${req.headers.host}`);
     const pathname = url.pathname;
 
     // API routes
     if (pathname.startsWith('/api/')) {
+      // For mutating requests, invalidate related cache entries
+      if (req.method !== 'GET') {
+        cache.invalidate(pathname);
+      }
+
+      // For GET requests, check response cache
+      // Skip caching for lightweight/frequently-polled endpoints
+      const skipCache = pathname === '/api/badges' || pathname === '/api/status'
+        || pathname === '/api/next-run' || pathname === '/api/claude/status';
+      if (req.method === 'GET' && !skipCache) {
+        const cacheKey = pathname + url.search;
+        const cached = cache.get(cacheKey);
+        if (cached) {
+          res.writeHead(cached.statusCode, { 'Content-Type': 'application/json' });
+          res.end(cached.body);
+          return;
+        }
+
+        // Intercept sendJSON to capture response for caching
+        const origEnd = res.end.bind(res);
+        res.end = function(body) {
+          // Cache if writeHead was called with 2xx (check res.statusCode)
+          if (res.statusCode >= 200 && res.statusCode < 300 && typeof body === 'string') {
+            cache.set(cacheKey, res.statusCode, body);
+          }
+          return origEnd(body);
+        };
+      }
+
       const routeKey = `${req.method} ${pathname}`;
 
       // Exact match first

--- a/lib/ui/shell.js
+++ b/lib/ui/shell.js
@@ -186,10 +186,11 @@ function buildHTML(config) {
 }`;
   } else {
     initJS = `async function init() {
+  // Fire GitHub stats in background — don't block page render on gh CLI latency
+  if (PORTAL_CONFIG.hasGitHub) loadQuickStats();
   await Promise.all([
     updateStatusDot(),
     loadNextRun(),
-    loadQuickStats(),
     updateClaudeStatus(),
     loadBadges(),
   ]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "1.4.21",
       "license": "MIT",
       "dependencies": {
-        "js-yaml": "^4.1.0",
-        "vestauth": "^0.1.32"
+        "js-yaml": "^4.1.0"
       },
       "bin": {
         "agent-portal": "index.js"
@@ -19,102 +18,11 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@ecies/ciphers": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@ecies/ciphers/-/ciphers-0.2.5.tgz",
-      "integrity": "sha512-GalEZH4JgOMHYYcYmVqnFirFsjZHeoGMDt9IxEnM9F7GRUUyUksJ7Ou53L83WHJq3RWKD3AcBpo0iQh0oMpf8A==",
-      "license": "MIT",
-      "engines": {
-        "bun": ">=1",
-        "deno": ">=2",
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "@noble/ciphers": "^1.0.0"
-      }
-    },
-    "node_modules/@noble/ciphers": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/curves": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
-      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/secp256k1": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.2.tgz",
-      "integrity": "sha512-/qzwYl5eFLH8OWIecQWM31qld2g1NfjgylK+TNhqtaUKP37Nm+Y+z30Fjhw0Ct8p9yCQEm2N3W/AckdIb3SMcQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
-    },
-    "node_modules/commander": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/eciesjs": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.18.tgz",
-      "integrity": "sha512-wG99Zcfcys9fZux7Cft8BAX/YrOJLJSZ3jyYPfhZHqN2E+Ffx+QXBDsv3gubEgPtV6dTzJMSQUwk1H98/t/0wQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@ecies/ciphers": "^0.2.5",
-        "@noble/ciphers": "^1.3.0",
-        "@noble/curves": "^1.9.7",
-        "@noble/hashes": "^1.8.0"
-      },
-      "engines": {
-        "bun": ">=1",
-        "deno": ">=2",
-        "node": ">=16"
-      }
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -126,21 +34,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/vestauth": {
-      "version": "0.1.32",
-      "resolved": "https://registry.npmjs.org/vestauth/-/vestauth-0.1.32.tgz",
-      "integrity": "sha512-nP1kDj5d60nVHxRBE6cei+tTAbcZQSy/DzAG/g4Z657exotNxxYiPxuEoR/GXp4l3CxGAhapU/0GC7viVOHf3A==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@noble/hashes": "^1.8.0",
-        "@noble/secp256k1": "^1.7.2",
-        "commander": "^11.1.0",
-        "eciesjs": "^0.4.16"
-      },
-      "bin": {
-        "vestauth": "src/cli/vestauth.js"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.4.21",
+  "version": "1.4.22",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- **Server-side response cache** (10s TTL) for GET /api/ endpoints — prevents redundant file I/O on parallel/rapid requests. Per-server-instance, auto-invalidated on mutations. Lightweight endpoints excluded.
- **Non-blocking GitHub stats** — `loadQuickStats()` fires in background instead of blocking `Promise.all` during init. GitHub CLI latency (15s timeout × N repos) no longer gates page render.
- **Journal optimization** — default response limited to last 100 entries from last 3 months instead of reading ALL monthly journal files on every request.

v1.4.22

## Test plan
- [x] All 260 unit tests pass
- [x] All 16 shell tests pass (11 framework-update + 5 telegram-session)
- [ ] Verify on dev-agent: page loads render in sub-5s
- [ ] Verify journal tab still shows recent entries correctly
- [ ] Verify GitHub stats appear in sidebar after brief delay

Refs #163