### PR TITLE
Split preferences into per-category model

### DIFF
--- a/lib/routes/preferences.js
+++ b/lib/routes/preferences.js
@@ -1,5 +1,5 @@
-// routes/preferences.js — Preference model CRUD routes
-// Follows the same pattern as todos.js (read/write structured YAML by index)
+// routes/preferences.js — Per-category preference model CRUD routes
+// Schema: preferences.<category>.<section>[index] where section is likes/dislikes
 // Registered when features.library is configured
 
 const fs = require('fs');
@@ -17,9 +17,9 @@ function register(routes, config) {
     try {
       const content = fs.readFileSync(prefsFile, 'utf-8');
       const data = yaml.load(content);
-      return (data && data.preferences) || { likes: [], dislikes: [], notes: [] };
+      return (data && data.preferences) || {};
     } catch {
-      return { likes: [], dislikes: [], notes: [] };
+      return {};
     }
   }
 
@@ -29,27 +29,43 @@ function register(routes, config) {
     fs.writeFileSync(prefsFile, yaml.dump({ preferences: prefs }, { lineWidth: -1 }));
   }
 
-  const validSections = ['likes', 'dislikes', 'notes'];
+  const validSections = ['likes', 'dislikes'];
 
-  // GET /api/preferences — return the preference model
+  function validateBody(body) {
+    if (!body.category || typeof body.category !== 'string') {
+      return 'Category required';
+    }
+    if (!body.section || !validSections.includes(body.section)) {
+      return 'Invalid section (likes, dislikes)';
+    }
+    return null;
+  }
+
+  function ensureCategory(prefs, category) {
+    if (!prefs[category]) prefs[category] = { likes: [], dislikes: [] };
+    if (!prefs[category].likes) prefs[category].likes = [];
+    if (!prefs[category].dislikes) prefs[category].dislikes = [];
+    return prefs[category];
+  }
+
+  // GET /api/preferences — return the full preference model (all categories)
   routes['GET /api/preferences'] = (req, res) => {
     sendJSON(res, 200, readPrefs());
   };
 
