### PR TITLE
Fix flaky cycle/run and cycle/respond tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -405,16 +405,22 @@ describe('POST /api/cron/toggle', () => {
 
 describe('POST /api/cycle/run', () => {
   let server, port;
+  const lockFile = '/tmp/test-portal-lock-nonexistent-cycle';
 
   before(async () => {
     // Use a lock file that won't exist (so lock check says "not running")
-    const result = createTestServer({ lockFile: '/tmp/test-portal-lock-nonexistent-cycle' });
+    // Clean up stale markers from previous runs
+    try { fs.unlinkSync(lockFile + '.starting'); } catch {}
+    const result = createTestServer({ lockFile });
     server = result.server;
     await new Promise(resolve => server.listen(0, resolve));
     port = server.address().port;
   });
 
-  after(() => server.close());
+  after(() => {
+    server.close();
+    try { fs.unlinkSync(lockFile + '.starting'); } catch {}
+  });
 
   it('returns 200 when no cycle is running (wake.sh may not exist but spawn succeeds)', async () => {
     const { status, data } = await fetchJSON(port, '/api/cycle/run', {
@@ -428,15 +434,21 @@ describe('POST /api/cycle/run', () => {
 
 describe('POST /api/cycle/respond', () => {
   let server, port;
+  const lockFile = '/tmp/test-portal-lock-nonexistent-respond';
 
   before(async () => {
-    const result = createTestServer({ lockFile: '/tmp/test-portal-lock-nonexistent-respond' });
+    // Clean up stale markers from previous runs
+    try { fs.unlinkSync(lockFile + '.starting'); } catch {}
+    const result = createTestServer({ lockFile });
     server = result.server;
     await new Promise(resolve => server.listen(0, resolve));
     port = server.address().port;
   });
 
-  after(() => server.close());
+  after(() => {
+    server.close();
+    try { fs.unlinkSync(lockFile + '.starting'); } catch {}
+  });
 
   it('returns 200 when no cycle is running (respond.sh resolved from framework)', async () => {
     const { status, data } = await fetchJSON(port, '/api/cycle/respond', {


### PR DESCRIPTION
## Summary

Fixes intermittent test failures where `POST /api/cycle/run` and `POST /api/cycle/respond` tests would return 409 instead of 200.

**Root cause:** Both tests create `.starting` marker files (via the route handler) but never cleaned them up. When tests ran again within 30 seconds (the marker TTL in `isCycleLocked()`), the stale markers caused the lock check to return true, blocking the request with 409.

**Fix:** Clean up `.starting` marker files in both `before()` (for stale markers from previous runs) and `after()` (for markers created during the test) hooks.

Bump to v1.5.3.

## Test plan

- [x] 265/265 tests pass
- [x] Verified fix by running tests twice in quick succession (both pass)
- [x] Previously reproduced the failure by running tests back-to-back