### PR TITLE
Reverse todos notes chronologically with infinite scroll

### DIFF
--- a/lib/ui/tabs/todos.js
+++ b/lib/ui/tabs/todos.js
@@ -82,13 +82,16 @@ async function loadTodos() {
 
     html += '</div>';
 
-    // Notes section
+    // Notes section — reverse chronological, first 5 visible, rest behind infinite scroll
+    var reversedNotes = notes.slice().reverse();
     html += '<div class="status-section"><h2>Notes</h2>';
-    if (notes.length === 0) {
+    if (reversedNotes.length === 0) {
       html += '<div style="color:#999;font-size:14px;padding:8px 0">No notes yet.</div>';
     } else {
-      html += '<div class="journal-thread">';
-      notes.forEach(function(n) {
+      html += '<div class="journal-thread" id="notes-thread">';
+      var initialCount = Math.min(5, reversedNotes.length);
+      for (var i = 0; i < initialCount; i++) {
+        var n = reversedNotes[i];
         html += '<div class="journal-entry author-' + escapeHtml(n.author) + '">'
           + '<div class="journal-entry-header">'
           + '<span class="author-badge ' + escapeHtml(n.author) + '">' + escapeHtml(n.author) + '</span>'
@@ -97,8 +100,13 @@ async function loadTodos() {
           + '</div>'
           + '<div class="journal-entry-body md-content">' + marked.parse(n.content) + '</div>'
           + '</div>';
-      });
+      }
+      if (reversedNotes.length > 5) {
+        html += '<div id="notes-load-sentinel" style="text-align:center;padding:12px;color:#999;font-size:13px">Scroll for older notes...</div>';
+      }
       html += '</div>';
+      // Store remaining notes for infinite scroll
+      window._remainingNotes = reversedNotes.slice(5);
     }
 
     // Add note form
@@ -113,6 +121,39 @@ async function loadTodos() {
 
     contentEl.innerHTML = html;
     contentEl.scrollTop = 0;
+
+    // Set up infinite scroll for notes
+    var sentinel = document.getElementById('notes-load-sentinel');
+    if (sentinel && window._remainingNotes && window._remainingNotes.length > 0) {
+      var batchSize = 5;
+      var observer = new IntersectionObserver(function(entries) {
+        if (!entries[0].isIntersecting) return;
+        var thread = document.getElementById('notes-thread');
+        if (!thread || !window._remainingNotes || window._remainingNotes.length === 0) {
+          observer.disconnect();
+          if (sentinel) sentinel.remove();
+          return;
+        }
+        var batch = window._remainingNotes.splice(0, batchSize);
+        var frag = '';
+        batch.forEach(function(n) {
+          frag += '<div class="journal-entry author-' + escapeHtml(n.author) + '">'
+            + '<div class="journal-entry-header">'
+            + '<span class="author-badge ' + escapeHtml(n.author) + '">' + escapeHtml(n.author) + '</span>'
+            + '<span class="tag-badge tag-' + escapeHtml(n.tag) + '">' + escapeHtml(n.tag) + '</span>'
+            + '<span class="timestamp">' + formatTimestamp(n.ts) + '</span>'
+            + '</div>'
+            + '<div class="journal-entry-body md-content">' + marked.parse(n.content) + '</div>'
+            + '</div>';
+        });
+        sentinel.insertAdjacentHTML('beforebegin', frag);
+        if (window._remainingNotes.length === 0) {
+          observer.disconnect();
+          sentinel.remove();
+        }
+      }, { rootMargin: '200px' });
+      observer.observe(sentinel);
+    }
   } catch (err) {
     contentEl.innerHTML = '<div class="empty">Failed to load todos</div>';
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/test/web-portal.test.js
+++ b/test/web-portal.test.js
@@ -90,6 +90,18 @@ describe('web portal — tab JS content integrity', () => {
     assert.ok(html.includes('/api/todos'), 'Todos tab should fetch /api/todos');
   });
 
+  it('todos notes render in reverse chronological order with infinite scroll', () => {
+    const config = {
+      name: 'TestAgent',
+      authors: {},
+      features: { tabs: ['journal', 'todos', 'status'] },
+    };
+    const html = buildHTML(config);
+    assert.ok(html.includes('.slice().reverse()'), 'Notes should be reversed for newest-first');
+    assert.ok(html.includes('notes-load-sentinel'), 'Should have infinite scroll sentinel');
+    assert.ok(html.includes('IntersectionObserver'), 'Should use IntersectionObserver for lazy loading');
+  });
+
   it('outputs tab JS references correct API endpoints', () => {
     const config = {
       name: 'TestAgent',


### PR DESCRIPTION
## Summary
- Notes section now displays in reverse chronological order (newest first)
- Only the first 5 notes render initially; older notes lazy-load via IntersectionObserver as the user scrolls
- 1 new test verifying reverse order, scroll sentinel, and observer setup
- Version bump to v1.5.9

Refs #188