### PR TITLE
Fix telegram responsive cycle: add allowedTools, Sandcat env, and logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-portal",
-  "version": "1.4.21",
+  "version": "1.5.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-portal",
-      "version": "1.4.21",
+      "version": "1.5.11",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.5.10",
+  "version": "1.5.11",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/scripts/telegram-respond.sh
+++ b/scripts/telegram-respond.sh
@@ -14,7 +14,13 @@ cd "$AGENT_DIR"
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
 
-# Source .env
+# Source sandcat profile scripts if available (Sandcat containers inject
+# env vars via /etc/profile.d/ but cron doesn't inherit them)
+for _f in /etc/profile.d/sandcat-*.sh; do
+  [ -r "$_f" ] && . "$_f"
+done
+
+# Source .env if present (pre-Sandcat containers use .env for secrets)
 if [ -f "$AGENT_DIR/.env" ]; then
   set -a; . "$AGENT_DIR/.env"; set +a
 fi
@@ -37,6 +43,11 @@ RECENT_CONVO=$(tail -20 logs/conversation.jsonl | jq -r '"[\(.role)] \(.text)"')
 
 # Log cycle start
 bash "$FRAMEWORK_DIR/scripts/log-event.sh" "$AGENT_DIR" responsive_cycle "Telegram message received"
+
+# Cycle logging (matching wake.sh pattern)
+CYCLE_TS="$(date +%Y%m%d-%H%M)"
+CYCLE_LOG="logs/cycles/${CYCLE_TS}-respond.log"
+mkdir -p logs/cycles
 
 echo "Running claude..."
 
@@ -83,6 +94,7 @@ fi
 
 run_claude() {
   echo "$FULL_PROMPT" | claude --print \
+    --allowedTools "Bash" "Edit" "Write" "Read" "Glob" "Grep" "WebSearch" "WebFetch" \
     "$@" \
     2>>logs/respond_errors.log
 }
@@ -106,6 +118,9 @@ else
   CLAUDE_EXIT=$?
 fi
 set -e
+
+# Write response to cycle log
+echo "$RESPONSE" > "$CYCLE_LOG"
 
 if [ "$CLAUDE_EXIT" -ne 0 ]; then
   echo "Claude exited with code $CLAUDE_EXIT"


### PR DESCRIPTION
## Summary

- **Add `--allowedTools`** to the `claude --print` invocation in `telegram-respond.sh` — this was missing entirely, which meant agents had no tool permissions when responding to Telegram messages (`wake.sh` has always had this)
- **Add Sandcat profile sourcing** (`/etc/profile.d/sandcat-*.sh`) before `.env` sourcing, matching the pattern in `wake.sh` — ensures secrets are available in Sandcat deployments
- **Add cycle logging** — writes Claude's response to `logs/cycles/<timestamp>-respond.log` for debugging parity with autonomous cycles

## Root cause

`telegram-respond.sh` invoked `claude --print` without `--allowedTools`. In non-interactive mode, Claude cannot get user approval for tool use, so all tools (Bash, Write, Edit, Read, etc.) were effectively blocked. This caused agents to complain they couldn't write files or access GitHub when responding to Telegram messages.

## Test plan

- [x] Existing `test/telegram-session.test.sh` passes (5/5)
- [ ] Send a Telegram message to an agent requesting an action (e.g. "update my priorities") and verify it can now use tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)