### PR TITLE
Phase 0B-1: Library route + content item fixtures

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,7 @@ require('./lib/routes/deploy').register(routes, config);
 require('./lib/routes/harness').register(routes, config);
 require('./lib/routes/uploads').register(routes, config);
 require('./lib/routes/todos').register(routes, config);
+require('./lib/routes/library').register(routes, config);
 require('./lib/routes/badges').register(routes, config);
 require('./lib/routes/capabilities').register(routes, config);
 require('./lib/routes/tts').register(routes, config);

--- a/lib/routes/library.js
+++ b/lib/routes/library.js
@@ -1,0 +1,153 @@
+// routes/library.js — Content library listing, detail, and feedback routes
+// Registered when features.library is configured
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const { sendJSON, readBody } = require('../helpers');
+
+function getLibraryItems(agentDir, dataDir) {
+  const itemsDir = path.join(agentDir, dataDir);
+  const feedbackDir = path.join(agentDir, 'input', 'feedback');
+  try {
+    const files = fs.readdirSync(itemsDir)
+      .filter(f => f.endsWith('.yaml') || f.endsWith('.yml'));
+    return files.map(f => {
+      try {
+        const content = fs.readFileSync(path.join(itemsDir, f), 'utf-8');
+        const item = yaml.load(content);
+        // Join with feedback
+        const feedbackFile = (item.id || f.replace(/\.ya?ml$/, '')) + '.feedback.yaml';
+        const feedbackPath = path.join(feedbackDir, feedbackFile);
+        let rating = null;
+        let reviewed = false;
+        if (fs.existsSync(feedbackPath)) {
+          reviewed = true;
+          const fb = fs.readFileSync(feedbackPath, 'utf-8');
+          const match = fb.match(/^rating:\s*(\S+)/m);
+          if (match) rating = match[1];
+        }
+        return {
+          id: item.id || f.replace(/\.ya?ml$/, ''),
+          title: item.title,
+          category: item.category,
+          format: item.format,
+          source: item.source,
+          source_url: item.source_url,
+          status: item.status,
+          discovered: item.discovered,
+          cover_url: (item.metadata && item.metadata.cover_url) || null,
+          rating,
+          reviewed,
+          _file: f,
+        };
+      } catch {
+        return null;
+      }
+    }).filter(Boolean).sort((a, b) => {
+      const da = a.discovered ? new Date(a.discovered) : new Date(0);
+      const db = b.discovered ? new Date(b.discovered) : new Date(0);
+      return db - da;
+    });
+  } catch {
+    return [];
+  }
+}
+
+function register(routes, config) {
+  const libraryConfig = config.features && config.features.library;
+  if (!libraryConfig) return;
+
+  const agentDir = config.agentDir || '.';
+  const dataDir = (typeof libraryConfig === 'object' && libraryConfig.dataDir) || 'content/items';
+  const feedbackDir = path.join(agentDir, 'input', 'feedback');
+
+  // GET /api/library — list all content items with feedback status
+  routes['GET /api/library'] = (req, res) => {
+    sendJSON(res, 200, getLibraryItems(agentDir, dataDir));
+  };
+
+  // GET /api/library/:id — single item detail with full metadata
+  routes['GET /api/library/:id'] = (req, res) => {
+    const id = req.params.id;
+    if (id.includes('/') || id.includes('\\') || id.includes('..')) {
+      return sendJSON(res, 400, { error: 'Invalid id' });
+    }
+    const itemsDir = path.join(agentDir, dataDir);
+    // Try both .yaml and .yml
+    let filePath = path.join(itemsDir, id + '.yaml');
+    if (!fs.existsSync(filePath)) {
+      filePath = path.join(itemsDir, id + '.yml');
+    }
+    if (!fs.existsSync(filePath)) {
+      return sendJSON(res, 404, { error: 'Not found' });
+    }
+    try {
+      const content = fs.readFileSync(filePath, 'utf-8');
+      const item = yaml.load(content);
+      // Merge feedback
+      const feedbackFile = id + '.feedback.yaml';
+      const feedbackPath = path.join(feedbackDir, feedbackFile);
+      if (fs.existsSync(feedbackPath)) {
+        const fbContent = fs.readFileSync(feedbackPath, 'utf-8');
+        item.feedback = yaml.load(fbContent);
+      }
+      sendJSON(res, 200, item);
+    } catch {
+      sendJSON(res, 500, { error: 'Failed to read item' });
+    }
+  };
+
+  // POST /api/feedback/library/:id — submit feedback for a content item
+  // Follows the same pattern as POST /api/feedback/:filename in outputs.js
+  routes['POST /api/feedback/library/:id'] = (req, res) => {
+    const id = req.params.id;
+    if (id.includes('/') || id.includes('\\') || id.includes('..')) {
+      return sendJSON(res, 400, { error: 'Invalid id' });
+    }
+
+    readBody(req).then(body => {
+      try {
+        const data = JSON.parse(body);
+        const ratingStr = data.rating; // "up" or "down"
+        if (ratingStr && ratingStr !== 'up' && ratingStr !== 'down') {
+          return sendJSON(res, 400, { error: 'Rating must be "up" or "down"' });
+        }
+        const notes = (data.notes || '').trim();
+        if (!ratingStr && !notes) {
+          return sendJSON(res, 400, { error: 'Provide a rating and/or notes' });
+        }
+
+        if (!fs.existsSync(feedbackDir)) {
+          fs.mkdirSync(feedbackDir, { recursive: true });
+        }
+
+        const feedbackFile = id + '.feedback.yaml';
+        const feedbackPath = path.join(feedbackDir, feedbackFile);
+        const now = new Date().toISOString();
+        let yamlStr = `item: ${id}\nreviewed_at: ${now}\n`;
+        if (ratingStr) yamlStr += `rating: ${ratingStr}\n`;
+        if (notes) {
+          yamlStr += `notes: |\n${notes.split('\n').map(l => '  ' + l).join('\n')}\n`;
+        }
+        fs.writeFileSync(feedbackPath, yamlStr);
+        sendJSON(res, 200, { ok: true, file: feedbackFile });
+      } catch {
+        sendJSON(res, 400, { error: 'Invalid JSON' });
+      }
+    });
+  };
+
+  // GET /api/library/recent — items discovered in the last 24 hours
+  routes['GET /api/library/recent'] = (req, res) => {
+    const items = getLibraryItems(agentDir, dataDir);
+    const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const recent = items.filter(item => {
+      if (!item.discovered) return false;
+      return new Date(item.discovered) > cutoff;
+    });
+    sendJSON(res, 200, recent);
+  };
+}
+
+module.exports = { register, getLibraryItems };

