### PR TITLE
Phase 0B-2: Sources and preferences routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,8 @@ require('./lib/routes/harness').register(routes, config);
 require('./lib/routes/uploads').register(routes, config);
 require('./lib/routes/todos').register(routes, config);
 require('./lib/routes/library').register(routes, config);
+require('./lib/routes/sources').register(routes, config);
+require('./lib/routes/preferences').register(routes, config);
 require('./lib/routes/badges').register(routes, config);
 require('./lib/routes/capabilities').register(routes, config);
 require('./lib/routes/tts').register(routes, config);

--- a/lib/routes/preferences.js
+++ b/lib/routes/preferences.js
@@ -1,0 +1,108 @@
+// routes/preferences.js — Preference model CRUD routes
+// Follows the same pattern as todos.js (read/write structured YAML by index)
+// Registered when features.library is configured
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const { sendJSON, readBody } = require('../helpers');
+
+function register(routes, config) {
+  if (!config.features || !config.features.library) return;
+
+  const agentDir = config.agentDir || '.';
+  const prefsFile = path.join(agentDir, 'memory', 'preferences.yaml');
+
+  function readPrefs() {
+    try {
+      const content = fs.readFileSync(prefsFile, 'utf-8');
+      const data = yaml.load(content);
+      return (data && data.preferences) || { likes: [], dislikes: [], notes: [] };
+    } catch {
+      return { likes: [], dislikes: [], notes: [] };
+    }
+  }
+
+  function writePrefs(prefs) {
+    const dir = path.dirname(prefsFile);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(prefsFile, yaml.dump({ preferences: prefs }, { lineWidth: -1 }));
+  }
+
+  const validSections = ['likes', 'dislikes', 'notes'];
+
+  // GET /api/preferences — return the preference model
+  routes['GET /api/preferences'] = (req, res) => {
+    sendJSON(res, 200, readPrefs());
+  };
+
+  // POST /api/preferences — add a new entry to a section
+  routes['POST /api/preferences'] = async (req, res) => {
+    try {
+      const body = JSON.parse(await readBody(req));
+      if (!body.section || !validSections.includes(body.section)) {
+        return sendJSON(res, 400, { error: 'Invalid section (likes, dislikes, notes)' });
+      }
+      if (!body.text || !body.text.trim()) {
+        return sendJSON(res, 400, { error: 'Text required' });
+      }
+
+      const prefs = readPrefs();
+      if (!prefs[body.section]) prefs[body.section] = [];
+      prefs[body.section].push({ text: body.text.trim(), source: 'user' });
+      writePrefs(prefs);
+      sendJSON(res, 200, { ok: true });
+    } catch (err) {
+      sendJSON(res, 500, { error: err.message });
+    }
+  };
+
+  // PUT /api/preferences — update an entry by index
+  routes['PUT /api/preferences'] = async (req, res) => {
+    try {
+      const body = JSON.parse(await readBody(req));
+      if (!body.section || !validSections.includes(body.section)) {
+        return sendJSON(res, 400, { error: 'Invalid section' });
+      }
+
+      const prefs = readPrefs();
+      const section = prefs[body.section] || [];
+      if (typeof body.index !== 'number' || body.index < 0 || body.index >= section.length) {
+        return sendJSON(res, 400, { error: 'Invalid index' });
+      }
+      if (!body.text || !body.text.trim()) {
+        return sendJSON(res, 400, { error: 'Text required' });
+      }
+
+      section[body.index].text = body.text.trim();
+      writePrefs(prefs);
+      sendJSON(res, 200, { ok: true });
+    } catch (err) {
+      sendJSON(res, 500, { error: err.message });
+    }
+  };
+
+  // DELETE /api/preferences — remove an entry by index
+  routes['DELETE /api/preferences'] = async (req, res) => {
+    try {
+      const body = JSON.parse(await readBody(req));
+      if (!body.section || !validSections.includes(body.section)) {
+        return sendJSON(res, 400, { error: 'Invalid section' });
+      }
+
+      const prefs = readPrefs();
+      const section = prefs[body.section] || [];
+      if (typeof body.index !== 'number' || body.index < 0 || body.index >= section.length) {
+        return sendJSON(res, 400, { error: 'Invalid index' });
+      }
+
+      section.splice(body.index, 1);
+      writePrefs(prefs);
+      sendJSON(res, 200, { ok: true });
+    } catch (err) {
+      sendJSON(res, 500, { error: err.message });
+    }
+  };
+}
+
+module.exports = { register };

