### PR TITLE
Fix top nav overflow with horizontal scrolling

### DIFF
--- a/lib/ui/styles.js
+++ b/lib/ui/styles.js
@@ -35,8 +35,8 @@ function getStyles(authors) {
   #main { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
 
   /* Tabs */
-  #tabs { display: flex; background: #fff; border-bottom: 1px solid #ddd; padding: 0 24px; }
-  .tab { padding: 12px 20px; font-size: 14px; font-weight: 500; color: #666; cursor: pointer; border-bottom: 2px solid transparent; transition: all 0.15s; }
+  #tabs { display: flex; background: #fff; border-bottom: 1px solid #ddd; padding: 0 24px; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+  .tab { padding: 12px 20px; font-size: 14px; font-weight: 500; color: #666; cursor: pointer; border-bottom: 2px solid transparent; transition: all 0.15s; white-space: nowrap; flex-shrink: 0; }
   .tab:hover { color: #333; }
   .tab.active { color: #1a73e8; border-bottom-color: #1a73e8; }
   .tab { position: relative; }
@@ -218,8 +218,8 @@ ${authorCSS}
     #sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.15); }
     #sidebar-overlay.open { display: block; }
     #menu-btn { display: block; }
-    #tabs { padding: 0 8px; overflow-x: auto; -webkit-overflow-scrolling: touch; position: sticky; top: 0; }
-    .tab { padding: 10px 14px; font-size: 13px; white-space: nowrap; }
+    #tabs { padding: 0 8px; position: sticky; top: 0; }
+    .tab { padding: 10px 14px; font-size: 13px; }
     #content { padding: 16px; padding-bottom: 72px; }
     .journal-entry { padding: 10px 12px; }
     .journal-entry-header { font-size: 12px; gap: 6px; }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.4.22",
+  "version": "1.4.23",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Tab bar now scrolls horizontally when tabs overflow the container width
- Applied `overflow-x: auto`, `white-space: nowrap`, and `flex-shrink: 0` to all viewports (was previously mobile-only)
- Narrower screens or zoomed views can now access all tabs by scrolling

v1.4.23

## Test plan
- [x] 45/45 UI tests pass
- [ ] Verify on dev-agent portal: tabs visible at various zoom levels

Refs #162