### PR TITLE
test: scope cycle run/respond tests to tmpdir (v1.5.15) (#222)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-portal",
-  "version": "1.5.14",
+  "version": "1.5.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-portal",
-      "version": "1.5.14",
+      "version": "1.5.15",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.5.14",
+  "version": "1.5.15",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -404,14 +404,16 @@ describe('POST /api/cron/toggle', () => {
 });
 
 describe('POST /api/cycle/run', () => {
-  let server, port;
+  let server, port, tmpDir;
   const lockFile = '/tmp/test-portal-lock-nonexistent-cycle';
 
   before(async () => {
     // Use a lock file that won't exist (so lock check says "not running")
     // Clean up stale markers from previous runs
     try { fs.unlinkSync(lockFile + '.starting'); } catch {}
-    const result = createTestServer({ lockFile });
+    // Use a tmpdir as agentDir so wake.sh writes its step log there, not in test/fixtures
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'portal-cycle-run-'));
+    const result = createTestServer({ lockFile, agentDir: tmpDir });
     server = result.server;
     await new Promise(resolve => server.listen(0, resolve));
     port = server.address().port;
@@ -420,6 +422,7 @@ describe('POST /api/cycle/run', () => {
   after(() => {
     server.close();
     try { fs.unlinkSync(lockFile + '.starting'); } catch {}
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {}
   });
 
   it('returns 200 when no cycle is running (wake.sh may not exist but spawn succeeds)', async () => {
@@ -433,13 +436,14 @@ describe('POST /api/cycle/run', () => {
 });
 
 describe('POST /api/cycle/respond', () => {
-  let server, port;
+  let server, port, tmpDir;
   const lockFile = '/tmp/test-portal-lock-nonexistent-respond';
 
   before(async () => {
     // Clean up stale markers from previous runs
     try { fs.unlinkSync(lockFile + '.starting'); } catch {}
-    const result = createTestServer({ lockFile });
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'portal-cycle-respond-'));
+    const result = createTestServer({ lockFile, agentDir: tmpDir });
     server = result.server;
     await new Promise(resolve => server.listen(0, resolve));
     port = server.address().port;
@@ -448,6 +452,7 @@ describe('POST /api/cycle/respond', () => {
   after(() => {
     server.close();
     try { fs.unlinkSync(lockFile + '.starting'); } catch {}
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {}
   });
 
   it('returns 200 when no cycle is running (respond.sh resolved from framework)', async () => {


### PR DESCRIPTION
Refs #222.

## Problem

Every `npm test` run appended 4 lines to `test/fixtures/logs/cycles/wake-steps.log` — surfaces as a modified file in `git status` after every local test iteration.

## Root cause

`test/routes.test.js` 'POST /api/cycle/run' block used `createTestServer({ lockFile })` without overriding `agentDir`, which defaults to `test/fixtures` in `createTestServer()`. The `/api/cycle/run` handler in `lib/routes/cycle.js` spawns `bash wake.sh <agentDir>` and returns 200 immediately without waiting. The detached `wake.sh` child then writes to `<agentDir>/logs/cycles/wake-steps.log` on startup (step log setup happens before it reads agent.yaml and aborts under `set -e`).

Same latent risk existed in the 'POST /api/cycle/respond' block — `respond.sh` also creates `logs/cycles/` early, but currently aborts before writing because the fixture has no `agent.yaml` (defense-in-depth fix here anyway).

## Fix

Both tests now scope `agentDir` to `fs.mkdtempSync(path.join(os.tmpdir(), 'portal-cycle-{run,respond}-'))` and clean up in `after()`. Mirrors the pattern already used in `test/badges.test.js` and other filesystem-scoped tests.

## Verification

- `npm test` → 390/390 pass (350 node + 40 shell)
- `git status` after `npm test` → clean (no `test/fixtures/logs/cycles/wake-steps.log` modification)
- Second `npm test` run → also clean
- No `/tmp/portal-cycle-*` tmpdir leak after test run

## Version

1.5.14 → 1.5.15 (package.json + package-lock.json per op-learning #62).