### PR TITLE
Test: comment-only recipe block (sandcat PR flow check)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,48 @@
 #!/usr/bin/env node
 // index.js — Agent portal entry point
 // Usage: agent-portal <config.json>
+//
+// ============================================================================
+// Test PR — comment-only change to verify sandcat-paradigm PR flow.
+// Content: recipe highlights from dinners-recipes-batch12-2026-04-14.md
+// (Bobbo's latest dinner recommendations).
+// ----------------------------------------------------------------------------
+// 1. Indonesian Chicken Satay with Peanut Sauce (RecipeTin Eats, 4.97/5)
+//    - Cuisine: Indonesian (new to rotation) | Gas grill | 35 min + marinate
+//    - ~330 cal / 40g protein per serving (~4 skewers + sauce)
+//    - Heartburn note: bird's-eye chilies omitted; sauce flavor stands without
+//      heat via coconut milk, peanut butter, kecap manis, lime.
+//    - Why: Indonesian cuisine was completely untouched; peanut sauce flavor
+//      profile unlike anything currently in rotation.
+//
+// 2. Cedar Plank Salmon (Feasting At Home, 5/5)
+//    - Cuisine: Pacific Northwest | Gas grill + cedar plank | 30 min + soak
+//    - 192 cal / 25g protein — leanest recipe in the batch
+//    - Heartburn note: zero spice heat; lemon zest + thyme only.
+//    - Why: Rob already cooks salmon regularly but always oven/stovetop.
+//      Cedar plank grilling is a genuinely new technique producing a
+//      fundamentally different smoky, woodsy, moist result.
+//
+// 3. Cajun Garlic Butter Shrimp (The Recipe Critic, 4.75/5)
+//    - Cuisine: Cajun/Southern (new) | Skillet | 10 min — fastest of any batch
+//    - 263 cal / 24g protein
+//    - Heartburn note: use mild cajun seasoning (paprika-forward, low
+//      cayenne); at 1 tsp for 4 servings the heat is negligible.
+//    - Why: Shrimp was the most underrepresented protein across 35 prior
+//      recommendations; soy-brown-sugar-mustard-garlic echoes the Korean
+//      pork HIT flavor building blocks.
+//
+// Batch summary:
+//   - New cuisines: Indonesian, Cajun/Southern
+//   - Proteins: Chicken, salmon, shrimp (broadest spread in any batch)
+//   - Equipment: Gas grill ×2, skillet ×1
+//   - All heartburn-safe, all bell-pepper-free
+//
+// Sources:
+//   - https://www.recipetineats.com/satay-chicken-with-peanut-sauce/
+//   - https://www.feastingathome.com/cedar-plank-salmon/
+//   - https://therecipecritic.com/cajun-garlic-butter-shrimp/
+// ============================================================================
 
 const fs = require('fs');
 const path = require('path');


### PR DESCRIPTION
## Summary

Comment-only change to verify the sandcat-paradigm PR flow works end-to-end. No functional changes.

Adds a block comment at the top of `index.js` with details from the latest dinner recipe batch (batch 12, 2026-04-14):

- **Indonesian Chicken Satay with Peanut Sauce** — new cuisine, gas grill, 4.97/5
- **Cedar Plank Salmon** — new technique on familiar protein, 5/5
- **Cajun Garlic Butter Shrimp** — new cuisine, 10-min skillet, 4.75/5

Each entry includes calories, protein, heartburn notes, rationale, and source URL.

## Test plan

- [ ] Confirm PR renders in GitHub
- [ ] Close (do not merge) — this is a flow test only

🤖 Generated with [Claude Code](https://claude.com/claude-code)