### PR TITLE
test: include shell tests in npm test (v1.5.14)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,13 +13,7 @@ jobs:
         with:
           node-version: "22"
       - run: npm install
-      - run: node --test test/*.test.js
-      - name: Run shell tests
-        run: |
-          for f in test/*.test.sh; do
-            echo "=== $f ==="
-            bash "$f" || exit 1
-          done
+      - run: npm test
 
   python-tests:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -204,7 +204,9 @@ agentDir/
 ### Run tests
 
 ```bash
-node --test test/*.test.js
+npm test              # runs both node and shell tests (same as CI)
+npm run test:node     # node tests only (test/*.test.js)
+npm run test:shell    # shell tests only (test/*.test.sh)
 ```
 
 ### Start the agent-controller

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-portal",
-  "version": "1.5.13",
+  "version": "1.5.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-portal",
-      "version": "1.5.13",
+      "version": "1.5.14",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,13 +1,15 @@
 {
   "name": "agent-portal",
-  "version": "1.5.13",
+  "version": "1.5.14",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {
     "agent-portal": "index.js"
   },
   "scripts": {
-    "test": "node --test test/*.test.js"
+    "test": "node --test test/*.test.js && for f in test/*.test.sh; do bash \"$f\" || exit 1; done",
+    "test:node": "node --test test/*.test.js",
+    "test:shell": "for f in test/*.test.sh; do bash \"$f\" || exit 1; done"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Problem

\`npm test\` ran only node tests (350) while CI ran both node tests AND shell tests (350 + 40 = 390). Developers running \`npm test\` locally were missing 40 tests of coverage — a regression in any of \`test/*.test.sh\` (framework-update, telegram-burst, telegram-session) would only surface on PR, not during local iteration.

Related to op-learning #63 (orphan shell tests got CI wiring in PR #220 but the \`npm test\` script stayed node-only).

## Change

\`\`\`diff
 "scripts": {
-  "test": "node --test test/*.test.js"
+  "test": "node --test test/*.test.js && for f in test/*.test.sh; do bash \"\$f\" || exit 1; done",
+  "test:node": "node --test test/*.test.js",
+  "test:shell": "for f in test/*.test.sh; do bash \"\$f\" || exit 1; done"
 }
\`\`\`

- \`npm test\` now runs both node and shell tests (same as CI).
- \`npm run test:node\` / \`npm run test:shell\` for targeted runs during iteration.
- CI workflow simplified to \`npm test\` (the inline for-loop from PR #220 moves to package.json — single source of truth).
- README "Run tests" section updated.
- Version 1.5.13 → 1.5.14, lockfile tracks (op-learning #62).

## Verification

\`\`\`
npm test          → 350 node pass + 11+24+5 shell pass = 390/390
npm run test:node → 350/350
npm run test:shell → 40/40
\`\`\`

No functional changes to any test file or source; this is test-runner plumbing.

## Out-of-scope observation

Noticed during verification: \`test/fixtures/logs/cycles/wake-steps.log\` gets appended to every \`npm test\` run. Cause: \`test/routes.test.js\` \`POST /api/cycle/run\` test spawns \`bash wake.sh\` with \`agentDir=test/fixtures\` (the default from \`createTestServer\`), and \`wake.sh\` writes \`<agentDir>/logs/cycles/wake-steps.log\` on startup. Not included in this PR — separate test-contamination class (similar to agentdeals op-learnings #48/#49/#54/#55). Will file a follow-up.