--- a/lib/routes/sources.js
+++ b/lib/routes/sources.js
@@ -1,0 +1,66 @@
+// routes/sources.js — Content source management routes
+// Registered when features.library is configured
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const { sendJSON, readBody } = require('../helpers');
+
+function register(routes, config) {
+  if (!config.features || !config.features.library) return;
+
+  const agentDir = config.agentDir || '.';
+  const sourcesFile = path.join(agentDir, 'config', 'sources.yaml');
+
+  function readSources() {
+    try {
+      const content = fs.readFileSync(sourcesFile, 'utf-8');
+      const data = yaml.load(content);
+      return (data && data.sources) || [];
+    } catch {
+      return [];
+    }
+  }
+
+  function writeSources(sources) {
+    const dir = path.dirname(sourcesFile);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(sourcesFile, yaml.dump({ sources }, { lineWidth: -1 }));
+  }
+
+  // GET /api/sources — list all sources
+  routes['GET /api/sources'] = (req, res) => {
+    const sources = readSources();
+    // Check credentials existence for each source
+    const credDir = path.join(agentDir, 'config', 'credentials');
+    const result = sources.map(s => ({
+      ...s,
+      hasCredentials: fs.existsSync(path.join(credDir, (s.id || '') + '.yaml')),
+    }));
+    sendJSON(res, 200, result);
+  };
+
+  // POST /api/sources/:id/approve — set source status to approved
+  routes['POST /api/sources/:id/approve'] = (req, res) => {
+    const id = req.params.id;
+    const sources = readSources();
+    const source = sources.find(s => s.id === id);
+    if (!source) return sendJSON(res, 404, { error: 'Source not found' });
+    source.status = 'approved';
+    writeSources(sources);
+    sendJSON(res, 200, { ok: true, id, status: 'approved' });
+  };
+
+  // POST /api/sources/:id/deny — set source status to denied
+  routes['POST /api/sources/:id/deny'] = (req, res) => {
+    const id = req.params.id;
+    const sources = readSources();
+    const source = sources.find(s => s.id === id);
+    if (!source) return sendJSON(res, 404, { error: 'Source not found' });
+    source.status = 'denied';
+    writeSources(sources);
+    sendJSON(res, 200, { ok: true, id, status: 'denied' });
+  };
+}
+
+module.exports = { register };

