### PR TITLE
Phase 0B-4: Preferences and sources tab UIs

### DIFF
--- a/lib/ui/shell.js
+++ b/lib/ui/shell.js
@@ -31,6 +31,8 @@ const { getOutputsTabJS } = require('./tabs/outputs');
 const { getTodosTabJS } = require('./tabs/todos');
 const { getCapabilitiesTabJS } = require('./tabs/capabilities');
 const { getLibraryTabJS } = require('./tabs/library');
+const { getPreferencesTabJS } = require('./tabs/preferences');
+const { getSourcesTabJS } = require('./tabs/sources');
 const { getProjectSidebarJS } = require('./sidebar-projects');
 const { getURLStateJS } = require('./url-state');
 
@@ -127,6 +129,16 @@ function buildHTML(config) {
   if (tabs.includes('library')) {
     tabJS += getLibraryTabJS();
     tabLoaderEntries.push(`library: loadLibrary`);
+  }
+
+  if (tabs.includes('preferences')) {
+    tabJS += getPreferencesTabJS();
+    tabLoaderEntries.push(`preferences: loadPreferences`);
+  }
+
+  if (tabs.includes('sources')) {
+    tabJS += getSourcesTabJS();
+    tabLoaderEntries.push(`sources: loadSources`);
   }
 
   // Project sidebar support

--- a/lib/ui/styles.js
+++ b/lib/ui/styles.js
@@ -287,6 +287,7 @@ ${authorCSS}
     .media-detail { grid-template-columns: 1fr; }
     .media-grid { grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); }
   }
