### PR TITLE
Library: hide disliked items by default, add visual rating markers

### DIFF
--- a/lib/routes/badges.js
+++ b/lib/routes/badges.js
@@ -62,11 +62,13 @@ function register(routes, config) {
         const feedbackDir = path.join(agentDir, 'input', 'feedback');
         const files = fs.readdirSync(itemsDir)
           .filter(f => f.endsWith('.yaml') || f.endsWith('.yml'));
+        const processedDir = path.join(feedbackDir, 'processed');
         let unrated = 0;
         for (const f of files) {
           const id = f.replace(/\.ya?ml$/, '');
           const feedbackFile = id + '.feedback.yaml';
-          if (!fs.existsSync(path.join(feedbackDir, feedbackFile))) unrated++;
+          if (!fs.existsSync(path.join(feedbackDir, feedbackFile))
+              && !fs.existsSync(path.join(processedDir, feedbackFile))) unrated++;
         }
         if (unrated > 0) badges.library = unrated;
       } catch {}

--- a/lib/routes/library.js
+++ b/lib/routes/library.js
@@ -16,14 +16,18 @@ function getLibraryItems(agentDir, dataDir) {
       try {
         const content = fs.readFileSync(path.join(itemsDir, f), 'utf-8');
         const item = yaml.load(content);
-        // Join with feedback
+        // Join with feedback (check both active and processed dirs)
         const feedbackFile = (item.id || f.replace(/\.ya?ml$/, '')) + '.feedback.yaml';
         const feedbackPath = path.join(feedbackDir, feedbackFile);
+        const processedDir = path.join(feedbackDir, 'processed');
+        const processedPath = path.join(processedDir, feedbackFile);
+        const activePath = fs.existsSync(feedbackPath) ? feedbackPath
+          : fs.existsSync(processedPath) ? processedPath : null;
         let rating = null;
         let reviewed = false;
-        if (fs.existsSync(feedbackPath)) {
+        if (activePath) {
           reviewed = true;
-          const fb = fs.readFileSync(feedbackPath, 'utf-8');
+          const fb = fs.readFileSync(activePath, 'utf-8');
           const match = fb.match(/^rating:\s*(\S+)/m);
           if (match) rating = match[1];
         }
@@ -85,11 +89,15 @@ function register(routes, config) {
     try {
       const content = fs.readFileSync(filePath, 'utf-8');
       const item = yaml.load(content);
-      // Merge feedback
+      // Merge feedback (check both active and processed dirs)
       const feedbackFile = id + '.feedback.yaml';
       const feedbackPath = path.join(feedbackDir, feedbackFile);
-      if (fs.existsSync(feedbackPath)) {
-        const fbContent = fs.readFileSync(feedbackPath, 'utf-8');
+      const processedDir = path.join(feedbackDir, 'processed');
+      const processedPath = path.join(processedDir, feedbackFile);
+      const activeFbPath = fs.existsSync(feedbackPath) ? feedbackPath
+        : fs.existsSync(processedPath) ? processedPath : null;
+      if (activeFbPath) {
+        const fbContent = fs.readFileSync(activeFbPath, 'utf-8');
         item.feedback = yaml.load(fbContent);
       }
       sendJSON(res, 200, item);

--- a/lib/ui/styles.js
+++ b/lib/ui/styles.js
@@ -276,6 +276,9 @@ ${authorCSS}
   .media-card-meta { display: flex; gap: 4px; align-items: center; flex-wrap: wrap; }
   .category-badge { font-size: 10px; padding: 2px 6px; border-radius: 4px; font-weight: 500; white-space: nowrap; }
   .rating-badge { font-size: 14px; }
+  .media-card-liked { border-left: 3px solid #2e7d32; }
+  .media-card-disliked { opacity: 0.5; border-left: 3px solid #c62828; }
+  .media-card-unrated { border-left: 3px solid #e0e0e0; }
   .media-detail { display: grid; grid-template-columns: 280px 1fr; gap: 24px; }
   .media-detail-cover-col { }
   .media-detail-cover { width: 100%; max-width: 280px; border-radius: 8px; }

--- a/lib/ui/tabs/library.js
+++ b/lib/ui/tabs/library.js
@@ -4,7 +4,7 @@
 function getLibraryTabJS() {
   return `
 var libraryItems = [];
-var libraryFilters = { category: '', source: '', rating: '', search: '' };
+var libraryFilters = { category: '', source: '', rating: 'default', search: '' };
 var librarySort = 'discovered';
 
 function getCategoryColor(cat) {
@@ -30,7 +30,8 @@ function renderLibraryGrid() {
   // Apply filters
   if (libraryFilters.category) items = items.filter(function(i) { return i.category === libraryFilters.category; });
   if (libraryFilters.source) items = items.filter(function(i) { return i.source === libraryFilters.source; });
-  if (libraryFilters.rating === 'up') items = items.filter(function(i) { return i.rating === 'up'; });
+  if (libraryFilters.rating === 'default') items = items.filter(function(i) { return i.rating !== 'down'; });
+  else if (libraryFilters.rating === 'up') items = items.filter(function(i) { return i.rating === 'up'; });
   else if (libraryFilters.rating === 'down') items = items.filter(function(i) { return i.rating === 'down'; });
   else if (libraryFilters.rating === 'unrated') items = items.filter(function(i) { return !i.rating; });
   if (libraryFilters.search) {
@@ -69,10 +70,11 @@ function renderLibraryGrid() {
   html += '</select>';
 
   html += '<select id="lib-rating-filter" onchange="libraryFilters.rating=this.value;renderLibraryGrid()">';
-  html += '<option value=""' + (!libraryFilters.rating ? ' selected' : '') + '>All ratings</option>';
+  html += '<option value="default"' + (libraryFilters.rating === 'default' ? ' selected' : '') + '>Liked + Unrated</option>';
   html += '<option value="up"' + (libraryFilters.rating === 'up' ? ' selected' : '') + '>👍 Liked</option>';
-  html += '<option value="down"' + (libraryFilters.rating === 'down' ? ' selected' : '') + '>👎 Disliked</option>';
   html += '<option value="unrated"' + (libraryFilters.rating === 'unrated' ? ' selected' : '') + '>Unrated</option>';
+  html += '<option value="down"' + (libraryFilters.rating === 'down' ? ' selected' : '') + '>👎 Disliked</option>';
+  html += '<option value="all"' + (libraryFilters.rating === 'all' ? ' selected' : '') + '>All</option>';
   html += '</select>';
 
   html += '<select id="lib-sort" onchange="librarySort=this.value;renderLibraryGrid()">';
@@ -97,7 +99,11 @@ function renderLibraryGrid() {
       if (item.rating === 'up') ratingBadge = '<span class="rating-badge rating-up">👍</span>';
       else if (item.rating === 'down') ratingBadge = '<span class="rating-badge rating-down">👎</span>';
 
-      html += '<div class="media-card" onclick="viewLibraryItem(\\'' + escapeHtml(item.id) + '\\')">';
+      var cardClass = 'media-card';
+      if (item.rating === 'up') cardClass += ' media-card-liked';
+      else if (item.rating === 'down') cardClass += ' media-card-disliked';
+      else cardClass += ' media-card-unrated';
+      html += '<div class="' + cardClass + '" onclick="viewLibraryItem(\\'' + escapeHtml(item.id) + '\\')">';
       html += coverHtml;
       html += '<div class="media-card-body">';
       html += '<div class="media-card-title">' + escapeHtml(item.title || 'Untitled') + '</div>';

--- a/test/library.test.js
+++ b/test/library.test.js
@@ -124,6 +124,43 @@ describe('GET /api/library/:id', () => {
     server.close();
   });
 
+  it('merges feedback from processed/ subdirectory', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'library-processed-'));
+    const itemsDir = path.join(tmpDir, 'content', 'items');
+    const processedDir = path.join(tmpDir, 'input', 'feedback', 'processed');
+    fs.mkdirSync(itemsDir, { recursive: true });
+    fs.mkdirSync(processedDir, { recursive: true });
+    fs.writeFileSync(path.join(itemsDir, 'test-item.yaml'),
+      'id: test-item\ntitle: Test Item\ncategory: comics\n');
+    fs.writeFileSync(path.join(processedDir, 'test-item.feedback.yaml'),
+      'rating: up\nnotes: Great stuff\n');
+
+    const config = {
+      name: 'Test', port: 0, agentDir: tmpDir,
+      cronFile: '/nonexistent/cron', lockFile: '/tmp/test-processed-lock',
+      _serverStartTime: Date.now(),
+      features: { library: { dataDir: 'content/items' } },
+    };
+    const routes = {};
+    require('../lib/routes/library').register(routes, config);
+    const server = createServer(config, { routes, getHTML: () => '<html>test</html>' });
+    await new Promise(resolve => server.listen(0, resolve));
+    const port = server.address().port;
+
+    // List should show as rated
+    const { data: list } = await fetchJSON(port, '/api/library');
+    assert.equal(list[0].rating, 'up');
+    assert.equal(list[0].reviewed, true);
+
+    // Detail should merge feedback
+    const { data: detail } = await fetchJSON(port, '/api/library/test-item');
+    assert.ok(detail.feedback);
+    assert.equal(detail.feedback.rating, 'up');
+
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
   it('returns item without feedback when none exists', async () => {
     const { server } = createLibraryServer();
     await new Promise(resolve => server.listen(0, resolve));


### PR DESCRIPTION
## Summary
- Default filter is now "Liked + Unrated" — disliked items hidden but accessible via Disliked filter option
- Filter options: Liked + Unrated (default), Liked, Unrated, Disliked, All
- Visual markers on cards: green left border (liked), gray left border (unrated), red left border + opacity (disliked)

## Test plan
- [x] All 349 tests pass
- [x] Visual verification: green/gray borders visible, disliked items hidden by default
- [x] Disliked filter shows empty state correctly
- [x] All filter shows everything including disliked

🤖 Generated with [Claude Code](https://claude.com/claude-code)