### PR TITLE
Add live journal updates via polling

### DIFF
--- a/lib/routes/journal.js
+++ b/lib/routes/journal.js
@@ -13,9 +13,16 @@ function register(routes, config) {
     const url = new URL(req.url, 'http://localhost');
     const limit = Math.min(parseInt(url.searchParams.get('limit')) || 0, 200);
     const before = url.searchParams.get('before') || '';
+    const after = url.searchParams.get('after') || '';
 
     // Read only last 3 months by default for performance (cache + TTL handles the rest)
     const allEntries = getAllJournalEntries(journalsDir, limit ? undefined : 3);
+
+    if (after) {
+      const afterDate = new Date(after);
+      const newEntries = allEntries.filter(e => new Date(e.ts) > afterDate);
+      return sendJSON(res, 200, { entries: newEntries, hasMore: false });
+    }
 
     if (!limit) {
       // Default to last 100 entries for performance — clients can request more

--- a/lib/routes/projects.js
+++ b/lib/routes/projects.js
@@ -100,7 +100,15 @@ function register(routes, config) {
       return sendJSON(res, 200, { slug, entries: [] });
     }
     const content = fs.readFileSync(journalPath, 'utf-8');
-    const entries = parseJournal(content);
+    let entries = parseJournal(content);
+
+    const url = new URL(req.url, 'http://localhost');
+    const after = url.searchParams.get('after') || '';
+    if (after) {
+      const afterDate = new Date(after);
+      entries = entries.filter(e => new Date(e.ts) > afterDate);
+    }
+
     sendJSON(res, 200, { slug, entries });
   };
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -82,7 +82,8 @@ function createServer(config, { routes, getHTML }) {
       // For GET requests, check response cache
       // Skip caching for lightweight/frequently-polled endpoints
       const skipCache = pathname === '/api/badges' || pathname === '/api/status'
-        || pathname === '/api/next-run' || pathname === '/api/claude/status';
+        || pathname === '/api/next-run' || pathname === '/api/claude/status'
+        || (url.searchParams.has('after') && (pathname === '/api/journal' || pathname.endsWith('/journal')));
       if (req.method === 'GET' && !skipCache) {
         const cacheKey = pathname + url.search;
         const cached = cache.get(cacheKey);

--- a/lib/ui/client-core.js
+++ b/lib/ui/client-core.js
@@ -315,6 +315,7 @@ async function loadQuickStats() {
 
 // --- Tabs ---
 function switchTab(tab) {
+  _stopJournalPoll();
   currentTab = tab;
   document.querySelectorAll('.tab').forEach(function(t) {
     t.classList.toggle('active', t.dataset.tab === tab);
@@ -420,9 +421,71 @@ async function loadJournal() {
     fixOutputLinks(contentEl);
     contentEl.scrollTop = contentEl.scrollHeight;
     _setupJournalScrollObserver();
+    _startJournalPoll();
   } catch (err) {
     contentEl.innerHTML = '<div class="empty">Failed to load journal</div>';
   }
+}
+
+var _journalPollTimer = null;
+var _journalPollInterval = 10000;
+
+function _startJournalPoll() {
+  _stopJournalPoll();
+  _journalPollTimer = setInterval(_pollForNewEntries, _journalPollInterval);
+}
+
+function _stopJournalPoll() {
+  if (_journalPollTimer) { clearInterval(_journalPollTimer); _journalPollTimer = null; }
+}
+
+async function _pollForNewEntries() {
+  if (!_journalEntries || _journalEntries.length === 0) return;
+  var newest = _journalEntries[_journalEntries.length - 1].ts;
+  try {
+    var pollUrl = '/api/journal?after=' + encodeURIComponent(newest);
+    if (typeof currentSlug !== 'undefined' && currentSlug) {
+      pollUrl = '/api/projects/' + encodeURIComponent(currentSlug) + '/journal?after=' + encodeURIComponent(newest);
+    }
+    var res = await fetch(pollUrl);
+    var data = await res.json();
+    var newEntries = data.entries || [];
+    if (newEntries.length === 0) return;
+
+    var thread = document.querySelector('.journal-thread');
+    if (!thread) return;
+
+    var startIdx = _journalEntries.length;
+    _journalEntries = _journalEntries.concat(newEntries);
+
+    var html = '';
+    newEntries.forEach(function(e, i) {
+      html += renderJournalEntry(e, startIdx + i);
+    });
+
+    var addNote = document.getElementById('add-note');
+    if (addNote) {
+      thread.insertBefore(_htmlToFragment(html), null);
+    } else {
+      thread.insertAdjacentHTML('beforeend', html);
+    }
+
+    fixOutputLinks(thread);
+
+    var contentEl = document.getElementById('content');
+    var isNearBottom = contentEl.scrollHeight - contentEl.scrollTop - contentEl.clientHeight < 150;
+    if (isNearBottom) {
+      contentEl.scrollTop = contentEl.scrollHeight;
+    }
+  } catch {}
+}
+
+function _htmlToFragment(html) {
+  var temp = document.createElement('div');
+  temp.innerHTML = html;
+  var frag = document.createDocumentFragment();
+  while (temp.firstChild) frag.appendChild(temp.firstChild);
+  return frag;
 }
 
 var _journalObserver = null;

--- a/lib/ui/sidebar-projects.js
+++ b/lib/ui/sidebar-projects.js
@@ -111,6 +111,7 @@ async function selectBobboLog() {
     contentEl.innerHTML = html;
     fixOutputLinks(contentEl);
     contentEl.scrollTop = contentEl.scrollHeight;
+    _startJournalPoll();
   } catch {
     contentEl.innerHTML = '<div class="empty">Failed to load running log</div>';
   }
@@ -191,6 +192,7 @@ async function loadProjectJournal() {
     contentEl.innerHTML = html;
     fixOutputLinks(contentEl);
     contentEl.scrollTop = contentEl.scrollHeight;
+    _startJournalPoll();
   } catch {
     contentEl.innerHTML = '<div class="empty">Failed to load journal</div>';
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary

- Journal views now auto-refresh every 10 seconds without full page reload
- New entries are appended to the DOM incrementally with auto-scroll when user is near bottom
- Added `?after=<timestamp>` parameter to both `/api/journal` and `/api/projects/:slug/journal` endpoints
- Polling requests bypass the response cache for guaranteed freshness
- Polling starts when journal tab loads, stops on tab switch (no wasted requests)
- Works for all journal views: main journal tab, cross-project running log, and per-project journals

Refs #190

## Test plan

- [x] 293 tests pass (no regressions)
- [x] Verified `?after=` parameter returns correct entries via direct API test
- [x] Verified all polling functions are correctly embedded in generated client JS
- [x] Verified cache skip logic for polling requests