### PR TITLE
Add guided category creation with freeform context

### DIFF
--- a/lib/routes/preferences.js
+++ b/lib/routes/preferences.js
@@ -121,6 +121,40 @@ function register(routes, config) {
       sendJSON(res, 500, { error: err.message });
     }
   };
+
+  // POST /api/preferences/category-request — submit freeform context for a new category
+  // Writes to input/feedback/ for the agent to process on its next cycle
+  routes['POST /api/preferences/category-request'] = async (req, res) => {
+    try {
+      const body = JSON.parse(await readBody(req));
+      if (!body.category || typeof body.category !== 'string') {
+        return sendJSON(res, 400, { error: 'Category required' });
+      }
+      if (!body.context || !body.context.trim()) {
+        return sendJSON(res, 400, { error: 'Context required' });
+      }
+
+      const feedbackDir = path.join(agentDir, 'input', 'feedback');
+      if (!fs.existsSync(feedbackDir)) fs.mkdirSync(feedbackDir, { recursive: true });
+
+      const category = body.category.trim().toLowerCase().replace(/\s+/g, '-');
+      const feedbackFile = path.join(feedbackDir, `category-${category}.feedback.yaml`);
+      const now = new Date().toISOString();
+      const yamlStr = `type: category-request\ncategory: ${category}\nsubmitted_at: ${now}\ncontext: |\n${body.context.trim().split('\n').map(l => '  ' + l).join('\n')}\n`;
+      fs.writeFileSync(feedbackFile, yamlStr);
+
+      // Also ensure the category exists in preferences (empty, for immediate UI)
+      const prefs = readPrefs();
+      if (!prefs[category]) {
+        prefs[category] = { likes: [], dislikes: [] };
+        writePrefs(prefs);
+      }
+
+      sendJSON(res, 200, { ok: true, category });
+    } catch (err) {
+      sendJSON(res, 500, { error: err.message });
+    }
+  };
 }
 
 module.exports = { register };

--- a/lib/ui/tabs/preferences.js
+++ b/lib/ui/tabs/preferences.js
@@ -85,15 +85,65 @@ async function loadPreferences() {
   }
 }
 
+var showingCategoryForm = false;
+
 function addCategory() {
-  var name = prompt('Category name (e.g. books, audiobooks, comics):');
-  if (!name || !name.trim()) return;
-  var key = name.trim().toLowerCase().replace(/\\s+/g, '-');
-  if (prefsData[key]) { renderCategoryPrefs(key); return; }
-  prefsData[key] = { likes: [], dislikes: [] };
-  // Write empty category by adding and immediately removing a placeholder
-  // Actually just render it locally — it will be persisted on first add
-  renderCategoryPrefs(key);
+  if (showingCategoryForm) return;
+  showingCategoryForm = true;
+  var contentEl = document.getElementById('content');
+  var categories = Object.keys(prefsData).sort();
+
+  var html = '<div class="status-section">';
+  if (categories.length > 0) {
+    html += renderPrefsCategoryNav(null);
+  }
+  html += '<h3 style="margin:0 0 12px;font-size:16px">Add Category</h3>';
+  html += '<div style="margin-bottom:12px">';
+  html += '<label style="display:block;font-size:13px;color:#555;margin-bottom:4px;font-weight:600">Category name</label>';
+  html += '<input type="text" id="new-cat-name" placeholder="e.g. audiobooks, comics, movies..." style="width:100%;max-width:300px;padding:6px 10px;border:1px solid #ddd;border-radius:4px;font-size:13px;font-family:inherit;box-sizing:border-box">';
+  html += '</div>';
+  html += '<div style="margin-bottom:12px">';
+  html += '<label style="display:block;font-size:13px;color:#555;margin-bottom:4px;font-weight:600">Tell ContentBot about your preferences</label>';
+  html += '<textarea id="new-cat-context" rows="5" placeholder="Describe what you like in this category. You might mention:\\n- What kinds of content you enjoy\\n- Formats you prefer (epub, audiobook, cbz...)\\n- Where you currently get this content\\n- What you don\\'t want\\n\\nExample: I listen on Libby mostly. I like narrative nonfiction, author-narrated, under 12 hours. Can\\'t track complex character casts in audio." style="width:100%;box-sizing:border-box;padding:8px;border:1px solid #ddd;border-radius:4px;font-size:13px;font-family:inherit;resize:vertical;line-height:1.5"></textarea>';
+  html += '</div>';
+  html += '<div style="display:flex;gap:8px">';
+  html += '<button class="refresh-btn" style="background:#1a73e8;color:#fff;border-color:#1a73e8" onclick="submitNewCategory()">Create Category</button>';
+  html += '<button class="refresh-btn" onclick="cancelNewCategory()">Cancel</button>';
+  html += '</div>';
+  html += '</div>';
+  contentEl.innerHTML = html;
+}
+
+function cancelNewCategory() {
+  showingCategoryForm = false;
+  loadPreferences();
+}
+
+async function submitNewCategory() {
+  var nameEl = document.getElementById('new-cat-name');
+  var contextEl = document.getElementById('new-cat-context');
+  var name = nameEl ? nameEl.value.trim() : '';
+  var context = contextEl ? contextEl.value.trim() : '';
+
+  if (!name) { alert('Please enter a category name'); return; }
+  if (!context) { alert('Please describe your preferences for this category — it helps ContentBot make better recommendations from the start'); return; }
+
+  var key = name.toLowerCase().replace(/\\s+/g, '-');
+
+  try {
+    // Submit the freeform context as a category request for the agent to process
+    await fetch('/api/preferences/category-request', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ category: key, context: context })
+    });
+    showingCategoryForm = false;
+    // Also create the category locally so it appears immediately
+    if (!prefsData[key]) prefsData[key] = { likes: [], dislikes: [] };
+    renderCategoryPrefs(key);
+  } catch {
+    alert('Failed to create category');
+  }
 }
 
 async function addPref(category, section) {

--- a/test/sources-preferences.test.js
+++ b/test/sources-preferences.test.js
@@ -324,3 +324,56 @@ describe('DELETE /api/preferences', () => {
     fs.rmSync(tmpDir, { recursive: true });
   });
 });
