### PR TITLE
Add Tailscale serve management to docker-compose-create.sh

### DIFF
--- a/scripts/docker-compose-create.sh
+++ b/scripts/docker-compose-create.sh
@@ -183,6 +183,18 @@ COMPOSEOF
 
 echo "  Compose file:        $STACK_DIR/docker-compose.yml"
 
+# ── Tailscale serve management ───────────────────────────────────────────
+# If tailscale is installed, manage HTTPS serve for the agent's portal port.
+# Disable before teardown (port conflict), re-enable after stack is healthy.
+# Fails silently if tailscale is not installed or not configured.
+HAS_TAILSCALE=false
+if command -v tailscale >/dev/null 2>&1; then
+    HAS_TAILSCALE=true
+    echo ""
+    echo "Disabling Tailscale serve on port $AGENT_PORT..."
+    sudo tailscale serve --https="$AGENT_PORT" off 2>/dev/null || true
+fi
+
 # ── Stop existing containers ──────────────────────────────────────────────
 # Stop any existing single-container setup (pre-Sandcat)
 if docker ps -a --format '{{.Names}}' | grep -q "^${AGENT_NAME}$"; then
@@ -251,6 +263,14 @@ echo "Restarting agent service for clean boot..."
 $COMPOSE restart agent
 
 sleep 3
+
+# ── Re-enable Tailscale serve ────────────────────────────────────────────
+if [ "$HAS_TAILSCALE" = true ]; then
+    echo "Re-enabling Tailscale serve on port $AGENT_PORT..."
+    sudo tailscale serve --bg --https="$AGENT_PORT" "http://localhost:$AGENT_PORT" 2>/dev/null || {
+        echo "Warning: Failed to re-enable Tailscale serve (continuing)" >&2
+    }
+fi
 
 # ── Done ──────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary
- Before stack teardown: `sudo tailscale serve --https=<port> off`
- After stack is healthy: `sudo tailscale serve --bg --https=<port> http://localhost:<port>`
- Silently skipped if `tailscale` is not installed on the host
- Requires passwordless sudoers entry for `tailscale` (see Flenderson README for setup)

## Test plan
- [x] 368/368 agent-portal tests passing
- [ ] Rebuild an agent on a machine with Tailscale — verify serve is disabled before teardown and re-enabled after
- [ ] Run on a machine without Tailscale — verify no errors, stack creates normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)