### PR TITLE
Add CI workflow for Node and Python tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  node-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - run: npm install
+      - run: node --test test/*.test.js
+
+  python-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: pip install pytest mitmproxy
+      - run: pytest sandcat/scripts/test_mitmproxy_addon.py -v


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that runs both test suites (Node + Python) on pull requests to main
- After merging, enable branch protection: Settings > Branches > Add rule for `main` > "Require status checks to pass" > select `node-tests` and `python-tests`

## Test plan
- [ ] Merge this PR
- [ ] Verify workflow appears in Actions tab
- [ ] Open a test PR to confirm both checks run
- [ ] Enable branch protection with required status checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)