--- a/test/fixtures/config/sources.yaml
+++ b/test/fixtures/config/sources.yaml
@@ -1,0 +1,37 @@
+sources:
+  - id: archive-org
+    name: Archive.org
+    url: https://archive.org
+    type: downloadable
+    status: approved
+    categories: [books, audiobooks]
+  - id: audible
+    name: Audible
+    url: https://www.audible.com
+    type: link-only
+    status: approved
+    categories: [audiobooks]
+  - id: youtube
+    name: YouTube
+    url: https://youtube.com
+    type: link-only
+    status: approved
+    categories: [short-form-video]
+  - id: dcui
+    name: DC Universe Infinite
+    url: https://www.dcuniverseinfinite.com
+    type: link-only
+    status: approved
+    categories: [comics]
+  - id: globalcomix
+    name: GlobalComix
+    url: https://globalcomix.com
+    type: downloadable
+    status: approved
+    categories: [comics]
+  - id: shady-torrents
+    name: ShadyTorrents.example
+    url: https://shadytorrents.example.com
+    type: torrent
+    status: pending
+    categories: [movies, books]

--- a/test/fixtures/content/items/1929-sorkin.yaml
+++ b/test/fixtures/content/items/1929-sorkin.yaml
@@ -1,0 +1,23 @@
+id: 1929-sorkin
+title: "1929"
+category: audiobooks
+format: audiobook
+source: audible
+source_url: https://www.audible.com/pd/1929-Audiobook/B0DXQH752D
+status: linked
+discovered: 2026-02-13T16:00:00Z
+reasoning: "Author of Too Big to Fail. Narrative retelling of the 1929 crash. Author-narrated. Exactly the Character Limit format."
+metadata:
+  author: Andrew Ross Sorkin
+  year: 2025
+  narrator: Andrew Ross Sorkin
+  tags: [nonfiction, narrative, finance, history]
+  cover_url: https://covers.openlibrary.org/b/id/14829084-L.jpg
+  description: "A narrative retelling of the 1929 Wall Street crash through the people who lived it."
+sources:
+  - name: Audible
+    url: https://www.audible.com/pd/1929-Audiobook/B0DXQH752D
+    type: link-only
+  - name: Libro.fm
+    url: https://libro.fm/audiobooks/9780593912089-1929
+    type: link-only

