### PR TITLE
Fix broken URL substitution test mock

### DIFF
--- a/sandcat/scripts/test_mitmproxy_addon.py
+++ b/sandcat/scripts/test_mitmproxy_addon.py
@@ -86,6 +86,7 @@ class _Request:
         self.method = method
         self.pretty_host = host
         self.url = url
+        self.path = "/" + url.split("/", 3)[-1] if url.count("/") >= 3 else "/"
         self.headers = _Headers(headers or {})
         self.content = content
 
@@ -264,7 +265,8 @@ class TestSecretSubstitution:
         )
         addon.request(flow)
         assert flow.response is None
-        assert "real-secret-value" in flow.request.url
+        # Addon substitutes in .path (not .url) to avoid mitmproxy host header bug
+        assert "real-secret-value" in flow.request.path
 
     def test_no_op_when_placeholder_absent(self):
         addon = self._make_addon_with_secrets()


### PR DESCRIPTION
## Summary
- The `_Request` test mock was missing the `path` attribute, causing `test_placeholder_replaced_in_url` to crash with `AttributeError` on every run
- The test assertion also checked `.url` but the addon intentionally substitutes in `.path` (to avoid the mitmproxy host header bug in wireguard mode) — fixed to match actual behavior

## Test plan
- [x] 37/37 Python tests pass (was 36/37)
- [x] 293/293 Node tests pass (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)