### PR TITLE
fix: capabilities tab default-on for all agents

### DIFF
--- a/lib/ui/shell.js
+++ b/lib/ui/shell.js
@@ -69,6 +69,10 @@ function buildHTML(config) {
     defaultTabs.splice(1, 0, 'github');
   }
   const tabs = (config.features && config.features.tabs) || defaultTabs;
+  // Capabilities is default-on for all agents — inject if not already present
+  if (!tabs.includes('capabilities')) {
+    tabs.push('capabilities');
+  }
 
   // Build tab HTML (with badge placeholder spans for outputs, requests, todos)
   const badgeTabs = ['outputs', 'requests', 'todos'];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/test/web-portal.test.js
+++ b/test/web-portal.test.js
@@ -197,7 +197,7 @@ describe('web portal — config injection', () => {
     const configMatch = html.match(/const PORTAL_CONFIG = ({[^;]+})/);
     assert.ok(configMatch, 'PORTAL_CONFIG should be present in HTML');
     const portalConfig = JSON.parse(configMatch[1]);
-    assert.deepEqual(portalConfig.tabs, ['journal', 'github', 'status']);
+    assert.deepEqual(portalConfig.tabs, ['journal', 'github', 'status', 'capabilities']);
     assert.equal(portalConfig.name, 'TestAgent');
     assert.equal(portalConfig.hasGitHub, true);
     assert.deepEqual(portalConfig.githubRepos, ['org/repo']);
@@ -232,5 +232,6 @@ describe('web portal — config injection', () => {
     assert.ok(html.includes('github: loadGitHub'), 'TAB_LOADERS should map github');
     assert.ok(html.includes('outputs: loadOutputs'), 'TAB_LOADERS should map outputs');
     assert.ok(html.includes('todos: loadTodos'), 'TAB_LOADERS should map todos');
+    assert.ok(html.includes('capabilities: loadCapabilities'), 'TAB_LOADERS should map capabilities (default-on)');
   });
 });


### PR DESCRIPTION
## Summary
- Capabilities tab now always appears for all agents, even those with explicit `features.tabs` configs
- Previously, PM and Bobbo agents defined their own tab lists that predated the capabilities tab addition, so they never got it
- After resolving tabs from config, capabilities is injected if not already present

## Changes
- `lib/ui/shell.js`: Add capabilities injection after tab resolution
- `test/web-portal.test.js`: Update assertions for new default-on behavior
- Version bump to v1.5.2

## Test plan
- [x] 265/265 tests pass
- [ ] Verify PM portal shows Capabilities tab after deploy

Refs #161