### PR TITLE
Add --effort max to all Claude Code invocations (#200)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/scripts/consolidate-memory.sh
+++ b/scripts/consolidate-memory.sh
@@ -173,7 +173,7 @@ PROMPT_EOF
 # Unset CLAUDECODE to allow running from post-cycle hooks (where the parent
 # Claude session has already exited but the env var may linger)
 echo "Invoking claude -p for consolidation..."
-RESULT=$(unset CLAUDECODE; claude -p --max-turns 1 < "$PROMPT_FILE" 2>/dev/null) || {
+RESULT=$(unset CLAUDECODE; claude -p --effort max --max-turns 1 < "$PROMPT_FILE" 2>/dev/null) || {
   echo "Error: claude -p failed"
   exit 1
 }

--- a/scripts/respond.sh
+++ b/scripts/respond.sh
@@ -88,7 +88,7 @@ while [ "$CLAUDE_EXIT" -ne 0 ] && [ "$RETRY" -lt "$MAX_RETRIES" ]; do
   fi
 
   set +e
-  cat "$PROMPT_FILE" | claude --print \
+  cat "$PROMPT_FILE" | claude --print --effort max \
     --allowedTools "Bash" "Read" "Write" "Edit" "Glob" "Grep" "WebSearch" "WebFetch" \
     2>&1 | tee "$CYCLE_LOG"
   CLAUDE_EXIT=${PIPESTATUS[1]}

--- a/scripts/telegram-respond.sh
+++ b/scripts/telegram-respond.sh
@@ -93,7 +93,7 @@ if [ -z "$SESSION_ARGS" ]; then
 fi
 
 run_claude() {
-  echo "$FULL_PROMPT" | claude --print \
+  echo "$FULL_PROMPT" | claude --print --effort max \
     --allowedTools "Bash" "Edit" "Write" "Read" "Glob" "Grep" "WebSearch" "WebFetch" \
     "$@" \
     2>>logs/respond_errors.log

--- a/scripts/wake.sh
+++ b/scripts/wake.sh
@@ -256,7 +256,7 @@ while [ "$CLAUDE_EXIT" -ne 0 ] && [ "$RETRY" -lt "$MAX_RETRIES" ]; do
     sleep 30
   fi
 
-  cat "$WAKE_PROMPT_FILE" 200>&- | claude --print \
+  cat "$WAKE_PROMPT_FILE" 200>&- | claude --print --effort max \
     --allowedTools "Bash" "Edit" "Write" "Read" "Glob" "Grep" "WebSearch" "WebFetch" \
     "mcp__playwright__browser_click" "mcp__playwright__browser_close" \
     "mcp__playwright__browser_console_messages" "mcp__playwright__browser_drag" \


### PR DESCRIPTION
## Summary

Per issue #200, hardcode `--effort max` on every `claude` invocation in the portal. Four call sites updated:

- `scripts/wake.sh` — scheduled work cycles (the primary agent runtime)
- `scripts/respond.sh` — portal "ask" feature (web UI prompts)
- `scripts/telegram-respond.sh` — responsive cycles triggered via Telegram
- `scripts/consolidate-memory.sh` — nightly memory consolidation (Haiku-backed utility)

Version bumped to **1.5.12**.

## Flag details

`claude --help` lists `--effort <level>` with valid values `low, medium, high, xhigh, max`. Placing the flag immediately after `--print` / `-p` preserves the existing argv shape so hook parsing and retry logic aren't affected.

## Configurability

Hardcoded for now, per issue — "we'll consider updating in the future if we want this configurable." No config surface added; the flag is literal in each script.

## Verification

- `node --test test/*.test.js` → 293/293 pass.
- `bash -n` on all four scripts → clean.
- Smoke test: `echo "hello" | claude --print --effort max --max-turns 1` → returned a normal response, so the flag is accepted by the installed CLI in the container.
- `git diff` → 5 files changed, 5/5 insertions (single flag added per script + version bump).

Refs #200