--- a/test/fixtures/content/items/bobiverse-taylor.yaml
+++ b/test/fixtures/content/items/bobiverse-taylor.yaml
@@ -1,0 +1,26 @@
+id: bobiverse-taylor
+title: "We Are Legion (We Are Bob)"
+category: audiobooks
+format: m4b
+source: audible
+source_url: https://www.audible.com/pd/We-Are-Legion-We-Are-Bob-Audiobook/B01L082HJ2
+status: linked
+discovered: 2026-02-15T08:00:00Z
+reasoning: "A software engineer uploaded into a Von Neumann probe — the ultimate competent-protagonist-solves-problems story. Funny and smart."
+metadata:
+  author: Dennis E. Taylor
+  narrator: Ray Porter
+  year: 2016
+  tags: [sci-fi, humor, space-exploration, ai]
+  cover_url: https://covers.openlibrary.org/b/id/8547639-L.jpg
+  description: "Bob Johansson becomes an AI space probe and sets off to explore the galaxy."
+sources:
+  - name: Audible
+    url: https://www.audible.com/pd/We-Are-Legion-We-Are-Bob-Audiobook/B01L082HJ2
+    type: link-only
+  - name: Libro.fm
+    url: https://libro.fm/audiobooks/9781494374587
+    type: link-only
+  - name: Libby
+    url: https://share.libbyapp.com/title/2768528
+    type: link-only

--- a/test/fixtures/content/items/challenger-higginbotham.yaml
+++ b/test/fixtures/content/items/challenger-higginbotham.yaml
@@ -1,0 +1,26 @@
+id: challenger-higginbotham
+title: "Challenger"
+category: audiobooks
+format: audiobook
+source: audible
+source_url: https://www.audible.com/pd/Challenger-Audiobook/B0CQ3126JT
+status: linked
+discovered: 2026-02-18T09:00:00Z
+reasoning: "Minute-by-minute Challenger disaster reconstruction. Engineering disaster investigation — exactly the single-event deeply-researched format that lands for you."
+metadata:
+  author: Adam Higginbotham
+  year: 2024
+  narrator: Jacques Roy
+  length: "17h 25m"
+  tags: [nonfiction, engineering, disaster, space, nasa]
+  description: "A minute-by-minute reconstruction of the 1986 Challenger disaster."
+sources:
+  - name: Audible
+    url: https://www.audible.com/pd/Challenger-Audiobook/B0CQ3126JT
+    type: link-only
+  - name: Libro.fm
+    url: https://libro.fm/audiobooks/9781797179483-challenger
+    type: link-only
+  - name: Kobo
+    url: https://www.kobo.com/us/en/audiobook/challenger-19
+    type: link-only

--- a/test/fixtures/content/items/children-of-time-tchaikovsky.yaml
+++ b/test/fixtures/content/items/children-of-time-tchaikovsky.yaml
@@ -1,0 +1,22 @@
+id: children-of-time-tchaikovsky
+title: "Children of Time"
+category: books
+format: epub
+source: archive-org
+source_url: https://archive.org/details/childrenoftime0000tcha_k7z6
+status: linked
+discovered: 2026-02-13T14:30:00Z
+reasoning: "Hard sci-fi about evolved spider intelligence. Won the Arthur C. Clarke Award. Deep worldbuilding, genuinely alien perspectives."
+metadata:
+  author: Adrian Tchaikovsky
+  year: 2015
+  tags: [sci-fi, evolution, space, hard-sci-fi]
+  cover_url: https://covers.openlibrary.org/b/id/8091016-L.jpg
+  description: "Humanity's last ark ship finds a planet where spiders have evolved intelligence."
+sources:
+  - name: Archive.org
+    url: https://archive.org/details/childrenoftime0000tcha_k7z6
+    type: downloadable
+  - name: Kobo
+    url: https://www.kobo.com/us/en/ebook/children-of-time-6
+    type: link-only

--- a/test/fixtures/content/items/dark-matter-crouch.yaml
+++ b/test/fixtures/content/items/dark-matter-crouch.yaml
@@ -1,0 +1,25 @@
+id: dark-matter-crouch
+title: "Dark Matter"
+category: books
+format: epub
+source: archive-org
+source_url: https://archive.org/details/darkmatter0000crou
+status: linked
+discovered: 2026-02-13T14:00:00Z
+reasoning: "Fast sci-fi thriller — Weir-adjacent in tone, smart and propulsive. Consistently called a one-sitting read."
+metadata:
+  author: Blake Crouch
+  year: 2016
+  tags: [sci-fi, thriller, parallel-universe]
+  cover_url: https://covers.openlibrary.org/b/id/8451934-L.jpg
+  description: "A man kidnapped into a parallel universe must find his way back to his family."
+sources:
+  - name: Archive.org
+    url: https://archive.org/details/darkmatter0000crou
+    type: downloadable
+  - name: Kobo
+    url: https://www.kobo.com/ww/en/ebook/dark-matter-40
+    type: link-only
+  - name: Libby
+    url: https://share.libbyapp.com/title/2575561
+    type: link-only

