### PR TITLE
Add Playwright browser tools to PM agent allowedTools

### DIFF
--- a/scripts/wake.sh
+++ b/scripts/wake.sh
@@ -258,6 +258,17 @@ while [ "$CLAUDE_EXIT" -ne 0 ] && [ "$RETRY" -lt "$MAX_RETRIES" ]; do
 
   cat "$WAKE_PROMPT_FILE" 200>&- | claude --print \
     --allowedTools "Bash" "Edit" "Write" "Read" "Glob" "Grep" "WebSearch" "WebFetch" \
+    "mcp__playwright__browser_click" "mcp__playwright__browser_close" \
+    "mcp__playwright__browser_console_messages" "mcp__playwright__browser_drag" \
+    "mcp__playwright__browser_evaluate" "mcp__playwright__browser_file_upload" \
+    "mcp__playwright__browser_fill_form" "mcp__playwright__browser_handle_dialog" \
+    "mcp__playwright__browser_hover" "mcp__playwright__browser_navigate" \
+    "mcp__playwright__browser_navigate_back" "mcp__playwright__browser_network_requests" \
+    "mcp__playwright__browser_press_key" "mcp__playwright__browser_resize" \
+    "mcp__playwright__browser_run_code" "mcp__playwright__browser_select_option" \
+    "mcp__playwright__browser_snapshot" "mcp__playwright__browser_tabs" \
+    "mcp__playwright__browser_take_screenshot" "mcp__playwright__browser_type" \
+    "mcp__playwright__browser_wait_for" \
     200>&- 2>&1 | tee 200>&- "$CYCLE_LOG"
   CLAUDE_EXIT=${PIPESTATUS[1]}
 


### PR DESCRIPTION
## Summary
- Adds all 21 `mcp__playwright__browser_*` tools individually to the `--allowedTools` list in `wake.sh`
- Uses Option B (specific tools) per Rob's directive — no wildcards
- Unblocks PM agent from using Playwright for web form interactions, affiliate signups, and email access

## Context
Rob approved this in the April 14 journal entry. The Playwright MCP server was already configured in `.mcp.json` but tools were blocked because `wake.sh` had a hardcoded allowlist that didn't include them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)