### PR TITLE
Track Claude auth confirmation timestamp

### DIFF
--- a/lib/routes/status.js
+++ b/lib/routes/status.js
@@ -50,6 +50,17 @@ function register(routes, config) {
       status.lastWake = null;
     }
 
+    // Last auth confirmed
+    try {
+      const authFile = path.join(logsDir, '.auth-last-confirmed');
+      const ts = fs.readFileSync(authFile, 'utf-8').trim();
+      const confirmed = new Date(ts);
+      const hoursAgo = Math.round((Date.now() - confirmed.getTime()) / 3600000 * 10) / 10;
+      status.lastAuthConfirmed = { ts, hoursAgo };
+    } catch {
+      status.lastAuthConfirmed = null;
+    }
+
     // Git info
     try {
       const head = execSync('git rev-parse --short HEAD', { cwd: agentDir, encoding: 'utf-8', timeout: 5000 }).trim();

--- a/lib/ui/client-core.js
+++ b/lib/ui/client-core.js
@@ -805,6 +805,21 @@ async function loadStatus() {
       + '<div class="value">Loading...</div>'
       + '</div>';
 
+    // Last auth confirmed
+    var authHtml = '';
+    if (status.lastAuthConfirmed) {
+      var h = status.lastAuthConfirmed.hoursAgo;
+      var authColor = h < 8 ? '#2e7d32' : h < 24 ? '#f9a825' : '#c62828';
+      authHtml = '<span style="color:' + authColor + '">' + formatTimestamp(status.lastAuthConfirmed.ts) + '</span>'
+        + ' <span style="color:#999">(' + h + 'h ago)</span>';
+    } else {
+      authHtml = '<span style="color:#999">Never confirmed</span>';
+    }
+    html += '<div class="status-card">'
+      + '<div class="label">Last Auth Confirmed</div>'
+      + '<div class="value">' + authHtml + '</div>'
+      + '</div>';
+
     html += '</div>';
 
     contentEl.innerHTML = html;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/scripts/wake.sh
+++ b/scripts/wake.sh
@@ -227,6 +227,17 @@ fi
 bash "$FRAMEWORK_DIR/scripts/run-hooks.sh" "$FRAMEWORK_DIR" "$AGENT_DIR" pre-cycle
 step "pre-cycle hooks done"
 
+# ── CLAUDE AUTH CHECK ──
+
+# Record auth confirmation timestamp (non-fatal)
+AUTH_CONFIRMED_FILE="$AGENT_DIR/logs/.auth-last-confirmed"
+if claude auth status --json 2>/dev/null | grep -q '"loggedIn": *true'; then
+  date -Iseconds > "$AUTH_CONFIRMED_FILE" 2>/dev/null || true
+  step "claude auth confirmed"
+else
+  step "claude auth NOT confirmed"
+fi
+
 # ── CLAUDE INVOCATION ──
 
 # Close lock fd before piping to Claude to prevent fd leak into child processes


### PR DESCRIPTION
## Summary

- Record Claude auth status each cycle via `claude auth status --json` in wake.sh
- Write timestamp to `logs/.auth-last-confirmed` when auth is confirmed
- Expose `lastAuthConfirmed` in `/api/status` with `ts` and `hoursAgo` fields
- Show in portal Status tab with color coding: green (<8h), yellow (8-24h), red (>24h), grey (never)
- v1.5.1

Refs #164

## Test plan

- [x] 265/265 tests pass
- [x] Auth timestamp file written on successful auth check
- [x] `/api/status` returns `lastAuthConfirmed` or null
- [x] Status tab shows colored timestamp with hours-ago