+
+describe('POST /api/preferences/category-request', () => {
+  it('writes feedback file and creates empty category', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cat-req-'));
+    const memDir = path.join(tmpDir, 'memory');
+    fs.mkdirSync(memDir, { recursive: true });
+    fs.copyFileSync(path.join(fixturesDir, 'memory', 'preferences.yaml'), path.join(memDir, 'preferences.yaml'));
+
+    const { server } = createTestSvr(tmpDir);
+    await new Promise(r => server.listen(0, r));
+    const port = server.address().port;
+
+    const { status, data } = await fetchJSON(port, '/api/preferences/category-request', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ category: 'movies', context: 'I like Harrison Ford. Action sci-fi. No horror.' }),
+    });
+    assert.equal(status, 200);
+    assert.equal(data.category, 'movies');
+
+    // Verify feedback file was written
+    const fbPath = path.join(tmpDir, 'input', 'feedback', 'category-movies.feedback.yaml');
+    assert.ok(fs.existsSync(fbPath), 'Feedback file should exist');
+    const fbContent = fs.readFileSync(fbPath, 'utf-8');
+    assert.ok(fbContent.includes('type: category-request'));
+    assert.ok(fbContent.includes('category: movies'));
+    assert.ok(fbContent.includes('Harrison Ford'));
+
+    // Verify category was added to preferences
+    const { data: prefs } = await fetchJSON(port, '/api/preferences');
+    assert.ok(prefs.movies, 'movies category should exist');
+    assert.deepEqual(prefs.movies.likes, []);
+    assert.deepEqual(prefs.movies.dislikes, []);
+
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('rejects missing context', async () => {
+    const { server } = createTestSvr(fixturesDir);
+    await new Promise(r => server.listen(0, r));
+    const port = server.address().port;
+
+    const { status } = await fetchJSON(port, '/api/preferences/category-request', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ category: 'movies' }),
+    });
+    assert.equal(status, 400);
+
+    server.close();
+  });
+});


### PR DESCRIPTION
## Summary
Replaces the bare `prompt()` for adding categories with an inline form containing:
- Category name input
- Freeform textarea with descriptive placeholder guiding the user to mention preferences, formats, sources, and exclusions
- Create Category / Cancel buttons

New `POST /api/preferences/category-request` endpoint:
- Writes freeform context to `input/feedback/category-{name}.feedback.yaml` for the agent to process next cycle
- Creates empty category in `preferences.yaml` for immediate UI display
- Agent reads the feedback file and extracts structured likes/dislikes, suggests sources, etc.

## Test plan
- [x] All 349 tests pass (2 new)
- [x] Category request writes feedback YAML with correct fields
- [x] Empty category created in preferences.yaml on submit
- [x] Missing context rejected with 400
- [x] Visual verification via shot-scraper

🤖 Generated with [Claude Code](https://claude.com/claude-code)