### PR TITLE
Add thumbnail_strategy field to source schema

### DIFF
--- a/lib/schemas/source.yaml
+++ b/lib/schemas/source.yaml
@@ -1,0 +1,74 @@
+# Source schema — defines the fields that agent-portal understands
+# for content sources in config/sources.yaml.
+#
+# Agents may add additional fields beyond this schema. Unknown fields
+# pass through the API (GET /api/sources) but are not rendered in the
+# portal UI unless explicitly supported.
+
+fields:
+  - name: id
+    type: string
+    required: true
+    description: Unique identifier for this source (kebab-case)
+    example: archive-org
+
+  - name: name
+    type: string
+    required: true
+    description: Human-readable display name
+    example: Archive.org
+
+  - name: url
+    type: string
+    required: true
+    description: Base URL for the source
+    example: https://archive.org
+
+  - name: type
+    type: string
+    required: true
+    description: How content from this source is accessed
+    values: [link-only, downloadable, torrent]
+    details: |
+      link-only: portal links to the source (streaming, purchase pages)
+      downloadable: agent can download files (epub, cbz, audio, video)
+      torrent: agent can operate a torrent client (Phase 3)
+
+  - name: status
+    type: string
+    required: true
+    description: Whether the agent may recommend content from this source
+    values: [approved, pending, denied]
+    details: |
+      approved: agent can recommend from this source
+      pending: agent discovered this source but user hasn't approved it yet
+      denied: user rejected this source
+
+  - name: categories
+    type: array of strings
+    required: true
+    description: Which media categories this source serves
+    example: [comics, books]
+
+  - name: thumbnail_strategy
+    type: text (multiline)
+    required: false
+    description: |
+      Freeform instructions for how the agent should find thumbnail
+      images for items from this source. The agent reads this when
+      creating content items and uses it to populate metadata.cover_url.
+    example: |
+      Use the Archive.org thumbnail API: https://archive.org/services/img/{identifier}
+      where {identifier} is the last path segment of the item URL.
+
+# File format: config/sources.yaml
+# ─────────────────────────────────
+# sources:
+#   - id: archive-org
+#     name: Archive.org
+#     url: https://archive.org
+#     type: downloadable
+#     status: approved
+#     categories: [comics, books]
+#     thumbnail_strategy: |
+#       Use https://archive.org/services/img/{identifier}

--- a/lib/ui/tabs/sources.js
+++ b/lib/ui/tabs/sources.js
@@ -85,6 +85,9 @@ function renderSourceRow(s) {
   if (s.hasCredentials) {
     html += '<span style="font-size:10px;padding:1px 5px;border-radius:3px;background:#e8eaf6;color:#283593">🔑 Credentials</span>';
   }
+  if (s.thumbnail_strategy) {
+    html += '<span style="font-size:10px;padding:1px 5px;border-radius:3px;background:#fce4ec;color:#880e4f" title="' + escapeHtml(s.thumbnail_strategy.trim()) + '">🖼 Thumbnail</span>';
+  }
   html += '<div style="margin-left:auto;display:flex;gap:4px">';
   if (s.status !== 'approved') {
     html += '<button class="refresh-btn" style="padding:2px 8px;font-size:11px;background:#e8f5e9;color:#2e7d32" onclick="approveSource(\\'' + escapeHtml(s.id) + '\\')">✓ Approve</button>';

--- a/test/fixtures/config/sources.yaml
+++ b/test/fixtures/config/sources.yaml
@@ -5,18 +5,26 @@ sources:
     type: downloadable
     status: approved
     categories: [books, audiobooks]
+    thumbnail_strategy: |
+      Use the Archive.org thumbnail API: https://archive.org/services/img/{identifier}
+      where {identifier} is the last path segment of the item URL.
+      Example: https://archive.org/details/maboroshi0000king → https://archive.org/services/img/maboroshi0000king
   - id: audible
     name: Audible
     url: https://www.audible.com
     type: link-only
     status: approved
     categories: [audiobooks]
+    thumbnail_strategy: |
+      Fetch the Audible product page and extract the og:image meta tag.
   - id: youtube
     name: YouTube
     url: https://youtube.com
     type: link-only
     status: approved
     categories: [short-form-video]
+    thumbnail_strategy: |
+      Use the YouTube thumbnail URL pattern: https://img.youtube.com/vi/{video_id}/hqdefault.jpg
   - id: dcui
     name: DC Universe Infinite
     url: https://www.dcuniverseinfinite.com


### PR DESCRIPTION
## Summary
Sources can now include a `thumbnail_strategy` field — freeform instructions for how the agent should find thumbnail images for items from that source.

- Portal defines the schema field; agent reads and executes the strategy when populating `metadata.cover_url`
- Sources tab shows a 🖼 Thumbnail badge with strategy text on hover
- Fixture sources updated with strategies for Archive.org (API pattern), YouTube (img URL pattern), Audible (og:image)

## Test plan
- [x] All 349 tests pass
- [x] `thumbnail_strategy` passed through in GET /api/sources response via existing `...s` spread

🤖 Generated with [Claude Code](https://claude.com/claude-code)