--- a/test/fixtures/content/items/dark-renaissance-greenblatt.yaml
+++ b/test/fixtures/content/items/dark-renaissance-greenblatt.yaml
@@ -1,0 +1,23 @@
+id: dark-renaissance-greenblatt
+title: "Dark Renaissance"
+category: audiobooks
+format: audiobook
+source: audible
+source_url: https://www.audible.com/pd/Dark-Renaissance-Audiobook/B0FG972PJV
+status: linked
+discovered: 2026-02-17T10:00:00Z
+reasoning: "Christopher Marlowe — spy, playwright, murdered at 29. Literary biography as thriller. Same DNA as Dylan Goes Electric."
+metadata:
+  author: Stephen Greenblatt
+  year: 2025
+  narrator: Edoardo Ballerini
+  length: "9h 47m"
+  tags: [nonfiction, biography, history, elizabethan]
+  description: "The life of Christopher Marlowe — spy, playwright, heretic."
+sources:
+  - name: Audible
+    url: https://www.audible.com/pd/Dark-Renaissance-Audiobook/B0FG972PJV
+    type: link-only
+  - name: Kobo
+    url: https://www.kobo.com/us/en/audiobook/dark-renaissance-3
+    type: link-only

--- a/test/fixtures/content/items/empire-of-pain-keefe.yaml
+++ b/test/fixtures/content/items/empire-of-pain-keefe.yaml
@@ -1,0 +1,26 @@
+id: empire-of-pain-keefe
+title: "Empire of Pain"
+category: audiobooks
+format: m4b
+source: audible
+source_url: https://www.audible.com/pd/Empire-of-Pain-Audiobook/0593344383
+status: linked
+discovered: 2026-03-05T09:20:00Z
+reasoning: "The Sackler family and the opioid crisis — investigative journalism turned into gripping narrative. Keefe is meticulous."
+metadata:
+  author: Patrick Radden Keefe
+  narrator: Patrick Radden Keefe
+  year: 2021
+  tags: [nonfiction, investigative, true-crime, healthcare]
+  cover_url: https://covers.openlibrary.org/b/id/10552686-L.jpg
+  description: "The saga of the Sackler dynasty and their role in the opioid epidemic."
+sources:
+  - name: Audible
+    url: https://www.audible.com/pd/Empire-of-Pain-Audiobook/0593344383
+    type: link-only
+  - name: Libro.fm
+    url: https://libro.fm/audiobooks/9780593344385
+    type: link-only
+  - name: Libby
+    url: https://share.libbyapp.com/title/5765576
+    type: link-only

--- a/test/fixtures/content/items/man-who-saw-seconds-boldizar.yaml
+++ b/test/fixtures/content/items/man-who-saw-seconds-boldizar.yaml
@@ -1,0 +1,22 @@
+id: man-who-saw-seconds-boldizar
+title: "The Man Who Saw Seconds"
+category: books
+format: epub
+source: kobo
+source_url: https://www.kobo.com/us/en/ebook/the-man-who-saw-seconds
+status: linked
+discovered: 2026-02-16T16:45:00Z
+reasoning: "Mind-bending thriller about a man who can see a few seconds into the future. Tight, propulsive, and surprisingly deep on free will."
+metadata:
+  author: Alexander Boldizar
+  year: 2016
+  tags: [thriller, sci-fi, philosophical, free-will]
+  cover_url: https://covers.openlibrary.org/b/id/8224701-L.jpg
+  description: "A man who can see seconds into the future becomes the world's most wanted fugitive."
+sources:
+  - name: Kobo
+    url: https://www.kobo.com/us/en/ebook/the-man-who-saw-seconds
+    type: link-only
+  - name: Archive.org
+    url: https://archive.org/details/manwhosawseconds
+    type: link-only

