### PR TITLE
Skip secret substitution for disallowed hosts instead of blocking

### DIFF
--- a/sandcat/scripts/mitmproxy_addon.py
+++ b/sandcat/scripts/mitmproxy_addon.py
@@ -164,17 +164,14 @@ class SandcatAddon:
             if not present:
                 continue
 
-            # Leak detection: block if secret going to disallowed host
+            # Skip substitution if secret is not allowed for this host.
+            # The placeholder (not the real value) stays in the request,
+            # which is harmless — e.g. it may appear in LLM prompt context.
             if not any(fnmatch(host, pattern) for pattern in allowed_hosts):
-                flow.response = http.Response.make(
-                    403,
-                    f"Blocked: secret {name!r} not allowed for host {host!r}\n".encode(),
-                    {"Content-Type": "text/plain"},
+                ctx.log.debug(
+                    f"Skipping secret {name!r} substitution for host {host!r} (not in allowed hosts)"
                 )
-                ctx.log.warn(
-                    f"Blocked secret {name!r} leak to disallowed host {host!r}"
-                )
-                return
+                continue
 
             value_bytes = value.encode()
 

--- a/sandcat/scripts/test_mitmproxy_addon.py
+++ b/sandcat/scripts/test_mitmproxy_addon.py
@@ -273,15 +273,16 @@ class TestSecretSubstitution:
         assert flow.response is None
         assert "real-secret-value" not in flow.request.url
 
-    def test_leak_detection_blocks_disallowed_host(self):
+    def test_skips_substitution_for_disallowed_host(self):
         addon = self._make_addon_with_secrets()
         flow = _make_flow(
             host="evil.com",
             headers={"Authorization": "Bearer SANDCAT_PLACEHOLDER_API_KEY"},
         )
         addon.request(flow)
-        assert flow.response is not None
-        assert flow.response["status"] == 403
+        assert flow.response is None  # request not blocked
+        # Placeholder left as-is (real value NOT substituted)
+        assert b"SANDCAT_PLACEHOLDER_API_KEY" in dict(flow.request.headers.fields)[b"Authorization"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- When a secret placeholder appears in a request to a host not in the secret's allowlist, the addon now **skips substitution** instead of **blocking the entire request with a 403**
- The placeholder string is not the real secret — it's harmless to leave in the request body (e.g. when it appears in LLM prompt context sent to `api.anthropic.com`)
- This fixes agent-pm's 11am cycle crash caused by `LASTPASS_MASTER_PASSWORD` placeholder appearing in Anthropic API calls

## Test plan
- [x] Updated `test_skips_substitution_for_disallowed_host` to verify request passes through with placeholder intact
- [x] 36/37 tests pass (1 pre-existing failure in `test_placeholder_replaced_in_url` — unrelated mock issue)
- [ ] After merge: `git pull` agent-portal on host, restart agent-pm's mitmproxy container, verify next PM cycle succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)