### PR TITLE
fix(memory): use OS CA bundle for HuggingFace HTTPS (v1.5.16)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-portal",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-portal",
-      "version": "1.5.15",
+      "version": "1.5.16",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/scripts/memory-index.py
+++ b/scripts/memory-index.py
@@ -17,6 +17,13 @@ import struct
 import sys
 from pathlib import Path
 
+# Prefer the OS CA bundle when present so HTTPS works inside TLS-intercepting
+# environments (e.g. mitmproxy-style sandboxes). httpx — which fastembed uses
+# to pull models from HuggingFace — defaults to certifi's bundle, which lacks
+# any system-injected proxy CA.
+if "SSL_CERT_FILE" not in os.environ and os.path.exists("/etc/ssl/certs/ca-certificates.crt"):
+    os.environ["SSL_CERT_FILE"] = "/etc/ssl/certs/ca-certificates.crt"
+
 import numpy as np
 from fastembed import TextEmbedding
 

--- a/scripts/memory-search.py
+++ b/scripts/memory-search.py
@@ -9,11 +9,19 @@ snippet, and relevance score.
 """
 
 import math
+import os
 import sqlite3
 import struct
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+
+# Prefer the OS CA bundle when present so HTTPS works inside TLS-intercepting
+# environments (e.g. mitmproxy-style sandboxes). httpx — which fastembed uses
+# to pull models from HuggingFace — defaults to certifi's bundle, which lacks
+# any system-injected proxy CA.
+if "SSL_CERT_FILE" not in os.environ and os.path.exists("/etc/ssl/certs/ca-certificates.crt"):
+    os.environ["SSL_CERT_FILE"] = "/etc/ssl/certs/ca-certificates.crt"
 
 import numpy as np
 from fastembed import TextEmbedding


### PR DESCRIPTION
## Summary

`scripts/memory-index.py` and `scripts/memory-search.py` both call fastembed's `TextEmbedding`, which downloads model files from HuggingFace via httpx. httpx defaults to certifi's CA bundle, which omits any system-injected proxy CA — so inside TLS-intercepting sandboxes (mitmproxy-style) every fresh-cache run hits `SSL CERTIFICATE_VERIFY_FAILED`. `/tmp/fastembed_cache` holding the downloaded model gets wiped between containers, so this fires on every fresh start.

## Symptom

Three consecutive memory-index failures across cycles 69, 70, 71 (Apr 25) triggered the occurrence-3 investigation rule (op-learning #86). Stack trace:

```
httpx.ConnectError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed:
unable to get local issuer certificate (_ssl.c:1000)
```

## Root cause

```text
$ openssl s_client -connect huggingface.co:443 < /dev/null
subject=CN = huggingface.co
issuer=CN = mitmproxy, O = mitmproxy
```

The connection is intercepted by mitmproxy. The mitmproxy CA is in the OS bundle at `/etc/ssl/certs/ca-certificates.crt` (verified: `openssl s_client -CAfile /etc/ssl/certs/...` → `Verify return code: 0 (ok)`), but **not** in certifi's bundle at `memory-venv/lib/python3.12/site-packages/certifi/cacert.pem` (verified: explicit `verify=certifi.where()` → fails).

httpx defaults to certifi for cross-platform predictability, ignoring `ssl.get_default_verify_paths()`. So every fastembed download fails inside this sandbox unless `SSL_CERT_FILE` is set.

## Fix

Add a 6-line guard at the top of each script that sets `SSL_CERT_FILE` to the OS bundle when present and the env var isn't already set. Both libraries (httpx, requests) honor `SSL_CERT_FILE` and route through certifi's `where()` resolution.

```python
if "SSL_CERT_FILE" not in os.environ and os.path.exists("/etc/ssl/certs/ca-certificates.crt"):
    os.environ["SSL_CERT_FILE"] = "/etc/ssl/certs/ca-certificates.crt"
```

Falls through harmlessly on macOS/dev machines where `/etc/ssl/certs/ca-certificates.crt` doesn't exist (certifi default remains).

## Verification

```text
$ rm -rf /tmp/fastembed_cache
$ memory-venv/bin/python scripts/memory-index.py /root/agent-coder
Loading embedding model (BAAI/bge-small-en-v1.5)...
Fetching 5 files: 100%|██████████| 5/5 [00:06<00:00,  1.37s/it]
[completes successfully]

$ rm -rf /tmp/fastembed_cache
$ memory-venv/bin/python scripts/memory-search.py "lockfile drift root cause" /root/agent-coder
[returns 5 ranked results — fresh model download succeeded]

$ npm test
# 390/390 passed (350 node + 40 shell)
```

Pre-fix reproduction: same commands without the env-var set fail with the SSL stack trace above.

## Test plan

- [x] `npm test` — 390/390 passes locally
- [x] Manual: wipe `/tmp/fastembed_cache`, run `memory-index.py` → completes
- [x] Manual: wipe `/tmp/fastembed_cache`, run `memory-search.py` → returns ranked results
- [x] Read fix on macOS-style path (no `/etc/ssl/certs/ca-certificates.crt`) → env var stays unset, certifi default applies — verified by reading the conditional
- [x] Version bumped 1.5.15 → 1.5.16 + lockfile updated (op-learning #62)