--- a/test/fixtures/content/items/mister-miracle-king.yaml
+++ b/test/fixtures/content/items/mister-miracle-king.yaml
@@ -1,0 +1,23 @@
+id: mister-miracle-king
+title: "Mister Miracle"
+category: comics
+format: cbz
+source: dcui
+source_url: https://www.dcuniverseinfinite.com/comics/book/mister-miracle/bf7847fa-6e9a-44d8-80f6-0fa2420799da
+status: linked
+discovered: 2026-02-13T17:00:00Z
+reasoning: "Tom King + Mitch Gerads. 12-issue masterpiece about Scott Free and Big Barda. Eisner Award winner."
+metadata:
+  author: Tom King
+  artist: Mitch Gerads
+  year: 2017
+  issues: 12
+  tags: [comics, dc, superhero, tom-king]
+  description: "Scott Free, the world's greatest escape artist, tries to escape the one trap from which no one can — death itself."
+sources:
+  - name: DC Universe Infinite
+    url: https://www.dcuniverseinfinite.com/comics/book/mister-miracle/bf7847fa-6e9a-44d8-80f6-0fa2420799da
+    type: link-only
+  - name: Hoopla (SD Library)
+    url: https://www.hoopladigital.com
+    type: link-only

--- a/test/fixtures/content/items/replaceable-you-roach.yaml
+++ b/test/fixtures/content/items/replaceable-you-roach.yaml
@@ -1,0 +1,23 @@
+id: replaceable-you-roach
+title: "Replaceable You"
+category: audiobooks
+format: audiobook
+source: audible
+source_url: https://www.audible.com/pd/Replaceable-You-Audiobook/B0F3QJ3T32
+status: linked
+discovered: 2026-02-18T10:00:00Z
+reasoning: "Mary Roach investigates body part replacement. Author-narrated, funny, science-driven. Perfect bedtime length at 8.5hrs."
+metadata:
+  author: Mary Roach
+  year: 2025
+  narrator: Mary Roach
+  length: "8h 37m"
+  tags: [nonfiction, science, humor, medicine]
+  description: "What happens when human body parts fail and how we're learning to replace them."
+sources:
+  - name: Audible
+    url: https://www.audible.com/pd/Replaceable-You-Audiobook/B0F3QJ3T32
+    type: link-only
+  - name: Kobo
+    url: https://www.kobo.com/us/en/audiobook/replaceable-you-1
+    type: link-only

--- a/test/fixtures/content/items/running-man-king.yaml
+++ b/test/fixtures/content/items/running-man-king.yaml
@@ -1,0 +1,21 @@
+id: running-man-king
+title: "The Running Man"
+category: books
+format: epub
+source: audible
+source_url: https://www.audible.com/pd/The-Running-Man-Audiobook/B019WULXBS
+status: linked
+discovered: 2026-02-13T18:00:00Z
+reasoning: "Already on your to-read list. Stephen King writing as Bachman — dystopian thriller, tight and fast."
+metadata:
+  author: Stephen King
+  year: 1982
+  tags: [sci-fi, dystopian, thriller]
+  description: "In a future America, a desperate man enters a lethal game show where the prize is survival."
+sources:
+  - name: Audible
+    url: https://www.audible.com/pd/The-Running-Man-Audiobook/B019WULXBS
+    type: link-only
+  - name: Libro.fm
+    url: https://libro.fm/audiobooks/9781508217350-the-running-man
+    type: link-only

--- a/test/fixtures/content/items/the-zorg-kara.yaml
+++ b/test/fixtures/content/items/the-zorg-kara.yaml
@@ -1,0 +1,23 @@
+id: the-zorg-kara
+title: "The Zorg"
+category: audiobooks
+format: audiobook
+source: audible
+source_url: https://www.audible.com/pd/The-Zorg-Audiobook/B0DRPRXR7P
+status: linked
+discovered: 2026-02-17T10:30:00Z
+reasoning: "Character Limit for the 18th century — a single horrifying event reconstructed from primary sources. Punchy at 7h43m."
+metadata:
+  author: Siddharth Kara
+  year: 2025
+  narrator: Dion Graham
+  length: "7h 43m"
+  tags: [nonfiction, history, slavery, abolition]
+  description: "The story of a slave ship insurance claim that sparked the abolition movement."
+sources:
+  - name: Audible
+    url: https://www.audible.com/pd/The-Zorg-Audiobook/B0DRPRXR7P
+    type: link-only
+  - name: Libro.fm
+    url: https://libro.fm/audiobooks/9781529966152-the-zorg
+    type: link-only

