### PR TITLE
Add approve/deny buttons to all source rows

### DIFF
--- a/lib/ui/tabs/sources.js
+++ b/lib/ui/tabs/sources.js
@@ -85,6 +85,14 @@ function renderSourceRow(s) {
   if (s.hasCredentials) {
     html += '<span style="font-size:10px;padding:1px 5px;border-radius:3px;background:#e8eaf6;color:#283593">🔑 Credentials</span>';
   }
+  html += '<div style="margin-left:auto;display:flex;gap:4px">';
+  if (s.status !== 'approved') {
+    html += '<button class="refresh-btn" style="padding:2px 8px;font-size:11px;background:#e8f5e9;color:#2e7d32" onclick="approveSource(\\'' + escapeHtml(s.id) + '\\')">✓ Approve</button>';
+  }
+  if (s.status !== 'denied') {
+    html += '<button class="refresh-btn" style="padding:2px 8px;font-size:11px;background:#ffebee;color:#c62828" onclick="denySource(\\'' + escapeHtml(s.id) + '\\')">✗ Deny</button>';
+  }
+  html += '</div>';
   html += '</div>';
   return html;
 }


### PR DESCRIPTION
## Summary
Previously only pending sources had Approve/Deny buttons. Now all source rows show the appropriate action button:
- Approved sources → ✗ Deny button
- Denied sources → ✓ Approve button  
- Pending sources → both buttons (unchanged)

## Test plan
- [x] All 345 tests pass
- [x] Visual verification via shot-scraper

🤖 Generated with [Claude Code](https://claude.com/claude-code)