+  .pending-source { padding: 12px; border-left: 3px solid #f9a825; background: #fffde7; border-radius: 4px; margin-bottom: 8px; }
 `;
 }
 

--- a/lib/ui/tabs/preferences.js
+++ b/lib/ui/tabs/preferences.js
@@ -1,0 +1,97 @@
+// preferences.js — Preferences tab client-side JavaScript
+// Editable lists of likes, dislikes, and notes (follows todos tab pattern)
+
+function getPreferencesTabJS() {
+  return `
+var prefsData = { likes: [], dislikes: [], notes: [] };
+
+function renderPrefsSection(section, items, label) {
+  var html = '<div style="margin-bottom:24px">';
+  html += '<h3 style="margin:0 0 8px;font-size:15px;color:#444">' + escapeHtml(label) + ' <span style="color:#999;font-weight:normal">(' + items.length + ')</span></h3>';
+
+  items.forEach(function(item, idx) {
+    var srcBadge = item.source === 'agent'
+      ? '<span style="font-size:10px;padding:1px 5px;border-radius:3px;background:#ede7f6;color:#4527a0;margin-left:6px">agent</span>'
+      : '<span style="font-size:10px;padding:1px 5px;border-radius:3px;background:#e3f2fd;color:#1565c0;margin-left:6px">user</span>';
+
+    html += '<div style="display:flex;align-items:flex-start;gap:8px;padding:8px;border-radius:4px;margin-bottom:4px;background:#fafafa">';
+    html += '<div style="flex:1;font-size:13px;color:#333" id="pref-text-' + section + '-' + idx + '">' + escapeHtml(item.text || '') + srcBadge + '</div>';
+    html += '<button class="refresh-btn" style="padding:2px 6px;font-size:11px" onclick="editPref(\\'' + section + '\\',' + idx + ')">Edit</button>';
+    html += '<button class="refresh-btn" style="padding:2px 6px;font-size:11px;color:#c62828" onclick="deletePref(\\'' + section + '\\',' + idx + ')">×</button>';
+    html += '</div>';
+  });
+
+  // Add new entry
+  html += '<div style="display:flex;gap:6px;margin-top:8px">';
+  html += '<input type="text" id="pref-add-' + section + '" placeholder="Add ' + section.slice(0, -1) + '..." style="flex:1;padding:6px 10px;border:1px solid #ddd;border-radius:4px;font-size:13px;font-family:inherit">';
+  html += '<button class="refresh-btn" onclick="addPref(\\'' + section + '\\')">Add</button>';
+  html += '</div>';
+  html += '</div>';
+  return html;
+}
+
+async function loadPreferences() {
+  var contentEl = document.getElementById('content');
+  contentEl.innerHTML = '<div class="empty">Loading preferences...</div>';
+  try {
+    var res = await fetch('/api/preferences');
+    prefsData = await res.json();
+
+    var html = '<div class="status-section">';
+    html += '<h2 style="margin:0 0 16px;font-size:18px">Taste Profile</h2>';
+    html += '<p style="color:#666;font-size:13px;margin-bottom:16px">These preferences guide ContentBot\\'s recommendations. The agent extracts patterns from your feedback; you can also add or edit entries directly.</p>';
+    html += renderPrefsSection('likes', prefsData.likes || [], '👍 Likes');
+    html += renderPrefsSection('dislikes', prefsData.dislikes || [], '👎 Dislikes');
+    html += renderPrefsSection('notes', prefsData.notes || [], '📝 Notes');
+    html += '</div>';
+
+    contentEl.innerHTML = html;
+    contentEl.scrollTop = 0;
+  } catch {
+    contentEl.innerHTML = '<div class="empty">Failed to load preferences</div>';
+  }
+}
+
+async function addPref(section) {
+  var input = document.getElementById('pref-add-' + section);
+  if (!input || !input.value.trim()) return;
+  try {
+    await fetch('/api/preferences', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ section: section, text: input.value.trim() })
+    });
+    loadPreferences();
+  } catch {}
+}
+
+async function editPref(section, index) {
+  var items = prefsData[section] || [];
+  var current = items[index] ? items[index].text : '';
+  var newText = prompt('Edit preference:', current);
+  if (newText === null || newText.trim() === '' || newText === current) return;
+  try {
+    await fetch('/api/preferences', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ section: section, index: index, text: newText.trim() })
+    });
+    loadPreferences();
+  } catch {}
+}
+
+async function deletePref(section, index) {
+  if (!confirm('Remove this preference?')) return;
+  try {
+    await fetch('/api/preferences', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ section: section, index: index })
+    });
+    loadPreferences();
+  } catch {}
+}
+`;
+}
+
+module.exports = { getPreferencesTabJS };

--- a/lib/ui/tabs/sources.js
+++ b/lib/ui/tabs/sources.js
@@ -1,0 +1,108 @@
+// sources.js — Sources tab client-side JavaScript
+// Source management: list, approve/deny pending, credentials
+
+function getSourcesTabJS() {
+  return `
+async function loadSources() {
+  var contentEl = document.getElementById('content');
+  contentEl.innerHTML = '<div class="empty">Loading sources...</div>';
+  try {
+    var res = await fetch('/api/sources');
+    var sources = await res.json();
+
+    var pending = sources.filter(function(s) { return s.status === 'pending'; });
+    var approved = sources.filter(function(s) { return s.status === 'approved'; });
+    var denied = sources.filter(function(s) { return s.status === 'denied'; });
+
+    var html = '<div class="status-section">';
+    html += '<h2 style="margin:0 0 16px;font-size:18px">Content Sources</h2>';
+
+    // Pending sources (highlighted)
+    if (pending.length > 0) {
+      html += '<div style="margin-bottom:24px">';
+      html += '<h3 style="margin:0 0 8px;font-size:15px;color:#e65100">⚠ Pending Approval (' + pending.length + ')</h3>';
+      pending.forEach(function(s) {
+        html += '<div class="pending-source">';
+        html += '<div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">';
+        html += '<strong style="font-size:14px">' + escapeHtml(s.name) + '</strong>';
+        html += '<span style="font-size:12px;color:#888">' + escapeHtml(s.url) + '</span>';
+        html += '<span class="category-badge" style="background:#f5f5f5;color:#666">' + escapeHtml(s.type) + '</span>';
+        if (s.categories && s.categories.length) {
+          s.categories.forEach(function(c) {
+            html += '<span style="font-size:10px;padding:1px 5px;border-radius:3px;background:#e8f5e9;color:#2e7d32">' + escapeHtml(c) + '</span>';
+          });
+        }
+        html += '</div>';
+        html += '<div style="display:flex;gap:6px;margin-top:8px">';
+        html += '<button class="refresh-btn" style="background:#e8f5e9;color:#2e7d32" onclick="approveSource(\\'' + escapeHtml(s.id) + '\\')">✓ Approve</button>';
+        html += '<button class="refresh-btn" style="background:#ffebee;color:#c62828" onclick="denySource(\\'' + escapeHtml(s.id) + '\\')">✗ Deny</button>';
+        html += '</div>';
+        html += '</div>';
+      });
+      html += '</div>';
+    }
+
+    // Approved sources
+    if (approved.length > 0) {
+      html += '<h3 style="margin:0 0 8px;font-size:15px;color:#2e7d32">✓ Approved (' + approved.length + ')</h3>';
+      approved.forEach(function(s) {
+        html += renderSourceRow(s);
+      });
+    }
+
+    // Denied sources
+    if (denied.length > 0) {
+      html += '<h3 style="margin:16px 0 8px;font-size:15px;color:#c62828">✗ Denied (' + denied.length + ')</h3>';
+      denied.forEach(function(s) {
+        html += renderSourceRow(s);
+      });
+    }
+
+    if (sources.length === 0) {
+      html += '<div class="empty">No sources configured</div>';
+    }
+
+    html += '</div>';
+    contentEl.innerHTML = html;
+    contentEl.scrollTop = 0;
+  } catch {
+    contentEl.innerHTML = '<div class="empty">Failed to load sources</div>';
+  }
+}
+
+function renderSourceRow(s) {
+  var statusColor = s.status === 'approved' ? '#2e7d32' : s.status === 'denied' ? '#c62828' : '#e65100';
+  var html = '<div style="display:flex;align-items:center;gap:8px;padding:8px;border-radius:4px;margin-bottom:4px;background:#fafafa;flex-wrap:wrap">';
+  html += '<strong style="font-size:13px;min-width:120px">' + escapeHtml(s.name) + '</strong>';
+  html += '<a href="' + escapeHtml(s.url) + '" target="_blank" rel="noopener" style="font-size:12px;color:#1565c0">' + escapeHtml(s.url) + '</a>';
+  html += '<span class="category-badge" style="background:#f5f5f5;color:#666">' + escapeHtml(s.type) + '</span>';
+  html += '<span style="font-size:11px;color:' + statusColor + '">' + escapeHtml(s.status) + '</span>';
+  if (s.categories && s.categories.length) {
+    s.categories.forEach(function(c) {
+      html += '<span style="font-size:10px;padding:1px 5px;border-radius:3px;background:#e8f5e9;color:#2e7d32">' + escapeHtml(c) + '</span>';
+    });
+  }
+  if (s.hasCredentials) {
+    html += '<span style="font-size:10px;padding:1px 5px;border-radius:3px;background:#e8eaf6;color:#283593">🔑 Credentials</span>';
+  }
+  html += '</div>';
+  return html;
+}
+
+async function approveSource(id) {
+  try {
+    await fetch('/api/sources/' + encodeURIComponent(id) + '/approve', { method: 'POST' });
+    loadSources();
+  } catch {}
+}
+
+async function denySource(id) {
+  try {
+    await fetch('/api/sources/' + encodeURIComponent(id) + '/deny', { method: 'POST' });
+    loadSources();
+  } catch {}
+}
+`;
+}
+
+module.exports = { getSourcesTabJS };

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -466,4 +466,75 @@ describe('buildHTML', () => {
     assert.ok(scriptMatch, 'should contain a script tag');
     assert.doesNotThrow(() => new Function(scriptMatch[1]), 'embedded JS with library tab must be syntactically valid');
   });
+
+  it('includes preferences tab JS when configured', () => {
+    const config = {
+      ...baseConfig,
+      features: { library: true, tabs: ['preferences', 'journal', 'status'] },
+    };
+    const html = buildHTML(config);
+    assert.ok(html.includes('data-tab="preferences"'));
+    assert.ok(html.includes('function loadPreferences'));
+    assert.ok(html.includes('preferences: loadPreferences'));
+    assert.ok(html.includes('function addPref'));
+    assert.ok(html.includes('function editPref'));
+    assert.ok(html.includes('function deletePref'));
+  });
+
+  it('excludes preferences tab JS when not configured', () => {
+    const html = buildHTML(baseConfig);
+    assert.ok(!html.includes('function loadPreferences'));
+    assert.ok(!html.includes('function addPref'));
+  });
+
+  it('preferences tab JS references correct API endpoints', () => {
+    const config = {
+      ...baseConfig,
+      features: { library: true, tabs: ['preferences', 'journal', 'status'] },
+    };
+    const html = buildHTML(config);
+    assert.ok(html.includes("fetch('/api/preferences')"));
+    assert.ok(html.includes("fetch('/api/preferences'"));
+  });
+
+  it('includes sources tab JS when configured', () => {
+    const config = {
+      ...baseConfig,
+      features: { library: true, tabs: ['sources', 'journal', 'status'] },
+    };
+    const html = buildHTML(config);
+    assert.ok(html.includes('data-tab="sources"'));
+    assert.ok(html.includes('function loadSources'));
+    assert.ok(html.includes('sources: loadSources'));
+    assert.ok(html.includes('function approveSource'));
+    assert.ok(html.includes('function denySource'));
+  });
+
+  it('excludes sources tab JS when not configured', () => {
+    const html = buildHTML(baseConfig);
+    assert.ok(!html.includes('function loadSources'));
+    assert.ok(!html.includes('function approveSource'));
+  });
+
+  it('sources tab JS references correct API endpoints', () => {
+    const config = {
+      ...baseConfig,
+      features: { library: true, tabs: ['sources', 'journal', 'status'] },
+    };
+    const html = buildHTML(config);
+    assert.ok(html.includes("fetch('/api/sources')"));
+    assert.ok(html.includes("/approve"));
+    assert.ok(html.includes("/deny"));
+  });
+
+  it('generates syntactically valid JS with all ContentBot tabs', () => {
+    const config = {
+      ...baseConfig,
+      features: { library: { dataDir: 'content/items' }, tabs: ['library', 'preferences', 'sources', 'journal', 'status'] },
+    };
+    const html = buildHTML(config);
+    const scriptMatch = html.match(/<script>([\s\S]*?)<\/script>/);
+    assert.ok(scriptMatch, 'should contain a script tag');
+    assert.doesNotThrow(() => new Function(scriptMatch[1]), 'embedded JS with all ContentBot tabs must be syntactically valid');
+  });
 });

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -410,4 +410,60 @@ describe('buildHTML', () => {
     assert.ok(scriptMatch, 'should contain a script tag');
     assert.doesNotThrow(() => new Function(scriptMatch[1]), 'embedded JS must be syntactically valid');
   });
+
+  it('includes library tab JS when configured', () => {
+    const config = {
+      ...baseConfig,
+      features: { library: { dataDir: 'content/items' }, tabs: ['library', 'journal', 'status'] },
+    };
+    const html = buildHTML(config);
+    assert.ok(html.includes('data-tab="library"'));
+    assert.ok(html.includes('function loadLibrary'));
+    assert.ok(html.includes('library: loadLibrary'));
+    assert.ok(html.includes('function renderLibraryGrid'));
+    assert.ok(html.includes('function viewLibraryItem'));
+    assert.ok(html.includes('function submitLibraryFeedback'));
+  });
+
+  it('excludes library tab JS when not configured', () => {
+    const html = buildHTML(baseConfig);
+    assert.ok(!html.includes('function loadLibrary'));
+    assert.ok(!html.includes('function renderLibraryGrid'));
+  });
+
+  it('library tab JS references correct API endpoints', () => {
+    const config = {
+      ...baseConfig,
+      features: { library: { dataDir: 'content/items' }, tabs: ['library', 'journal', 'status'] },
+    };
+    const html = buildHTML(config);
+    assert.ok(html.includes("fetch('/api/library')"));
+    assert.ok(html.includes("fetch('/api/library/'"));
+    assert.ok(html.includes("fetch('/api/feedback/library/'"));
+  });
+
+  it('library tab includes media grid CSS', () => {
+    const config = {
+      ...baseConfig,
+      features: { library: { dataDir: 'content/items' }, tabs: ['library', 'journal', 'status'] },
+    };
+    const html = buildHTML(config);
+    assert.ok(html.includes('.media-grid'));
+    assert.ok(html.includes('.media-card'));
+    assert.ok(html.includes('.media-detail'));
+    assert.ok(html.includes('.youtube-embed'));
+    assert.ok(html.includes('.library-filter-bar'));
+    assert.ok(html.includes('.category-badge'));
+  });
+
+  it('library tab generates syntactically valid JavaScript', () => {
+    const config = {
+      ...baseConfig,
+      features: { library: { dataDir: 'content/items' }, tabs: ['library', 'journal', 'status'] },
+    };
+    const html = buildHTML(config);
+    const scriptMatch = html.match(/<script>([\s\S]*?)<\/script>/);
+    assert.ok(scriptMatch, 'should contain a script tag');
+    assert.doesNotThrow(() => new Function(scriptMatch[1]), 'embedded JS with library tab must be syntactically valid');
+  });
 });


### PR DESCRIPTION
## Summary
- New `lib/ui/tabs/preferences.js`: editable likes/dislikes/notes lists with agent/user badges, CRUD operations
- New `lib/ui/tabs/sources.js`: pending source approval, approved/denied source lists with URL links and category badges
- CSS: `.pending-source` yellow highlight card for pending sources

**Stacked on PR #207** (library tab UI). Will retarget to main after #207 merges.

## Verification (shot-scraper screenshots)
- Preferences tab shows 4 likes, 2 dislikes, 3 notes with correct source badges
- Each entry has Edit and × buttons
- Add input + button at bottom of each section
- Sources tab shows 1 pending (ShadyTorrents) with Approve/Deny buttons
- 5 approved sources with clickable URLs, type badges, category badges

## Test plan
- [x] All 316 tests pass
- [x] Visual verification via shot-scraper

🤖 Generated with [Claude Code](https://claude.com/claude-code)