### PR TITLE
Fix back stack navigation for simple sidebar

### DIFF
--- a/lib/ui/client-core.js
+++ b/lib/ui/client-core.js
@@ -28,6 +28,7 @@ window.fetch = function() {
 };
 
 let currentTab = PORTAL_CONFIG.tabs[0] || 'journal';
+let suppressPushState = false;
 
 function toggleSidebar() {
   document.getElementById('sidebar').classList.toggle('open');
@@ -328,7 +329,12 @@ function switchTab(tab) {
   // Clear file param when switching away from outputs
   if (tab !== 'outputs') params.delete('file');
   var qs = params.toString();
-  history.replaceState(null, '', qs ? '?' + qs : window.location.pathname);
+  var url = qs ? '?' + qs : window.location.pathname;
+  if (suppressPushState) {
+    history.replaceState({ tab: tab }, '', url);
+  } else {
+    history.pushState({ tab: tab }, '', url);
+  }
 
   const loader = TAB_LOADERS[tab];
   if (loader) {

--- a/lib/ui/shell.js
+++ b/lib/ui/shell.js
@@ -211,12 +211,39 @@ function buildHTML(config) {
   if (urlTab && PORTAL_CONFIG.tabs.indexOf(urlTab) !== -1) {
     currentTab = urlTab;
   }
+  // Suppress pushState during init to avoid polluting history
+  suppressPushState = true;
   switchTab(currentTab);
   // If deep-linked to a specific output file, open it
   if (urlFile && currentTab === 'outputs' && typeof viewOutput === 'function') {
     viewOutput(urlFile);
   }
-}`;
+  suppressPushState = false;
+  // Replace initial state so popstate has data to work with
+  history.replaceState({ tab: currentTab, file: urlFile || null }, '', window.location.href);
+}
+
+// Handle browser back/forward for simple sidebar navigation
+window.addEventListener('popstate', function(e) {
+  suppressPushState = true;
+  var state = e.state || {};
+  var tab = state.tab;
+  var file = state.file;
+  // Fallback: read from URL if state is missing
+  if (!tab) {
+    var params = new URLSearchParams(window.location.search);
+    tab = params.get('tab') || PORTAL_CONFIG.tabs[0] || 'journal';
+    file = params.get('file');
+  }
+  if (tab && PORTAL_CONFIG.tabs.indexOf(tab) !== -1) {
+    currentTab = tab;
+    switchTab(currentTab);
+    if (file && currentTab === 'outputs' && typeof viewOutput === 'function') {
+      viewOutput(file);
+    }
+  }
+  suppressPushState = false;
+});`;
   }
 
   const portalConfig = {

--- a/lib/ui/tabs/outputs.js
+++ b/lib/ui/tabs/outputs.js
@@ -174,7 +174,7 @@ async function loadOutputs() {
   if (params.has('file')) {
     params.delete('file');
     var qs = params.toString();
-    history.replaceState(null, '', qs ? '?' + qs : window.location.pathname);
+    history.replaceState({ tab: 'outputs' }, '', qs ? '?' + qs : window.location.pathname);
   }
   const slug = typeof currentSlug !== 'undefined' ? currentSlug : null;
   const url = slug ? '/api/projects/' + encodeURIComponent(slug) + '/outputs' : '/api/outputs';
@@ -219,7 +219,12 @@ async function viewOutput(filename) {
   var params = new URLSearchParams(window.location.search);
   params.set('tab', 'outputs');
   params.set('file', filename);
-  history.replaceState(null, '', '?' + params.toString());
+  var outputUrl = '?' + params.toString();
+  if (typeof suppressPushState !== 'undefined' && suppressPushState) {
+    history.replaceState({ tab: 'outputs', file: filename }, '', outputUrl);
+  } else {
+    history.pushState({ tab: 'outputs', file: filename }, '', outputUrl);
+  }
   const contentEl = document.getElementById('content');
   contentEl.innerHTML = '<div class="empty">Loading output...</div>';
   try {

--- a/lib/ui/url-state.js
+++ b/lib/ui/url-state.js
@@ -7,7 +7,7 @@
  */
 function getURLStateJS() {
   return `
-let suppressPushState = false;
+// suppressPushState is declared in client-core.js
 
 function pushURLState() {
   if (suppressPushState) return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Switches from `history.replaceState()` to `history.pushState()` for tab switches and output detail navigation in the simple sidebar, so each navigation creates a browser history entry
- Adds a `popstate` event listener for simple sidebar to restore the correct tab and output view on browser back/forward
- Suppresses pushState during initial page load to avoid polluting history on deep-link or refresh
- Bumps version to 1.5.8

## Details
Previously, all simple sidebar navigation used `replaceState`, meaning the browser only had one history entry. Navigating agent home → outputs tab → output detail → back would skip all the way past the agent page instead of stepping back through outputs list first.

Now each `switchTab()` and `viewOutput()` call pushes a history entry, and the `popstate` handler reads the saved state (with URL param fallback) to restore the correct view.

The project sidebar's `url-state.js` already handled this correctly via its own `pushURLState()` and `popstate` listener. This change brings the same behavior to simple sidebar agents. The shared `suppressPushState` flag in `client-core.js` is now used by both sidebar types.

## Test plan
- [x] 292 tests pass (no regressions)
- [ ] Manual: Navigate to simple sidebar agent → switch tabs → press back → verify correct tab restored
- [ ] Manual: Navigate to outputs tab → click output file → press back → verify outputs list shown
- [ ] Manual: Verify deep-linking still works (e.g. `?tab=outputs&file=foo.md`)
- [ ] Manual: Verify project sidebar back/forward navigation still works

Refs #186