-  // POST /api/preferences — add a new entry to a section
+  // POST /api/preferences — add a new entry to a category section
   routes['POST /api/preferences'] = async (req, res) => {
     try {
       const body = JSON.parse(await readBody(req));
-      if (!body.section || !validSections.includes(body.section)) {
-        return sendJSON(res, 400, { error: 'Invalid section (likes, dislikes, notes)' });
-      }
+      const err = validateBody(body);
+      if (err) return sendJSON(res, 400, { error: err });
       if (!body.text || !body.text.trim()) {
         return sendJSON(res, 400, { error: 'Text required' });
       }
 
       const prefs = readPrefs();
-      if (!prefs[body.section]) prefs[body.section] = [];
-      prefs[body.section].push({ text: body.text.trim(), source: 'user' });
+      const cat = ensureCategory(prefs, body.category);
+      cat[body.section].push({ text: body.text.trim(), source: 'user' });
       writePrefs(prefs);
       sendJSON(res, 200, { ok: true });
     } catch (err) {
@@ -57,16 +73,17 @@ function register(routes, config) {
     }
   };
 
-  // PUT /api/preferences — update an entry by index
+  // PUT /api/preferences — update an entry by category + section + index
   routes['PUT /api/preferences'] = async (req, res) => {
     try {
       const body = JSON.parse(await readBody(req));
-      if (!body.section || !validSections.includes(body.section)) {
-        return sendJSON(res, 400, { error: 'Invalid section' });
-      }
+      const err = validateBody(body);
+      if (err) return sendJSON(res, 400, { error: err });
 
       const prefs = readPrefs();
-      const section = prefs[body.section] || [];
+      const cat = prefs[body.category];
+      if (!cat) return sendJSON(res, 400, { error: 'Category not found' });
+      const section = cat[body.section] || [];
       if (typeof body.index !== 'number' || body.index < 0 || body.index >= section.length) {
         return sendJSON(res, 400, { error: 'Invalid index' });
       }
@@ -82,16 +99,17 @@ function register(routes, config) {
     }
   };
 
-  // DELETE /api/preferences — remove an entry by index
+  // DELETE /api/preferences — remove an entry by category + section + index
   routes['DELETE /api/preferences'] = async (req, res) => {
     try {
       const body = JSON.parse(await readBody(req));
-      if (!body.section || !validSections.includes(body.section)) {
-        return sendJSON(res, 400, { error: 'Invalid section' });
-      }
+      const err = validateBody(body);
+      if (err) return sendJSON(res, 400, { error: err });
 
       const prefs = readPrefs();
-      const section = prefs[body.section] || [];
+      const cat = prefs[body.category];
+      if (!cat) return sendJSON(res, 400, { error: 'Category not found' });
+      const section = cat[body.section] || [];
       if (typeof body.index !== 'number' || body.index < 0 || body.index >= section.length) {
         return sendJSON(res, 400, { error: 'Invalid index' });
       }

--- a/lib/ui/tabs/preferences.js
+++ b/lib/ui/tabs/preferences.js
@@ -1,31 +1,62 @@
-// preferences.js — Preferences tab client-side JavaScript
-// Editable lists of likes, dislikes, and notes (follows todos tab pattern)
+// preferences.js — Per-category preferences tab client-side JavaScript
+// Editable likes/dislikes per media category
 
 function getPreferencesTabJS() {
   return `
-var prefsData = { likes: [], dislikes: [], notes: [] };
+var prefsData = {};
+var prefsActiveCategory = null;
 
-function renderPrefsSection(section, items, label) {
-  var html = '<div style="margin-bottom:24px">';
-  html += '<h3 style="margin:0 0 8px;font-size:15px;color:#444">' + escapeHtml(label) + ' <span style="color:#999;font-weight:normal">(' + items.length + ')</span></h3>';
+function renderPrefsSection(category, section, items, label) {
+  var html = '<div style="margin-bottom:20px">';
+  html += '<h4 style="margin:0 0 6px;font-size:14px;color:#555">' + escapeHtml(label) + ' <span style="color:#999;font-weight:normal">(' + items.length + ')</span></h4>';
 
   items.forEach(function(item, idx) {
     var srcBadge = item.source === 'agent'
       ? '<span style="font-size:10px;padding:1px 5px;border-radius:3px;background:#ede7f6;color:#4527a0;margin-left:6px">agent</span>'
       : '<span style="font-size:10px;padding:1px 5px;border-radius:3px;background:#e3f2fd;color:#1565c0;margin-left:6px">user</span>';
 
-    html += '<div style="display:flex;align-items:flex-start;gap:8px;padding:8px;border-radius:4px;margin-bottom:4px;background:#fafafa">';
-    html += '<div style="flex:1;font-size:13px;color:#333" id="pref-text-' + section + '-' + idx + '">' + escapeHtml(item.text || '') + srcBadge + '</div>';
-    html += '<button class="refresh-btn" style="padding:2px 6px;font-size:11px" onclick="editPref(\\'' + section + '\\',' + idx + ')">Edit</button>';
-    html += '<button class="refresh-btn" style="padding:2px 6px;font-size:11px;color:#c62828" onclick="deletePref(\\'' + section + '\\',' + idx + ')">×</button>';
+    html += '<div style="display:flex;align-items:flex-start;gap:8px;padding:6px 8px;border-radius:4px;margin-bottom:3px;background:#fafafa">';
+    html += '<div style="flex:1;font-size:13px;color:#333">' + escapeHtml(item.text || '') + srcBadge + '</div>';
+    html += '<button class="refresh-btn" style="padding:2px 6px;font-size:11px" onclick="editPref(\\'' + escapeHtml(category) + '\\',\\'' + section + '\\',' + idx + ')">Edit</button>';
+    html += '<button class="refresh-btn" style="padding:2px 6px;font-size:11px;color:#c62828" onclick="deletePref(\\'' + escapeHtml(category) + '\\',\\'' + section + '\\',' + idx + ')">×</button>';
     html += '</div>';
   });
 
-  // Add new entry
-  html += '<div style="display:flex;gap:6px;margin-top:8px">';
-  html += '<input type="text" id="pref-add-' + section + '" placeholder="Add ' + section.slice(0, -1) + '..." style="flex:1;padding:6px 10px;border:1px solid #ddd;border-radius:4px;font-size:13px;font-family:inherit">';
-  html += '<button class="refresh-btn" onclick="addPref(\\'' + section + '\\')">Add</button>';
+  html += '<div style="display:flex;gap:6px;margin-top:6px">';
+  html += '<input type="text" id="pref-add-' + category + '-' + section + '" placeholder="Add..." style="flex:1;padding:5px 8px;border:1px solid #ddd;border-radius:4px;font-size:12px;font-family:inherit">';
+  html += '<button class="refresh-btn" style="font-size:12px" onclick="addPref(\\'' + escapeHtml(category) + '\\',\\'' + section + '\\')">Add</button>';
   html += '</div>';
+  html += '</div>';
+  return html;
+}
+
+function renderCategoryPrefs(category) {
+  prefsActiveCategory = category;
+  var cat = prefsData[category] || { likes: [], dislikes: [] };
+  var html = '<div class="status-section">';
+  html += renderPrefsCategoryNav(category);
+  html += '<h3 style="margin:0 0 12px;font-size:16px;text-transform:capitalize">' + escapeHtml(category) + '</h3>';
+  html += renderPrefsSection(category, 'likes', cat.likes || [], '👍 Likes');
+  html += renderPrefsSection(category, 'dislikes', cat.dislikes || [], '👎 Dislikes');
+  html += '</div>';
+  document.getElementById('content').innerHTML = html;
+}
+
+function renderPrefsCategoryNav(activeCategory) {
+  var categories = Object.keys(prefsData).sort();
+  var html = '<div style="display:flex;gap:6px;margin-bottom:16px;flex-wrap:wrap">';
+  categories.forEach(function(cat) {
+    var isActive = cat === activeCategory;
+    var likes = (prefsData[cat] && prefsData[cat].likes) ? prefsData[cat].likes.length : 0;
+    var dislikes = (prefsData[cat] && prefsData[cat].dislikes) ? prefsData[cat].dislikes.length : 0;
+    var count = likes + dislikes;
+    html += '<button class="refresh-btn" style="padding:4px 12px;font-size:13px;text-transform:capitalize;'
+      + (isActive ? 'background:#1a73e8;color:#fff;border-color:#1a73e8' : '') + '" '
+      + 'onclick="renderCategoryPrefs(\\'' + escapeHtml(cat) + '\\')">'
+      + escapeHtml(cat) + ' <span style="opacity:0.7">(' + count + ')</span></button>';
+  });
+  // Add new category button
+  html += '<button class="refresh-btn" style="padding:4px 12px;font-size:13px;color:#888" onclick="addCategory()">+ Category</button>';
   html += '</div>';
   return html;
 }
@@ -37,36 +68,52 @@ async function loadPreferences() {
     var res = await fetch('/api/preferences');
     prefsData = await res.json();
 
-    var html = '<div class="status-section">';
-    html += '<h2 style="margin:0 0 16px;font-size:18px">Taste Profile</h2>';
-    html += '<p style="color:#666;font-size:13px;margin-bottom:16px">These preferences guide ContentBot\\'s recommendations. The agent extracts patterns from your feedback; you can also add or edit entries directly.</p>';
-    html += renderPrefsSection('likes', prefsData.likes || [], '👍 Likes');
-    html += renderPrefsSection('dislikes', prefsData.dislikes || [], '👎 Dislikes');
-    html += renderPrefsSection('notes', prefsData.notes || [], '📝 Notes');
-    html += '</div>';
-
-    contentEl.innerHTML = html;
-    contentEl.scrollTop = 0;
+    var categories = Object.keys(prefsData).sort();
+    if (categories.length === 0) {
+      var html = '<div class="status-section">';
+      html += '<h2 style="margin:0 0 16px;font-size:18px">Taste Profile</h2>';
+      html += '<p style="color:#666;font-size:13px;margin-bottom:16px">No preferences yet. Preferences are organized per media category — the agent will create them as you give feedback, or you can add categories manually.</p>';
+      html += '<button class="refresh-btn" onclick="addCategory()">+ Add Category</button>';
+      html += '</div>';
+      contentEl.innerHTML = html;
+    } else {
+      var active = prefsActiveCategory && categories.includes(prefsActiveCategory) ? prefsActiveCategory : categories[0];
+      renderCategoryPrefs(active);
+    }
   } catch {
     contentEl.innerHTML = '<div class="empty">Failed to load preferences</div>';
   }
 }
 
-async function addPref(section) {
-  var input = document.getElementById('pref-add-' + section);
+function addCategory() {
+  var name = prompt('Category name (e.g. books, audiobooks, comics):');
+  if (!name || !name.trim()) return;
+  var key = name.trim().toLowerCase().replace(/\\s+/g, '-');
+  if (prefsData[key]) { renderCategoryPrefs(key); return; }
+  prefsData[key] = { likes: [], dislikes: [] };
+  // Write empty category by adding and immediately removing a placeholder
+  // Actually just render it locally — it will be persisted on first add
+  renderCategoryPrefs(key);
+}
+
+async function addPref(category, section) {
+  var input = document.getElementById('pref-add-' + category + '-' + section);
   if (!input || !input.value.trim()) return;
   try {
     await fetch('/api/preferences', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ section: section, text: input.value.trim() })
+      body: JSON.stringify({ category: category, section: section, text: input.value.trim() })
     });
-    loadPreferences();
+    var res = await fetch('/api/preferences');
+    prefsData = await res.json();
+    renderCategoryPrefs(category);
   } catch {}
 }
 
-async function editPref(section, index) {
-  var items = prefsData[section] || [];
+async function editPref(category, section, index) {
+  var cat = prefsData[category] || {};
+  var items = cat[section] || [];
   var current = items[index] ? items[index].text : '';
   var newText = prompt('Edit preference:', current);
   if (newText === null || newText.trim() === '' || newText === current) return;
@@ -74,21 +121,25 @@ async function editPref(section, index) {
     await fetch('/api/preferences', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ section: section, index: index, text: newText.trim() })
+      body: JSON.stringify({ category: category, section: section, index: index, text: newText.trim() })
     });
-    loadPreferences();
+    var res = await fetch('/api/preferences');
+    prefsData = await res.json();
+    renderCategoryPrefs(category);
   } catch {}
 }
 
-async function deletePref(section, index) {
+async function deletePref(category, section, index) {
   if (!confirm('Remove this preference?')) return;
   try {
     await fetch('/api/preferences', {
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ section: section, index: index })
+      body: JSON.stringify({ category: category, section: section, index: index })
     });
-    loadPreferences();
+    var res = await fetch('/api/preferences');
+    prefsData = await res.json();
+    renderCategoryPrefs(category);
   } catch {}
 }
 `;

--- a/test/fixtures/memory/preferences.yaml
+++ b/test/fixtures/memory/preferences.yaml
@@ -1,22 +1,35 @@
 preferences:
-  likes:
-    - text: "Hard sci-fi with rigorous world-building and internal logic"
-      source: agent
-    - text: "Competent protagonists who solve problems methodically (Andy Weir style)"
-      source: agent
-    - text: "Deeply researched narrative nonfiction, author-narrated audiobooks"
-      source: agent
-    - text: "Tom King comics (Mister Miracle, Batman, Wonder Woman)"
-      source: user
-  dislikes:
-    - text: "Stories that sacrifice world-building consistency for plot convenience"
-      source: agent
-    - text: "YA dystopian fiction with arbitrary rules"
-      source: user
-  notes:
-    - text: "Has Netflix, no other streaming subscriptions currently"
-      source: user
-    - text: "Prefers EPUB over PDF for books"
-      source: user
-    - text: "San Diego Public Library card available for Libby/Hoopla"
-      source: agent
+  books:
+    likes:
+      - text: "Hard sci-fi with rigorous world-building and internal logic"
+        source: agent
+      - text: "Competent protagonists who solve problems methodically (Andy Weir style)"
+        source: agent
+    dislikes:
+      - text: "Stories that sacrifice world-building consistency for plot convenience"
+        source: agent
+      - text: "Game-universe novels (Doom, StarCraft, etc.)"
+        source: user
+  audiobooks:
+    likes:
+      - text: "Deeply researched narrative nonfiction, author-narrated"
+        source: agent
+      - text: "Under 12 hours ideal"
+        source: user
+    dislikes:
+      - text: "Complex multi-character casts (hard to track in audio)"
+        source: user
+  comics:
+    likes:
+      - text: "Tom King (Mister Miracle, Batman, Wonder Woman)"
+        source: user
+      - text: "Game-universe content is fine here"
+        source: user
+    dislikes: []
+  short-form-video:
+    likes:
+      - text: "Gaming content (Doom, StarCraft, etc.)"
+        source: user
+      - text: "Engineering and space content"
+        source: agent
+    dislikes: []

--- a/test/sources-preferences.test.js
+++ b/test/sources-preferences.test.js
@@ -137,21 +137,22 @@ describe('POST /api/sources/:id/deny', () => {
   });
 });
 
-// --- Preferences ---
+// --- Preferences (per-category) ---
 
 describe('GET /api/preferences', () => {
-  it('returns preference model from memory/preferences.yaml', async () => {
+  it('returns per-category preference model', async () => {
     const { server } = createTestSvr(fixturesDir);
     await new Promise(r => server.listen(0, r));
     const port = server.address().port;
 
     const { status, data } = await fetchJSON(port, '/api/preferences');
     assert.equal(status, 200);
-    assert.ok(Array.isArray(data.likes));
-    assert.ok(Array.isArray(data.dislikes));
-    assert.ok(Array.isArray(data.notes));
-    assert.ok(data.likes.length >= 3);
-    assert.equal(data.likes[0].source, 'agent');
+    assert.ok(data.books, 'should have books category');
+    assert.ok(data.audiobooks, 'should have audiobooks category');
+    assert.ok(Array.isArray(data.books.likes));
+    assert.ok(Array.isArray(data.books.dislikes));
+    assert.ok(data.books.likes.length >= 1);
+    assert.equal(data.books.likes[0].source, 'agent');
 
     server.close();
   });
@@ -164,9 +165,7 @@ describe('GET /api/preferences', () => {
 
     const { status, data } = await fetchJSON(port, '/api/preferences');
     assert.equal(status, 200);
-    assert.deepEqual(data.likes, []);
-    assert.deepEqual(data.dislikes, []);
-    assert.deepEqual(data.notes, []);
+    assert.deepEqual(data, {});
 
     server.close();
     fs.rmSync(tmpDir, { recursive: true });
@@ -174,7 +173,7 @@ describe('GET /api/preferences', () => {
 });
 
 describe('POST /api/preferences', () => {
-  it('adds a new like entry with source: user', async () => {
+  it('adds entry to a category with source: user', async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prefs-add-'));
     const memDir = path.join(tmpDir, 'memory');
     fs.mkdirSync(memDir, { recursive: true });
@@ -187,18 +186,57 @@ describe('POST /api/preferences', () => {
     const { status } = await fetchJSON(port, '/api/preferences', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ section: 'likes', text: 'Space opera with big fleet battles' }),
+      body: JSON.stringify({ category: 'books', section: 'likes', text: 'Space opera with fleet battles' }),
     });
     assert.equal(status, 200);
 
-    // Verify it was added
     const { data } = await fetchJSON(port, '/api/preferences');
-    const added = data.likes[data.likes.length - 1];
-    assert.equal(added.text, 'Space opera with big fleet battles');
+    const added = data.books.likes[data.books.likes.length - 1];
+    assert.equal(added.text, 'Space opera with fleet battles');
     assert.equal(added.source, 'user');
 
     server.close();
     fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('creates new category on first add', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prefs-newcat-'));
+    const memDir = path.join(tmpDir, 'memory');
+    fs.mkdirSync(memDir, { recursive: true });
+    fs.copyFileSync(path.join(fixturesDir, 'memory', 'preferences.yaml'), path.join(memDir, 'preferences.yaml'));
+
+    const { server } = createTestSvr(tmpDir);
+    await new Promise(r => server.listen(0, r));
+    const port = server.address().port;
+
+    const { status } = await fetchJSON(port, '/api/preferences', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ category: 'movies', section: 'likes', text: 'Harrison Ford' }),
+    });
+    assert.equal(status, 200);
+
+    const { data } = await fetchJSON(port, '/api/preferences');
+    assert.ok(data.movies, 'movies category should exist');
+    assert.equal(data.movies.likes[0].text, 'Harrison Ford');
+
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('rejects missing category', async () => {
+    const { server } = createTestSvr(fixturesDir);
+    await new Promise(r => server.listen(0, r));
+    const port = server.address().port;
+
+    const { status } = await fetchJSON(port, '/api/preferences', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ section: 'likes', text: 'test' }),
+    });
+    assert.equal(status, 400);
+
+    server.close();
   });
 
   it('rejects invalid section', async () => {
@@ -209,7 +247,7 @@ describe('POST /api/preferences', () => {
     const { status } = await fetchJSON(port, '/api/preferences', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ section: 'invalid', text: 'test' }),
+      body: JSON.stringify({ category: 'books', section: 'notes', text: 'test' }),
     });
     assert.equal(status, 400);
 
@@ -218,7 +256,7 @@ describe('POST /api/preferences', () => {
 });
 
 describe('PUT /api/preferences', () => {
-  it('updates an entry by index', async () => {
+  it('updates entry by category + section + index', async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prefs-put-'));
     const memDir = path.join(tmpDir, 'memory');
     fs.mkdirSync(memDir, { recursive: true });
@@ -231,12 +269,12 @@ describe('PUT /api/preferences', () => {
     const { status } = await fetchJSON(port, '/api/preferences', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ section: 'likes', index: 0, text: 'Updated preference text' }),
+      body: JSON.stringify({ category: 'books', section: 'likes', index: 0, text: 'Updated preference' }),
     });
     assert.equal(status, 200);
 
     const { data } = await fetchJSON(port, '/api/preferences');
-    assert.equal(data.likes[0].text, 'Updated preference text');
+    assert.equal(data.books.likes[0].text, 'Updated preference');
 
     server.close();
     fs.rmSync(tmpDir, { recursive: true });
@@ -250,7 +288,7 @@ describe('PUT /api/preferences', () => {
     const { status } = await fetchJSON(port, '/api/preferences', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ section: 'likes', index: 999, text: 'test' }),
+      body: JSON.stringify({ category: 'books', section: 'likes', index: 999, text: 'test' }),
     });
     assert.equal(status, 400);
 
@@ -259,7 +297,7 @@ describe('PUT /api/preferences', () => {
 });
 
 describe('DELETE /api/preferences', () => {
-  it('removes an entry by index', async () => {
+  it('removes entry by category + section + index', async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prefs-del-'));
     const memDir = path.join(tmpDir, 'memory');
     fs.mkdirSync(memDir, { recursive: true });
@@ -269,19 +307,18 @@ describe('DELETE /api/preferences', () => {
     await new Promise(r => server.listen(0, r));
     const port = server.address().port;
 
-    // Get initial count
     const { data: before } = await fetchJSON(port, '/api/preferences');
-    const countBefore = before.dislikes.length;
+    const countBefore = before.books.dislikes.length;
 
     const { status } = await fetchJSON(port, '/api/preferences', {
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ section: 'dislikes', index: 0 }),
+      body: JSON.stringify({ category: 'books', section: 'dislikes', index: 0 }),
     });
     assert.equal(status, 200);
 
     const { data: after } = await fetchJSON(port, '/api/preferences');
-    assert.equal(after.dislikes.length, countBefore - 1);
+    assert.equal(after.books.dislikes.length, countBefore - 1);
 
     server.close();
     fs.rmSync(tmpDir, { recursive: true });


### PR DESCRIPTION
## Summary
Preferences are now organized per media category instead of globally. This prevents cross-category collisions — e.g., "likes gaming content" means different things for YouTube vs. books vs. comics.

**Schema change:**
- Before: `preferences.likes[]`, `preferences.dislikes[]`, `preferences.notes[]`
- After: `preferences.<category>.likes[]`, `preferences.<category>.dislikes[]`

**Notes section removed** — global context like streaming subscriptions is handled via the sources system (Netflix as an approved source implies library access). Global identity preferences belong in the agent's persona, not the preferences file.

**API body** changes from `{ section, index, text }` to `{ category, section, index, text }`.

**UI:** Category nav bar with entry counts, active category highlight, per-category likes/dislikes editing, "+ Category" button.

## Test plan
- [x] All 347 tests pass (2 new: create-new-category, reject-missing-category)
- [x] Visual verification via shot-scraper
- [x] Fixture updated with realistic per-category data (books, audiobooks, comics, short-form-video)

🤖 Generated with [Claude Code](https://claude.com/claude-code)