### PR TITLE
fix(memory): batch fastembed calls to avoid OOM on catch-up (v1.5.17)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-portal",
-  "version": "1.5.16",
+  "version": "1.5.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-portal",
-      "version": "1.5.16",
+      "version": "1.5.17",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.5.16",
+  "version": "1.5.17",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/scripts/memory-index.py
+++ b/scripts/memory-index.py
@@ -30,6 +30,7 @@ from fastembed import TextEmbedding
 EMBED_DIM = 384
 SIMILARITY_THRESHOLD = 0.92
 MODEL_NAME = "BAAI/bge-small-en-v1.5"
+EMBED_BATCH_SIZE = 50
 
 
 def init_db(db_path: str) -> sqlite3.Connection:
@@ -206,9 +207,13 @@ def main():
 
     print(f"Indexing {len(all_new)} new entries ({len(new_journal)} journal, {len(new_events)} events)...")
 
-    # Generate embeddings in batch
+    # Embed in chunks so a long catch-up after an outage doesn't OOM the worker
+    # — fastembed materializes the whole batch at peak, so 700+ entries can
+    # exceed available memory inside small containers.
     texts = [e["content"] for e in all_new]
-    embeddings = list(model.embed(texts))
+    embeddings = []
+    for i in range(0, len(texts), EMBED_BATCH_SIZE):
+        embeddings.extend(model.embed(texts[i:i + EMBED_BATCH_SIZE]))
 
     indexed = 0
     skipped = 0


### PR DESCRIPTION
## Summary

After PR #224 unblocked `memory-index.py` inside the TLS-intercepting sandbox, the first run faced a 700-entry backlog (the indexer had been silently failing for 32 days). fastembed materializes the whole batch at peak, so passing all 700 texts to `model.embed()` in one shot was SIGKILL'd by the OOM watcher.

## Symptom

```text
$ memory-venv/bin/python -u scripts/memory-index.py /root/agent-coder
Loading embedding model (BAAI/bge-small-en-v1.5)...
Indexing 700 new entries (360 journal, 340 events)...
/bin/bash: line 1: 23126 Killed   ... python -u scripts/memory-index.py ...
exit: 137
```

The `index_state` watermark only advances after the entire `model.embed()` call returns, so without batching the catch-up gets stuck — every subsequent run re-tries the same 700 entries and OOMs again.

## Fix

Process the embed call in chunks of `EMBED_BATCH_SIZE` (50). Total memory at completion is unchanged (still 700 × 384 floats stored), but peak working set drops to roughly one chunk's tensors at a time.

```python
embeddings = []
for i in range(0, len(texts), EMBED_BATCH_SIZE):
    embeddings.extend(model.embed(texts[i:i + EMBED_BATCH_SIZE]))
```

Steady state is unaffected — incremental cycles only add ~5 entries, well below the chunk threshold.

## Verification

```text
$ memory-venv/bin/python -u scripts/memory-index.py /root/agent-coder
Loading embedding model (BAAI/bge-small-en-v1.5)...
Indexing 700 new entries (360 journal, 340 events)...
Done. Indexed: 553, Skipped (duplicates): 147
```

Backlog cleared in one invocation; `index_state` watermarks advanced to today's entries.

## Test plan

- [x] `npm test` — 390/390 passes locally
- [x] Manual: 700-entry catch-up run → completes without OOM
- [x] Manual: subsequent invocation → "No new entries to index" (idempotent)
- [x] Version bumped 1.5.16 → 1.5.17 + lockfile updated