### PR TITLE
Add Capabilities tab (MCP servers, scripts, skills, workspaces)

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,7 @@ require('./lib/routes/claude').register(routes, config);
 require('./lib/routes/uploads').register(routes, config);
 require('./lib/routes/todos').register(routes, config);
 require('./lib/routes/badges').register(routes, config);
+require('./lib/routes/capabilities').register(routes, config);
 
 // Build HTML page (cached — config doesn't change at runtime)
 let cachedHTML;

--- a/lib/routes/capabilities.js
+++ b/lib/routes/capabilities.js
@@ -1,0 +1,147 @@
+// routes/capabilities.js — /api/capabilities
+// Returns MCP servers, scripts/tools, and skills available to the agent
+
+const fs = require('fs');
+const path = require('path');
+const { sendJSON } = require('../helpers');
+
+function readMCPServers(agentDir, workspaces) {
+  const servers = [];
+
+  // Check agent dir for .mcp.json
+  const agentMcp = path.join(agentDir, '.mcp.json');
+  try {
+    if (fs.existsSync(agentMcp)) {
+      const data = JSON.parse(fs.readFileSync(agentMcp, 'utf-8'));
+      if (data.mcpServers) {
+        for (const [name, cfg] of Object.entries(data.mcpServers)) {
+          servers.push({ name, source: 'agent', ...cfg });
+        }
+      }
+    }
+  } catch {}
+
+  // Check each workspace for .mcp.json
+  if (Array.isArray(workspaces)) {
+    for (const ws of workspaces) {
+      const wsPath = ws.path || ws;
+      const wsMcp = path.join(wsPath, '.mcp.json');
+      try {
+        if (fs.existsSync(wsMcp)) {
+          const data = JSON.parse(fs.readFileSync(wsMcp, 'utf-8'));
+          if (data.mcpServers) {
+            for (const [name, cfg] of Object.entries(data.mcpServers)) {
+              // Avoid duplicates
+              if (!servers.some(s => s.name === name)) {
+                servers.push({ name, source: path.basename(wsPath), ...cfg });
+              }
+            }
+          }
+        }
+      } catch {}
+    }
+  }
+
+  return servers;
+}
+
+function readScripts(agentDir) {
+  const scripts = [];
+  const toolsDir = path.join(agentDir, 'tools');
+  try {
+    const files = fs.readdirSync(toolsDir).filter(f => !f.startsWith('.'));
+    for (const f of files) {
+      const filePath = path.join(toolsDir, f);
+      const stat = fs.statSync(filePath);
+      if (stat.isFile()) {
+        // Read first line for description (shebang or comment)
+        const content = fs.readFileSync(filePath, 'utf-8');
+        const lines = content.split('\n');
+        let description = '';
+        for (const line of lines.slice(0, 5)) {
+          if (line.startsWith('#') && !line.startsWith('#!')) {
+            description = line.replace(/^#+\s*/, '').trim();
+            break;
+          }
+        }
+        scripts.push({
+          name: f,
+          size: stat.size,
+          description,
+        });
+      }
+    }
+  } catch {}
+  return scripts;
+}
+
+function readSkills(agentDir) {
+  const skills = [];
+  const skillsDir = path.join(agentDir, 'skills');
+  try {
+    const files = fs.readdirSync(skillsDir).filter(f => f.endsWith('.md') && !f.startsWith('.'));
+    for (const f of files) {
+      const content = fs.readFileSync(path.join(skillsDir, f), 'utf-8');
+      const name = f.replace('.md', '').replace(/-/g, ' ');
+      // Extract first heading or "When to use" section
+      let description = '';
+      const headingMatch = content.match(/^# (.+)$/m);
+      if (headingMatch) {
+        description = headingMatch[1].replace(/^Skill:\s*/i, '').trim();
+      }
+      // Extract "When to use" content
+      let whenToUse = '';
+      const whenMatch = content.match(/## When to use\n([\s\S]*?)(?=\n##|\n$)/);
+      if (whenMatch) {
+        whenToUse = whenMatch[1].trim().split('\n').map(l => l.replace(/^- /, '').trim()).filter(Boolean).join('; ');
+      }
+      skills.push({ name, filename: f, description, whenToUse });
+    }
+  } catch {}
+  return skills;
+}
+
+function readWorkspaces(agentDir) {
+  const workspaces = [];
+  const agentYaml = path.join(agentDir, 'agent.yaml');
+  try {
+    if (fs.existsSync(agentYaml)) {
+      const content = fs.readFileSync(agentYaml, 'utf-8');
+      // Simple YAML parsing for workspaces array
+      const wsMatch = content.match(/^workspaces:\n((?:\s+-[\s\S]*?)(?=\n\w|\n$))/m);
+      if (wsMatch) {
+        const entries = wsMatch[1].split(/\n\s+-\s+/).filter(Boolean);
+        for (const entry of entries) {
+          const repoMatch = entry.match(/repo:\s*(.+)/);
+          const pathMatch = entry.match(/path:\s*(.+)/);
+          if (repoMatch) {
+            workspaces.push({
+              repo: repoMatch[1].trim(),
+              path: pathMatch ? pathMatch[1].trim() : '',
+            });
+          }
+        }
+      }
+    }
+  } catch {}
+  return workspaces;
+}
+
+function register(routes, config) {
+  // Always register — capabilities are discovered from agent directory
+
+  const agentDir = config.agentDir || '.';
+
+  routes['GET /api/capabilities'] = (req, res) => {
+    const workspaces = readWorkspaces(agentDir);
+    const data = {
+      mcpServers: readMCPServers(agentDir, workspaces),
+      scripts: readScripts(agentDir),
+      skills: readSkills(agentDir),
+      workspaces,
+    };
+    sendJSON(res, 200, data);
+  };
+}
+
+module.exports = { register };

--- a/lib/ui/shell.js
+++ b/lib/ui/shell.js
@@ -29,6 +29,7 @@ const { getHealthTabJS } = require('./tabs/health');
 const { getRequestsTabJS } = require('./tabs/requests');
 const { getOutputsTabJS } = require('./tabs/outputs');
 const { getTodosTabJS } = require('./tabs/todos');
+const { getCapabilitiesTabJS } = require('./tabs/capabilities');
 const { getProjectSidebarJS } = require('./sidebar-projects');
 const { getURLStateJS } = require('./url-state');
 
@@ -63,7 +64,7 @@ function buildHTML(config) {
   }
 
   // Determine which tabs to show
-  const defaultTabs = ['journal', 'status'];
+  const defaultTabs = ['journal', 'status', 'capabilities'];
   if (config.features && config.features.github) {
     defaultTabs.splice(1, 0, 'github');
   }
@@ -111,6 +112,11 @@ function buildHTML(config) {
   if (tabs.includes('todos')) {
     tabJS += getTodosTabJS();
     tabLoaderEntries.push(`todos: loadTodos`);
+  }
+
+  if (tabs.includes('capabilities')) {
+    tabJS += getCapabilitiesTabJS();
+    tabLoaderEntries.push(`capabilities: loadCapabilities`);
   }
 
   // Project sidebar support

--- a/lib/ui/tabs/capabilities.js
+++ b/lib/ui/tabs/capabilities.js
@@ -1,0 +1,100 @@
+// tabs/capabilities.js — Capabilities tab client-side JS
+// Renders MCP servers, scripts/tools, skills, and workspaces
+
+function getCapabilitiesTabJS() {
+  return `
+// --- Capabilities tab ---
+async function loadCapabilities() {
+  var contentEl = document.getElementById('content');
+  contentEl.innerHTML = '<div class="empty">Loading capabilities...</div>';
+  try {
+    var res = await fetch('/api/capabilities');
+    var data = await res.json();
+    var html = '<div style="max-width:800px">';
+
+    // MCP Servers
+    html += '<div class="status-section"><h2>MCP Servers</h2>';
+    if (!data.mcpServers || data.mcpServers.length === 0) {
+      html += '<div style="color:#999;font-size:14px;padding:8px 0">No MCP servers discovered.</div>';
+    } else {
+      data.mcpServers.forEach(function(srv) {
+        html += '<div class="status-card" style="display:flex;align-items:center;gap:12px">'
+          + '<div style="width:36px;height:36px;border-radius:8px;background:#e3f2fd;display:flex;align-items:center;justify-content:center;flex-shrink:0">'
+          + '<span style="font-size:16px">\\u2699</span></div>'
+          + '<div style="flex:1;min-width:0">'
+          + '<div style="font-weight:600;font-size:14px">' + escapeHtml(srv.name) + '</div>'
+          + (srv.url ? '<div style="font-size:12px;color:#888;font-family:monospace;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">' + escapeHtml(srv.url) + '</div>' : '')
+          + (srv.command ? '<div style="font-size:12px;color:#888;font-family:monospace">cmd: ' + escapeHtml(Array.isArray(srv.command) ? srv.command.join(' ') : srv.command) + '</div>' : '')
+          + '</div>'
+          + '<span style="font-size:11px;color:#888;background:#f5f5f5;padding:2px 8px;border-radius:8px;flex-shrink:0">' + escapeHtml(srv.source || 'local') + '</span>'
+          + '</div>';
+      });
+    }
+    html += '</div>';
+
+    // Scripts & Tools
+    html += '<div class="status-section"><h2>Scripts &amp; Tools</h2>';
+    if (!data.scripts || data.scripts.length === 0) {
+      html += '<div style="color:#999;font-size:14px;padding:8px 0">No scripts found in tools/.</div>';
+    } else {
+      data.scripts.forEach(function(s) {
+        html += '<div class="status-card" style="display:flex;align-items:center;gap:12px">'
+          + '<div style="width:36px;height:36px;border-radius:8px;background:#e8f5e9;display:flex;align-items:center;justify-content:center;flex-shrink:0">'
+          + '<span style="font-size:16px">\\u{1F4DC}</span></div>'
+          + '<div style="flex:1;min-width:0">'
+          + '<div style="font-weight:600;font-size:14px;font-family:monospace">' + escapeHtml(s.name) + '</div>'
+          + (s.description ? '<div style="font-size:13px;color:#555">' + escapeHtml(s.description) + '</div>' : '')
+          + '</div>'
+          + '<span style="font-size:11px;color:#888">' + (s.size < 1024 ? s.size + 'B' : Math.round(s.size / 1024) + 'KB') + '</span>'
+          + '</div>';
+      });
+    }
+    html += '</div>';
+
+    // Skills
+    html += '<div class="status-section"><h2>Skills</h2>';
+    if (!data.skills || data.skills.length === 0) {
+      html += '<div style="color:#999;font-size:14px;padding:8px 0">No skills found in skills/.</div>';
+    } else {
+      data.skills.forEach(function(sk) {
+        html += '<div class="status-card" style="display:flex;align-items:center;gap:12px">'
+          + '<div style="width:36px;height:36px;border-radius:8px;background:#f3e5f5;display:flex;align-items:center;justify-content:center;flex-shrink:0">'
+          + '<span style="font-size:16px">\\u{1F4A1}</span></div>'
+          + '<div style="flex:1;min-width:0">'
+          + '<div style="font-weight:600;font-size:14px">' + escapeHtml(sk.description || sk.name) + '</div>'
+          + (sk.whenToUse ? '<div style="font-size:13px;color:#555">' + escapeHtml(sk.whenToUse) + '</div>' : '')
+          + '<div style="font-size:11px;color:#aaa;margin-top:2px">' + escapeHtml(sk.filename) + '</div>'
+          + '</div>'
+          + '</div>';
+      });
+    }
+    html += '</div>';
+
+    // Workspaces
+    html += '<div class="status-section"><h2>Managed Workspaces</h2>';
+    if (!data.workspaces || data.workspaces.length === 0) {
+      html += '<div style="color:#999;font-size:14px;padding:8px 0">No workspaces configured in agent.yaml.</div>';
+    } else {
+      data.workspaces.forEach(function(ws) {
+        html += '<div class="status-card" style="display:flex;align-items:center;gap:12px">'
+          + '<div style="width:36px;height:36px;border-radius:8px;background:#fff3e0;display:flex;align-items:center;justify-content:center;flex-shrink:0">'
+          + '<span style="font-size:16px">\\u{1F4C2}</span></div>'
+          + '<div style="flex:1;min-width:0">'
+          + '<div style="font-weight:600;font-size:14px">' + escapeHtml(ws.repo) + '</div>'
+          + (ws.path ? '<div style="font-size:12px;color:#888;font-family:monospace">' + escapeHtml(ws.path) + '</div>' : '')
+          + '</div>'
+          + '</div>';
+      });
+    }
+    html += '</div>';
+
+    html += '</div>';
+    contentEl.innerHTML = html;
+  } catch (err) {
+    contentEl.innerHTML = '<div class="empty">Failed to load capabilities</div>';
+  }
+}
+`;
+}
+
+module.exports = { getCapabilitiesTabJS };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.4.23",
+  "version": "1.5.0",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/test/capabilities.test.js
+++ b/test/capabilities.test.js
@@ -1,0 +1,115 @@
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { createServer } = require('../lib/server');
+
+function createCapabilitiesServer(tmpDir) {
+  const config = {
+    name: 'Test',
+    port: 0,
+    agentDir: tmpDir,
+    _serverStartTime: Date.now(),
+    authors: {},
+    features: {
+      tabs: ['journal', 'status', 'capabilities'],
+    },
+  };
+
+  const routes = {};
+  require('../lib/routes/capabilities').register(routes, config);
+  return { server: createServer(config, { routes, getHTML: () => '<html>test</html>' }), config };
+}
+
+async function fetchJSON(port, urlPath) {
+  const res = await fetch(`http://localhost:${port}${urlPath}`);
+  return res.json();
+}
+
+describe('GET /api/capabilities', () => {
+  let tmpDir, server, port;
+
+  before(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'capabilities-test-'));
+
+    // Create tools directory with a script
+    fs.mkdirSync(path.join(tmpDir, 'tools'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'tools', 'helper.sh'), '#!/bin/bash\n# My helper script\necho hello');
+
+    // Create skills directory with a skill
+    fs.mkdirSync(path.join(tmpDir, 'skills'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'skills', 'test-skill.md'),
+      '# Skill: Test Skill\n\n## When to use\n- Testing things\n- Verifying results\n\n## Steps\n1. Do the thing\n');
+
+    // Create .mcp.json
+    fs.writeFileSync(path.join(tmpDir, '.mcp.json'), JSON.stringify({
+      mcpServers: {
+        'test-server': { url: 'https://example.com/mcp' },
+      },
+    }));
+
+    // Create agent.yaml with workspaces
+    fs.writeFileSync(path.join(tmpDir, 'agent.yaml'),
+      'name: test-agent\nworkspaces:\n  - repo: owner/repo1\n    path: /tmp/repo1\n  - repo: owner/repo2\n    path: /tmp/repo2\n');
+
+    const { server: s } = createCapabilitiesServer(tmpDir);
+    server = s;
+    await new Promise(resolve => server.listen(0, resolve));
+    port = server.address().port;
+  });
+
+  after(async () => {
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns MCP servers from .mcp.json', async () => {
+    const data = await fetchJSON(port, '/api/capabilities');
+    assert.ok(Array.isArray(data.mcpServers));
+    assert.equal(data.mcpServers.length, 1);
+    assert.equal(data.mcpServers[0].name, 'test-server');
+    assert.equal(data.mcpServers[0].url, 'https://example.com/mcp');
+  });
+
+  it('returns scripts from tools/', async () => {
+    const data = await fetchJSON(port, '/api/capabilities');
+    assert.ok(Array.isArray(data.scripts));
+    assert.equal(data.scripts.length, 1);
+    assert.equal(data.scripts[0].name, 'helper.sh');
+    assert.equal(data.scripts[0].description, 'My helper script');
+  });
+
+  it('returns skills from skills/', async () => {
+    const data = await fetchJSON(port, '/api/capabilities');
+    assert.ok(Array.isArray(data.skills));
+    assert.equal(data.skills.length, 1);
+    assert.equal(data.skills[0].description, 'Test Skill');
+    assert.ok(data.skills[0].whenToUse.includes('Testing things'));
+  });
+
+  it('returns workspaces from agent.yaml', async () => {
+    const data = await fetchJSON(port, '/api/capabilities');
+    assert.ok(Array.isArray(data.workspaces));
+    assert.equal(data.workspaces.length, 2);
+    assert.equal(data.workspaces[0].repo, 'owner/repo1');
+    assert.equal(data.workspaces[1].repo, 'owner/repo2');
+  });
+
+  it('handles empty directories gracefully', async () => {
+    // Create a server with an empty agent dir
+    const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cap-empty-'));
+    const { server: s2 } = createCapabilitiesServer(emptyDir);
+    await new Promise(resolve => s2.listen(0, resolve));
+    const port2 = s2.address().port;
+
+    const data = await fetchJSON(port2, '/api/capabilities');
+    assert.deepEqual(data.mcpServers, []);
+    assert.deepEqual(data.scripts, []);
+    assert.deepEqual(data.skills, []);
+    assert.deepEqual(data.workspaces, []);
+
+    s2.close();
+    fs.rmSync(emptyDir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- New **Capabilities** tab that auto-discovers and displays agent capabilities
- **MCP Servers**: reads `.mcp.json` from agent dir and workspace dirs
- **Scripts & Tools**: lists files in `tools/` with descriptions parsed from comments
- **Skills**: parses `skills/*.md` with "When to use" section extraction
- **Managed Workspaces**: parses `agent.yaml` workspaces array
- Default-on: included in default tabs list, route always registered
- Read-only — no manual triggers, as requested

v1.5.0

## Test plan
- [x] 265/265 tests pass (5 new capabilities tests)
- [x] E2E verified: discovers 1 MCP server, 1 script, 1 skill, 3 workspaces from real agent-coder dir
- [ ] Verify on dev-agent portal after rebuild

Refs #161