### PR TITLE
Restore --allowedTools defaults in harness config for claude-code

### DIFF
--- a/scripts/read-harness-config.sh
+++ b/scripts/read-harness-config.sh
@@ -9,6 +9,9 @@
 AGENT_DIR="${1:-.}"
 PORTAL_CONFIG="$AGENT_DIR/portal.config.json"
 
+# Default extraFlags for claude-code: --effort max + full allowedTools list
+CLAUDE_CODE_DEFAULT_FLAGS="--effort max --allowedTools Bash Edit Write Read Glob Grep WebSearch WebFetch mcp__playwright__browser_click mcp__playwright__browser_close mcp__playwright__browser_console_messages mcp__playwright__browser_drag mcp__playwright__browser_evaluate mcp__playwright__browser_file_upload mcp__playwright__browser_fill_form mcp__playwright__browser_handle_dialog mcp__playwright__browser_hover mcp__playwright__browser_navigate mcp__playwright__browser_navigate_back mcp__playwright__browser_network_requests mcp__playwright__browser_press_key mcp__playwright__browser_resize mcp__playwright__browser_run_code mcp__playwright__browser_select_option mcp__playwright__browser_snapshot mcp__playwright__browser_tabs mcp__playwright__browser_take_screenshot mcp__playwright__browser_type mcp__playwright__browser_wait_for"
+
 if [ -f "$PORTAL_CONFIG" ] && command -v node >/dev/null 2>&1; then
   eval "$(node -e "
     const c = JSON.parse(require('fs').readFileSync('$PORTAL_CONFIG', 'utf-8'));
@@ -21,6 +24,11 @@ else
   HARNESS_TYPE="claude-code"
   HARNESS_CMD="claude --print"
   HARNESS_EXTRA_FLAGS=""
+fi
+
+# Apply claude-code defaults when no extraFlags configured
+if [ "$HARNESS_TYPE" = "claude-code" ] && [ -z "$HARNESS_EXTRA_FLAGS" ]; then
+  HARNESS_EXTRA_FLAGS="$CLAUDE_CODE_DEFAULT_FLAGS"
 fi
 
 echo "export HARNESS_TYPE=${HARNESS_TYPE@Q}"


### PR DESCRIPTION
## Summary

- Adds `CLAUDE_CODE_DEFAULT_FLAGS` to `read-harness-config.sh` containing `--effort max` and the full `--allowedTools` list (8 core tools + 21 playwright tools)
- Applied automatically when `HARNESS_TYPE=claude-code` and no custom `extraFlags` are set in `portal.config.json`
- Fixes `wake.sh` and `respond.sh` which both use `$HARNESS_CMD $HARNESS_EXTRA_FLAGS`

## Root cause

PR #202 (`1d7edbc`) refactored all cycle scripts to use a pluggable harness config. The `--allowedTools` list and `--effort max` were removed from `wake.sh` but never added to the default `HARNESS_EXTRA_FLAGS`. This left every agent running without tool permissions in autonomous and respond cycles — tools returned "requires approval" with no approver present in `--print` mode.

The PM agent's 3pm cycle today hit this: it ran for 14 minutes but couldn't write files, call GitHub APIs, or persist any state.

## Test plan

- [x] All 349 existing tests pass
- [x] `read-harness-config.sh` outputs correct defaults for agent-pm (verified manually)
- [x] Telegram session tests pass (5/5)
- [ ] Next PM agent cycle should have full tool access

🤖 Generated with [Claude Code](https://claude.com/claude-code)