--- a/test/sources-preferences.test.js
+++ b/test/sources-preferences.test.js
@@ -1,0 +1,289 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { createServer } = require('../lib/server');
+
+const fixturesDir = path.join(__dirname, 'fixtures');
+
+function createTestSvr(agentDir, configOverrides = {}) {
+  const config = {
+    name: 'Test',
+    port: 0,
+    agentDir,
+    cronFile: '/nonexistent/cron',
+    lockFile: '/tmp/test-sp-lock',
+    _serverStartTime: Date.now(),
+    features: { library: { dataDir: 'content/items' } },
+    ...configOverrides,
+  };
+  const routes = {};
+  require('../lib/routes/sources').register(routes, config);
+  require('../lib/routes/preferences').register(routes, config);
+  return { server: createServer(config, { routes, getHTML: () => '<html>test</html>' }), config };
+}
+
+function fetchJSON(port, urlPath, options = {}) {
+  return new Promise((resolve, reject) => {
+    const headers = { ...(options.headers || {}) };
+    if (options.body && !headers['Content-Length']) {
+      headers['Content-Length'] = Buffer.byteLength(options.body);
+    }
+    const opts = { hostname: '127.0.0.1', port, path: urlPath, method: options.method || 'GET', headers };
+    const req = http.request(opts, (res) => {
+      let data = '';
+      res.on('data', (chunk) => (data += chunk));
+      res.on('end', () => {
+        try { resolve({ status: res.statusCode, data: JSON.parse(data) }); }
+        catch { resolve({ status: res.statusCode, data }); }
+      });
+    });
+    req.on('error', reject);
+    if (options.body) req.write(options.body);
+    req.end();
+  });
+}
+
+// --- Sources ---
+
+describe('GET /api/sources', () => {
+  it('returns sources from config/sources.yaml', async () => {
+    const { server } = createTestSvr(fixturesDir);
+    await new Promise(r => server.listen(0, r));
+    const port = server.address().port;
+
+    const { status, data } = await fetchJSON(port, '/api/sources');
+    assert.equal(status, 200);
+    assert.ok(Array.isArray(data));
+    assert.ok(data.length >= 5);
+    const archiveOrg = data.find(s => s.id === 'archive-org');
+    assert.ok(archiveOrg);
+    assert.equal(archiveOrg.status, 'approved');
+    assert.equal(archiveOrg.type, 'downloadable');
+
+    server.close();
+  });
+
+  it('includes pending sources', async () => {
+    const { server } = createTestSvr(fixturesDir);
+    await new Promise(r => server.listen(0, r));
+    const port = server.address().port;
+
+    const { data } = await fetchJSON(port, '/api/sources');
+    const pending = data.find(s => s.id === 'shady-torrents');
+    assert.ok(pending);
+    assert.equal(pending.status, 'pending');
+
+    server.close();
+  });
+});
+
+describe('POST /api/sources/:id/approve', () => {
+  it('sets source status to approved', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sources-test-'));
+    const configDir = path.join(tmpDir, 'config');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.copyFileSync(path.join(fixturesDir, 'config', 'sources.yaml'), path.join(configDir, 'sources.yaml'));
+
+    const { server } = createTestSvr(tmpDir);
+    await new Promise(r => server.listen(0, r));
+    const port = server.address().port;
+
+    const { status, data } = await fetchJSON(port, '/api/sources/shady-torrents/approve', { method: 'POST' });
+    assert.equal(status, 200);
+    assert.equal(data.ok, true);
+    assert.equal(data.status, 'approved');
+
+    // Verify written to file
+    const { data: sources } = await fetchJSON(port, '/api/sources');
+    const updated = sources.find(s => s.id === 'shady-torrents');
+    assert.equal(updated.status, 'approved');
+
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('returns 404 for unknown source', async () => {
+    const { server } = createTestSvr(fixturesDir);
+    await new Promise(r => server.listen(0, r));
+    const port = server.address().port;
+
+    const { status } = await fetchJSON(port, '/api/sources/nonexistent/approve', { method: 'POST' });
+    assert.equal(status, 404);
+
+    server.close();
+  });
+});
+
+describe('POST /api/sources/:id/deny', () => {
+  it('sets source status to denied', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sources-deny-'));
+    const configDir = path.join(tmpDir, 'config');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.copyFileSync(path.join(fixturesDir, 'config', 'sources.yaml'), path.join(configDir, 'sources.yaml'));
+
+    const { server } = createTestSvr(tmpDir);
+    await new Promise(r => server.listen(0, r));
+    const port = server.address().port;
+
+    const { status, data } = await fetchJSON(port, '/api/sources/shady-torrents/deny', { method: 'POST' });
+    assert.equal(status, 200);
+    assert.equal(data.status, 'denied');
+
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+});
+
+// --- Preferences ---
+
+describe('GET /api/preferences', () => {
+  it('returns preference model from memory/preferences.yaml', async () => {
+    const { server } = createTestSvr(fixturesDir);
+    await new Promise(r => server.listen(0, r));
+    const port = server.address().port;
+
+    const { status, data } = await fetchJSON(port, '/api/preferences');
+    assert.equal(status, 200);
+    assert.ok(Array.isArray(data.likes));
+    assert.ok(Array.isArray(data.dislikes));
+    assert.ok(Array.isArray(data.notes));
+    assert.ok(data.likes.length >= 3);
+    assert.equal(data.likes[0].source, 'agent');
+
+    server.close();
+  });
+
+  it('returns empty model when file missing', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prefs-empty-'));
+    const { server } = createTestSvr(tmpDir);
+    await new Promise(r => server.listen(0, r));
+    const port = server.address().port;
+
+    const { status, data } = await fetchJSON(port, '/api/preferences');
+    assert.equal(status, 200);
+    assert.deepEqual(data.likes, []);
+    assert.deepEqual(data.dislikes, []);
+    assert.deepEqual(data.notes, []);
+
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+});
+
+describe('POST /api/preferences', () => {
+  it('adds a new like entry with source: user', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prefs-add-'));
+    const memDir = path.join(tmpDir, 'memory');
+    fs.mkdirSync(memDir, { recursive: true });
+    fs.copyFileSync(path.join(fixturesDir, 'memory', 'preferences.yaml'), path.join(memDir, 'preferences.yaml'));
+
+    const { server } = createTestSvr(tmpDir);
+    await new Promise(r => server.listen(0, r));
+    const port = server.address().port;
+
+    const { status } = await fetchJSON(port, '/api/preferences', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ section: 'likes', text: 'Space opera with big fleet battles' }),
+    });
+    assert.equal(status, 200);
+
+    // Verify it was added
+    const { data } = await fetchJSON(port, '/api/preferences');
+    const added = data.likes[data.likes.length - 1];
+    assert.equal(added.text, 'Space opera with big fleet battles');
+    assert.equal(added.source, 'user');
+
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('rejects invalid section', async () => {
+    const { server } = createTestSvr(fixturesDir);
+    await new Promise(r => server.listen(0, r));
+    const port = server.address().port;
+
+    const { status } = await fetchJSON(port, '/api/preferences', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ section: 'invalid', text: 'test' }),
+    });
+    assert.equal(status, 400);
+
+    server.close();
+  });
+});
+
+describe('PUT /api/preferences', () => {
+  it('updates an entry by index', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prefs-put-'));
+    const memDir = path.join(tmpDir, 'memory');
+    fs.mkdirSync(memDir, { recursive: true });
+    fs.copyFileSync(path.join(fixturesDir, 'memory', 'preferences.yaml'), path.join(memDir, 'preferences.yaml'));
+
+    const { server } = createTestSvr(tmpDir);
+    await new Promise(r => server.listen(0, r));
+    const port = server.address().port;
+
+    const { status } = await fetchJSON(port, '/api/preferences', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ section: 'likes', index: 0, text: 'Updated preference text' }),
+    });
+    assert.equal(status, 200);
+
+    const { data } = await fetchJSON(port, '/api/preferences');
+    assert.equal(data.likes[0].text, 'Updated preference text');
+
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('rejects invalid index', async () => {
+    const { server } = createTestSvr(fixturesDir);
+    await new Promise(r => server.listen(0, r));
+    const port = server.address().port;
+
+    const { status } = await fetchJSON(port, '/api/preferences', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ section: 'likes', index: 999, text: 'test' }),
+    });
+    assert.equal(status, 400);
+
+    server.close();
+  });
+});
+
+describe('DELETE /api/preferences', () => {
+  it('removes an entry by index', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prefs-del-'));
+    const memDir = path.join(tmpDir, 'memory');
+    fs.mkdirSync(memDir, { recursive: true });
+    fs.copyFileSync(path.join(fixturesDir, 'memory', 'preferences.yaml'), path.join(memDir, 'preferences.yaml'));
+
+    const { server } = createTestSvr(tmpDir);
+    await new Promise(r => server.listen(0, r));
+    const port = server.address().port;
+
+    // Get initial count
+    const { data: before } = await fetchJSON(port, '/api/preferences');
+    const countBefore = before.dislikes.length;
+
+    const { status } = await fetchJSON(port, '/api/preferences', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ section: 'dislikes', index: 0 }),
+    });
+    assert.equal(status, 200);
+
+    const { data: after } = await fetchJSON(port, '/api/preferences');
+    assert.equal(after.dislikes.length, countBefore - 1);
+
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+});


### PR DESCRIPTION
## Summary
- New `lib/routes/sources.js`: list, approve, deny sources from `config/sources.yaml`
- New `lib/routes/preferences.js`: CRUD on preference model following `todos.js` pattern — index in body, section-based addressing
- Preferences entries tagged with `source: user` when added via portal

**Stacked on PR #204** (0B-1 library route).

## Test plan
- [x] All 316 tests pass (12 new)
- [x] Sources: list returns fixture data, approve/deny updates YAML, 404 for unknown
- [x] Preferences: GET returns model, POST adds with source:user, PUT updates by index, DELETE removes by index
- [x] Invalid section/index rejected with 400
- [x] Empty preference file returns empty model

🤖 Generated with [Claude Code](https://claude.com/claude-code)