--- a/test/fixtures/content/items/we-are-legion-taylor.yaml
+++ b/test/fixtures/content/items/we-are-legion-taylor.yaml
@@ -1,0 +1,24 @@
+id: we-are-legion-taylor
+title: "We Are Legion (We Are Bob)"
+category: audiobooks
+format: audiobook
+source: audible
+source_url: https://www.audible.com/pd/We-Are-Legion-We-Are-Bob-Audiobook/B01L082HJ2
+status: linked
+discovered: 2026-02-13T15:00:00Z
+reasoning: "Software engineer wakes up as a Von Neumann probe AI. Funny, science-driven, satisfying in the Project Hail Mary way. Ray Porter narration is excellent."
+metadata:
+  author: Dennis E. Taylor
+  year: 2016
+  narrator: Ray Porter
+  length: "9h 56m"
+  tags: [sci-fi, humor, space, ai]
+  cover_url: https://covers.openlibrary.org/b/id/8543488-L.jpg
+  description: "A software engineer dies and wakes up as an AI tasked with exploring the galaxy."
+sources:
+  - name: Audible
+    url: https://www.audible.com/pd/We-Are-Legion-We-Are-Bob-Audiobook/B01L082HJ2
+    type: link-only
+  - name: Libby
+    url: https://www.overdrive.com/media/12148031/we-are-legion
+    type: link-only

--- a/test/fixtures/content/items/yt-spacex-landing.yaml
+++ b/test/fixtures/content/items/yt-spacex-landing.yaml
@@ -1,0 +1,19 @@
+id: yt-spacex-landing
+title: "SpaceX Starship Full Flight Test"
+category: short-form-video
+format: video
+source: youtube
+source_url: https://www.youtube.com/watch?v=dQw4w9WgXcQ
+status: linked
+discovered: 2026-02-14T08:00:00Z
+reasoning: "Full uncut footage of the latest Starship test flight. Given your interest in space and engineering, this is must-watch."
+metadata:
+  channel: SpaceX
+  duration: "12:34"
+  tags: [space, engineering, spacex, rockets]
+  video_id: dQw4w9WgXcQ
+  description: "Complete footage of Starship's orbital test flight with booster catch attempt."
+sources:
+  - name: YouTube
+    url: https://www.youtube.com/watch?v=dQw4w9WgXcQ
+    type: link-only

--- a/test/fixtures/input/feedback/1929-sorkin.feedback.yaml
+++ b/test/fixtures/input/feedback/1929-sorkin.feedback.yaml
@@ -1,0 +1,3 @@
+rating: up
+notes: "Bought this immediately after the rec. Author narration is great. Exactly the Character Limit format."
+timestamp: 2026-02-14T10:00:00Z

--- a/test/fixtures/input/feedback/dark-matter-crouch.feedback.yaml
+++ b/test/fixtures/input/feedback/dark-matter-crouch.feedback.yaml
@@ -1,0 +1,3 @@
+rating: up
+notes: "Exactly the kind of fast sci-fi I love. Read it in two nights."
+timestamp: 2026-02-15T22:00:00Z

--- a/test/fixtures/input/feedback/empire-of-pain-keefe.feedback.yaml
+++ b/test/fixtures/input/feedback/empire-of-pain-keefe.feedback.yaml
@@ -1,0 +1,3 @@
+rating: down
+notes: "Not interested in the Sackler story. Dropped."
+timestamp: 2026-02-15T09:00:00Z

--- a/test/fixtures/input/feedback/mister-miracle-king.feedback.yaml
+++ b/test/fixtures/input/feedback/mister-miracle-king.feedback.yaml
@@ -1,0 +1,3 @@
+rating: up
+notes: "Already own this. Tom King at his best."
+timestamp: 2026-02-14T08:00:00Z

--- a/test/fixtures/input/feedback/we-are-legion-taylor.feedback.yaml
+++ b/test/fixtures/input/feedback/we-are-legion-taylor.feedback.yaml
@@ -1,0 +1,3 @@
+rating: up
+notes: "This is so me. Engineer protagonist, hard sci-fi played for humor. Ray Porter's narration is the selling point."
+timestamp: 2026-02-16T20:00:00Z

--- a/test/fixtures/memory/preferences.yaml
+++ b/test/fixtures/memory/preferences.yaml
@@ -1,0 +1,22 @@
+preferences:
+  likes:
+    - text: "Hard sci-fi with rigorous world-building and internal logic"
+      source: agent
+    - text: "Competent protagonists who solve problems methodically (Andy Weir style)"
+      source: agent
+    - text: "Deeply researched narrative nonfiction, author-narrated audiobooks"
+      source: agent
+    - text: "Tom King comics (Mister Miracle, Batman, Wonder Woman)"
+      source: user
+  dislikes:
+    - text: "Stories that sacrifice world-building consistency for plot convenience"
+      source: agent
+    - text: "YA dystopian fiction with arbitrary rules"
+      source: user
+  notes:
+    - text: "Has Netflix, no other streaming subscriptions currently"
+      source: user
+    - text: "Prefers EPUB over PDF for books"
+      source: user
+    - text: "San Diego Public Library card available for Libby/Hoopla"
+      source: agent

--- a/test/library.test.js
+++ b/test/library.test.js
@@ -1,0 +1,237 @@
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { createServer } = require('../lib/server');
+
+const fixturesDir = path.join(__dirname, 'fixtures');
+
+function createLibraryServer(configOverrides = {}) {
+  const config = {
+    name: 'ContentBot Test',
+    port: 0,
+    agentDir: fixturesDir,
+    cronFile: '/nonexistent/cron',
+    lockFile: '/tmp/test-library-lock-nonexistent',
+    _serverStartTime: Date.now(),
+    features: {
+      library: { dataDir: 'content/items' },
+    },
+    ...configOverrides,
+  };
+
+  const routes = {};
+  require('../lib/routes/library').register(routes, config);
+  require('../lib/routes/outputs').register(routes, config);
+  return { server: createServer(config, { routes, getHTML: () => '<html>test</html>' }), config };
+}
+
+function fetchJSON(port, urlPath, options = {}) {
+  return new Promise((resolve, reject) => {
+    const opts = { hostname: '127.0.0.1', port, path: urlPath, method: options.method || 'GET', ...options };
+    const req = http.request(opts, (res) => {
+      let data = '';
+      res.on('data', (chunk) => (data += chunk));
+      res.on('end', () => {
+        try {
+          resolve({ status: res.statusCode, data: JSON.parse(data) });
+        } catch {
+          resolve({ status: res.statusCode, data });
+        }
+      });
+    });
+    req.on('error', reject);
+    if (options.body) req.write(options.body);
+    req.end();
+  });
+}
+
+describe('GET /api/library', () => {
+  it('returns content items with feedback status', async () => {
+    const { server } = createLibraryServer();
+    await new Promise(resolve => server.listen(0, resolve));
+    const port = server.address().port;
+
+    const { status, data } = await fetchJSON(port, '/api/library');
+    assert.equal(status, 200);
+    assert.ok(Array.isArray(data));
+    assert.ok(data.length >= 10, `Expected at least 10 items, got ${data.length}`);
+
+    // Items should be sorted by discovered desc
+    for (let i = 1; i < data.length; i++) {
+      if (data[i - 1].discovered && data[i].discovered) {
+        assert.ok(new Date(data[i - 1].discovered) >= new Date(data[i].discovered),
+          `Items not sorted by discovered desc at index ${i}`);
+      }
+    }
+
+    // Check a known item with feedback
+    const darkMatter = data.find(d => d.id === 'dark-matter-crouch');
+    assert.ok(darkMatter, 'dark-matter-crouch should exist');
+    assert.equal(darkMatter.category, 'books');
+    assert.equal(darkMatter.rating, 'up');
+    assert.equal(darkMatter.reviewed, true);
+
+    // Check unreviewed item
+    const challenger = data.find(d => d.id === 'challenger-higginbotham');
+    assert.ok(challenger, 'challenger-higginbotham should exist');
+    assert.equal(challenger.rating, null);
+    assert.equal(challenger.reviewed, false);
+
+    server.close();
+  });
+
+  it('returns 404 when library not configured', async () => {
+    const config = {
+      name: 'Test',
+      port: 0,
+      agentDir: fixturesDir,
+      cronFile: '/nonexistent/cron',
+      lockFile: '/tmp/test-nolibrary-lock',
+      _serverStartTime: Date.now(),
+      features: {},
+    };
+    const routes = {};
+    require('../lib/routes/library').register(routes, config);
+    const { server } = { server: createServer(config, { routes, getHTML: () => '<html>test</html>' }) };
+    await new Promise(resolve => server.listen(0, resolve));
+    const port = server.address().port;
+
+    const { status } = await fetchJSON(port, '/api/library');
+    assert.equal(status, 404);
+
+    server.close();
+  });
+});
+
+describe('GET /api/library/:id', () => {
+  it('returns full item detail with merged feedback', async () => {
+    const { server } = createLibraryServer();
+    await new Promise(resolve => server.listen(0, resolve));
+    const port = server.address().port;
+
+    const { status, data } = await fetchJSON(port, '/api/library/dark-matter-crouch');
+    assert.equal(status, 200);
+    assert.equal(data.title, 'Dark Matter');
+    assert.equal(data.category, 'books');
+    assert.ok(data.metadata);
+    assert.equal(data.metadata.author, 'Blake Crouch');
+    assert.ok(data.feedback, 'Should have merged feedback');
+    assert.equal(data.feedback.rating, 'up');
+
+    server.close();
+  });
+
+  it('returns item without feedback when none exists', async () => {
+    const { server } = createLibraryServer();
+    await new Promise(resolve => server.listen(0, resolve));
+    const port = server.address().port;
+
+    const { status, data } = await fetchJSON(port, '/api/library/challenger-higginbotham');
+    assert.equal(status, 200);
+    assert.equal(data.title, 'Challenger');
+    assert.equal(data.feedback, undefined);
+
+    server.close();
+  });
+
+  it('returns 404 for nonexistent item', async () => {
+    const { server } = createLibraryServer();
+    await new Promise(resolve => server.listen(0, resolve));
+    const port = server.address().port;
+
+    const { status } = await fetchJSON(port, '/api/library/nonexistent-item');
+    assert.equal(status, 404);
+
+    server.close();
+  });
+
+  it('rejects path traversal', async () => {
+    const { server } = createLibraryServer();
+    await new Promise(resolve => server.listen(0, resolve));
+    const port = server.address().port;
+
+    const { status } = await fetchJSON(port, '/api/library/..%2F..%2Fetc%2Fpasswd');
+    assert.equal(status, 400);
+
+    server.close();
+  });
+});
+
+describe('POST /api/feedback/library/:id', () => {
+  it('creates feedback file with thumbs up', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'library-test-'));
+    // Copy an item fixture
+    const itemsDir = path.join(tmpDir, 'content', 'items');
+    fs.mkdirSync(itemsDir, { recursive: true });
+    fs.copyFileSync(
+      path.join(fixturesDir, 'content', 'items', 'challenger-higginbotham.yaml'),
+      path.join(itemsDir, 'challenger-higginbotham.yaml')
+    );
+
+    const config = {
+      name: 'Test',
+      port: 0,
+      agentDir: tmpDir,
+      cronFile: '/nonexistent/cron',
+      lockFile: '/tmp/test-feedback-lock',
+      _serverStartTime: Date.now(),
+      features: { library: { dataDir: 'content/items' } },
+    };
+    const routes = {};
+    require('../lib/routes/library').register(routes, config);
+    const server = createServer(config, { routes, getHTML: () => '<html>test</html>' });
+    await new Promise(resolve => server.listen(0, resolve));
+    const port = server.address().port;
+
+    const { status, data } = await fetchJSON(port, '/api/feedback/library/challenger-higginbotham', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rating: 'up', notes: 'Loved the engineering detail' }),
+    });
+    assert.equal(status, 200);
+    assert.equal(data.ok, true);
+
+    // Verify file was written
+    const fbPath = path.join(tmpDir, 'input', 'feedback', 'challenger-higginbotham.feedback.yaml');
+    assert.ok(fs.existsSync(fbPath), 'Feedback file should exist');
+    const fbContent = fs.readFileSync(fbPath, 'utf-8');
+    assert.ok(fbContent.includes('rating: up'));
+    assert.ok(fbContent.includes('Loved the engineering detail'));
+
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('rejects invalid rating', async () => {
+    const { server } = createLibraryServer();
+    await new Promise(resolve => server.listen(0, resolve));
+    const port = server.address().port;
+
+    const { status } = await fetchJSON(port, '/api/feedback/library/some-item', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rating: 'maybe' }),
+    });
+    assert.equal(status, 400);
+
+    server.close();
+  });
+
+  it('rejects empty feedback', async () => {
+    const { server } = createLibraryServer();
+    await new Promise(resolve => server.listen(0, resolve));
+    const port = server.address().port;
+
+    const { status } = await fetchJSON(port, '/api/feedback/library/some-item', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    assert.equal(status, 400);
+
+    server.close();
+  });
+});


### PR DESCRIPTION
## Summary
- New `lib/routes/library.js` with 4 endpoints: list, detail, feedback, recent items
- 14 content item YAML fixtures based on Bobbo's media recommendations (books, audiobooks, comics, video)
- 5 feedback fixtures (4 thumbs up, 1 thumbs down)
- Preferences and sources fixture YAML for upcoming routes
- Follows existing outputs.js pattern exactly: read directory, join feedback, return sorted array

**Stacked on PR #203** (0A-2 script updates).

## Test plan
- [x] All 304 tests pass (9 new library tests)
- [x] List returns items sorted by discovered desc
- [x] Feedback join works (rated items show rating, unrated show null)
- [x] Detail merges feedback into item
- [x] Detail returns 404 for nonexistent items
- [x] Path traversal rejected
- [x] Feedback creation writes YAML file
- [x] Invalid/empty feedback rejected
- [x] Routes not registered when features.library not configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)