### PR TITLE
feat(preferences): add rated-items store for user-added content

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ require('./lib/routes/todos').register(routes, config);
 require('./lib/routes/library').register(routes, config);
 require('./lib/routes/sources').register(routes, config);
 require('./lib/routes/preferences').register(routes, config);
+require('./lib/routes/rated-items').register(routes, config);
 require('./lib/routes/media-files').register(routes, config);
 require('./lib/routes/badges').register(routes, config);
 require('./lib/routes/capabilities').register(routes, config);

--- a/lib/routes/rated-items.js
+++ b/lib/routes/rated-items.js
@@ -1,0 +1,142 @@
+// routes/rated-items.js — User-added content ratings (not tied to Library items)
+// Schema: memory/rated-items.yaml -> { items: [{ id, category, title, description, rating, created_at, processed_at }] }
+// Registered when features.library is configured.
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const { sendJSON, readBody } = require('../helpers');
+
+function register(routes, config) {
+  if (!config.features || !config.features.library) return;
+
+  const agentDir = config.agentDir || '.';
+  const file = path.join(agentDir, 'memory', 'rated-items.yaml');
+
+  function read() {
+    try {
+      const data = yaml.load(fs.readFileSync(file, 'utf-8'));
+      return (data && Array.isArray(data.items)) ? data.items : [];
+    } catch {
+      return [];
+    }
+  }
+
+  function write(items) {
+    const dir = path.dirname(file);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(file, yaml.dump({ items }, { lineWidth: -1 }));
+  }
+
+  function slugify(s) {
+    return String(s).toLowerCase().trim()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 40) || 'item';
+  }
+
+  function newId(title) {
+    const ts = Date.now().toString(36);
+    const rand = Math.random().toString(36).slice(2, 6);
+    return `rated-${ts}-${slugify(title)}-${rand}`;
+  }
+
+  function validateRating(r) {
+    return r === 'up' || r === 'down';
+  }
+
+  // GET /api/rated-items?category=... — list, optionally filtered. Newest first.
+  routes['GET /api/rated-items'] = (req, res, url) => {
+    const items = read();
+    const category = url && url.searchParams ? url.searchParams.get('category') : null;
+    const filtered = category ? items.filter(i => i.category === category) : items;
+    const sorted = filtered.slice().sort((a, b) => {
+      const ad = a.created_at || '';
+      const bd = b.created_at || '';
+      return bd.localeCompare(ad);
+    });
+    sendJSON(res, 200, sorted);
+  };
+
+  // POST /api/rated-items — { category, title, description, rating }
+  routes['POST /api/rated-items'] = async (req, res) => {
+    try {
+      const body = JSON.parse(await readBody(req));
+      if (!body.category || typeof body.category !== 'string') {
+        return sendJSON(res, 400, { error: 'Category required' });
+      }
+      if (!body.title || !String(body.title).trim()) {
+        return sendJSON(res, 400, { error: 'Title required' });
+      }
+      if (!validateRating(body.rating)) {
+        return sendJSON(res, 400, { error: 'Rating must be "up" or "down"' });
+      }
+      const items = read();
+      const item = {
+        id: newId(body.title),
+        category: body.category.trim(),
+        title: String(body.title).trim(),
+        description: body.description ? String(body.description).trim() : '',
+        rating: body.rating,
+        created_at: new Date().toISOString(),
+        processed_at: null,
+      };
+      items.push(item);
+      write(items);
+      sendJSON(res, 200, item);
+    } catch (err) {
+      sendJSON(res, 500, { error: err.message });
+    }
+  };
+
+  // PUT /api/rated-items — { id, title?, description?, rating?, category? }
+  routes['PUT /api/rated-items'] = async (req, res) => {
+    try {
+      const body = JSON.parse(await readBody(req));
+      if (!body.id) return sendJSON(res, 400, { error: 'id required' });
+      const items = read();
+      const idx = items.findIndex(i => i.id === body.id);
+      if (idx === -1) return sendJSON(res, 404, { error: 'Not found' });
+
+      const item = items[idx];
+      if (typeof body.title === 'string') {
+        if (!body.title.trim()) return sendJSON(res, 400, { error: 'Title cannot be empty' });
+        item.title = body.title.trim();
+      }
+      if (typeof body.description === 'string') {
+        item.description = body.description.trim();
+      }
+      if (typeof body.rating !== 'undefined') {
+        if (!validateRating(body.rating)) return sendJSON(res, 400, { error: 'Rating must be "up" or "down"' });
+        item.rating = body.rating;
+      }
+      if (typeof body.category === 'string' && body.category.trim()) {
+        item.category = body.category.trim();
+      }
+      // Edits invalidate prior agent processing — preferences will be re-extracted
+      item.processed_at = null;
+      write(items);
+      sendJSON(res, 200, item);
+    } catch (err) {
+      sendJSON(res, 500, { error: err.message });
+    }
+  };
+
+  // DELETE /api/rated-items — { id }
+  routes['DELETE /api/rated-items'] = async (req, res) => {
+    try {
+      const body = JSON.parse(await readBody(req));
+      if (!body.id) return sendJSON(res, 400, { error: 'id required' });
+      const items = read();
+      const idx = items.findIndex(i => i.id === body.id);
+      if (idx === -1) return sendJSON(res, 404, { error: 'Not found' });
+      items.splice(idx, 1);
+      write(items);
+      sendJSON(res, 200, { ok: true });
+    } catch (err) {
+      sendJSON(res, 500, { error: err.message });
+    }
+  };
+}
+
+module.exports = { register };

--- a/lib/ui/tabs/preferences.js
+++ b/lib/ui/tabs/preferences.js
@@ -5,6 +5,9 @@ function getPreferencesTabJS() {
   return `
 var prefsData = {};
 var prefsActiveCategory = null;
+var ratedItemsByCategory = {};
+var expandedRatedItem = null;
+var editingRatedItem = null;
 
 function renderPrefsSection(category, section, items, label) {
   var html = '<div style="margin-bottom:20px">';
@@ -38,8 +41,165 @@ function renderCategoryPrefs(category) {
   html += '<h3 style="margin:0 0 12px;font-size:16px;text-transform:capitalize">' + escapeHtml(category) + '</h3>';
   html += renderPrefsSection(category, 'likes', cat.likes || [], '👍 Likes');
   html += renderPrefsSection(category, 'dislikes', cat.dislikes || [], '👎 Dislikes');
+  html += '<div id="rated-items-' + escapeHtml(category) + '"></div>';
   html += '</div>';
   document.getElementById('content').innerHTML = html;
+  loadRatedItems(category);
+}
+
+function pendingBadge(item) {
+  if (item.processed_at) return '';
+  return '<span title="Awaiting next agent cycle" style="font-size:10px;padding:1px 5px;border-radius:3px;background:#fff3e0;color:#e65100;margin-left:6px">pending</span>';
+}
+
+function ratingIcon(rating) {
+  return rating === 'up'
+    ? '<span style="color:#2e7d32;font-size:14px">👍</span>'
+    : '<span style="color:#c62828;font-size:14px">👎</span>';
+}
+
+function renderRatedItemRow(item) {
+  var isExpanded = expandedRatedItem === item.id;
+  var isEditing = editingRatedItem === item.id;
+  var html = '<div style="border:1px solid #eee;border-radius:4px;padding:8px 10px;margin-bottom:6px;background:#fafafa">';
+
+  if (isEditing) {
+    html += '<div style="display:flex;gap:6px;margin-bottom:6px;align-items:center">';
+    html += '<select id="rated-edit-rating-' + item.id + '" style="padding:4px;font-size:12px">';
+    html += '<option value="up"' + (item.rating === 'up' ? ' selected' : '') + '>👍 Up</option>';
+    html += '<option value="down"' + (item.rating === 'down' ? ' selected' : '') + '>👎 Down</option>';
+    html += '</select>';
+    html += '<input type="text" id="rated-edit-title-' + item.id + '" value="' + escapeHtml(item.title) + '" style="flex:1;padding:4px 8px;border:1px solid #ddd;border-radius:4px;font-size:13px;font-family:inherit">';
+    html += '</div>';
+    html += '<textarea id="rated-edit-desc-' + item.id + '" rows="3" placeholder="Description (why you liked/disliked it)" style="width:100%;box-sizing:border-box;padding:6px 8px;border:1px solid #ddd;border-radius:4px;font-size:12px;font-family:inherit;resize:vertical">' + escapeHtml(item.description || '') + '</textarea>';
+    html += '<div style="display:flex;gap:6px;margin-top:6px">';
+    html += '<button class="refresh-btn" style="background:#1a73e8;color:#fff;border-color:#1a73e8;font-size:12px" onclick="saveRatedItem(\\'' + item.id + '\\')">Save</button>';
+    html += '<button class="refresh-btn" style="font-size:12px" onclick="cancelEditRatedItem()">Cancel</button>';
+    html += '</div>';
+  } else {
+    html += '<div style="display:flex;align-items:center;gap:8px;cursor:pointer" onclick="toggleRatedItem(\\'' + item.id + '\\')">';
+    html += '<div>' + ratingIcon(item.rating) + '</div>';
+    html += '<div style="flex:1;font-size:13px;color:#333;font-weight:500">' + escapeHtml(item.title) + pendingBadge(item) + '</div>';
+    html += '<button class="refresh-btn" style="padding:2px 6px;font-size:11px" onclick="event.stopPropagation();editRatedItem(\\'' + item.id + '\\')">Edit</button>';
+    html += '<button class="refresh-btn" style="padding:2px 6px;font-size:11px;color:#c62828" onclick="event.stopPropagation();deleteRatedItem(\\'' + item.id + '\\')">×</button>';
+    html += '</div>';
+    if (isExpanded && item.description) {
+      html += '<div style="margin-top:6px;padding-top:6px;border-top:1px dashed #eee;font-size:12px;color:#555;white-space:pre-wrap">' + escapeHtml(item.description) + '</div>';
+    }
+  }
+  html += '</div>';
+  return html;
+}
+
+function renderRatedItemsSection(category) {
+  var items = ratedItemsByCategory[category] || [];
+  var html = '<div style="margin-top:24px;padding-top:16px;border-top:1px solid #eee">';
+  html += '<h4 style="margin:0 0 6px;font-size:14px;color:#555">📚 Rated content <span style="color:#999;font-weight:normal">(' + items.length + ')</span></h4>';
+  html += '<p style="margin:0 0 10px;font-size:12px;color:#888">Add things you\\'ve seen, read, or played — the agent will use them to learn your taste on its next cycle.</p>';
+
+  if (items.length === 0) {
+    html += '<div style="font-size:12px;color:#999;font-style:italic;margin-bottom:10px">No rated items yet.</div>';
+  } else {
+    items.forEach(function(item) { html += renderRatedItemRow(item); });
+  }
+
+  // Add form
+  html += '<div style="margin-top:12px;padding:10px;border:1px dashed #ccc;border-radius:4px;background:#fff">';
+  html += '<div style="font-size:12px;color:#555;font-weight:600;margin-bottom:6px">Add rated content</div>';
+  html += '<input type="text" id="rated-add-title-' + category + '" placeholder="Title (e.g. The Godfather)" style="width:100%;box-sizing:border-box;padding:6px 8px;border:1px solid #ddd;border-radius:4px;font-size:13px;font-family:inherit;margin-bottom:6px">';
+  html += '<textarea id="rated-add-desc-' + category + '" rows="2" placeholder="Description — disambiguate (year, author, director...) and say what you liked or didn\\'t" style="width:100%;box-sizing:border-box;padding:6px 8px;border:1px solid #ddd;border-radius:4px;font-size:12px;font-family:inherit;resize:vertical;margin-bottom:6px"></textarea>';
+  html += '<div style="display:flex;gap:6px">';
+  html += '<button class="refresh-btn" style="font-size:12px;background:#e8f5e9;border-color:#a5d6a7" onclick="addRatedItem(\\'' + category + '\\',\\'up\\')">👍 Add as Like</button>';
+  html += '<button class="refresh-btn" style="font-size:12px;background:#ffebee;border-color:#ef9a9a" onclick="addRatedItem(\\'' + category + '\\',\\'down\\')">👎 Add as Dislike</button>';
+  html += '</div>';
+  html += '</div>';
+
+  html += '</div>';
+  return html;
+}
+
+async function loadRatedItems(category) {
+  try {
+    var res = await fetch('/api/rated-items?category=' + encodeURIComponent(category));
+    ratedItemsByCategory[category] = await res.json();
+  } catch {
+    ratedItemsByCategory[category] = [];
+  }
+  var el = document.getElementById('rated-items-' + category);
+  if (el) el.innerHTML = renderRatedItemsSection(category);
+}
+
+function toggleRatedItem(id) {
+  expandedRatedItem = expandedRatedItem === id ? null : id;
+  if (prefsActiveCategory) loadRatedItems(prefsActiveCategory);
+}
+
+function editRatedItem(id) {
+  editingRatedItem = id;
+  if (prefsActiveCategory) loadRatedItems(prefsActiveCategory);
+}
+
+function cancelEditRatedItem() {
+  editingRatedItem = null;
+  if (prefsActiveCategory) loadRatedItems(prefsActiveCategory);
+}
+
+async function saveRatedItem(id) {
+  var titleEl = document.getElementById('rated-edit-title-' + id);
+  var descEl = document.getElementById('rated-edit-desc-' + id);
+  var ratingEl = document.getElementById('rated-edit-rating-' + id);
+  if (!titleEl || !titleEl.value.trim()) { alert('Title required'); return; }
+  try {
+    await fetch('/api/rated-items', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: id,
+        title: titleEl.value.trim(),
+        description: descEl ? descEl.value : '',
+        rating: ratingEl ? ratingEl.value : 'up',
+      })
+    });
+    editingRatedItem = null;
+    if (prefsActiveCategory) loadRatedItems(prefsActiveCategory);
+  } catch {
+    alert('Failed to save');
+  }
+}
+
+async function deleteRatedItem(id) {
+  if (!confirm('Remove this rated item?')) return;
+  try {
+    await fetch('/api/rated-items', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: id })
+    });
+    if (prefsActiveCategory) loadRatedItems(prefsActiveCategory);
+  } catch {}
+}
+
+async function addRatedItem(category, rating) {
+  var titleEl = document.getElementById('rated-add-title-' + category);
+  var descEl = document.getElementById('rated-add-desc-' + category);
+  if (!titleEl || !titleEl.value.trim()) { alert('Title required'); return; }
+  try {
+    await fetch('/api/rated-items', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        category: category,
+        title: titleEl.value.trim(),
+        description: descEl ? descEl.value.trim() : '',
+        rating: rating,
+      })
+    });
+    titleEl.value = '';
+    if (descEl) descEl.value = '';
+    loadRatedItems(category);
+  } catch {
+    alert('Failed to add');
+  }
 }
 
 function renderPrefsCategoryNav(activeCategory) {

--- a/test/rated-items.test.js
+++ b/test/rated-items.test.js
@@ -1,0 +1,163 @@
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const yaml = require('js-yaml');
+const { createServer } = require('../lib/server');
+
+function makeAgentDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rated-items-'));
+  fs.mkdirSync(path.join(dir, 'memory'), { recursive: true });
+  return dir;
+}
+
+function createTestSvr(agentDir) {
+  const config = {
+    name: 'Test',
+    port: 0,
+    agentDir,
+    cronFile: '/nonexistent/cron',
+    lockFile: '/tmp/test-ri-lock',
+    _serverStartTime: Date.now(),
+    features: { library: { dataDir: 'content/items' } },
+  };
+  const routes = {};
+  require('../lib/routes/rated-items').register(routes, config);
+  return createServer(config, { routes, getHTML: () => '<html>test</html>' });
+}
+
+function fetchJSON(port, urlPath, options = {}) {
+  return new Promise((resolve, reject) => {
+    const headers = { ...(options.headers || {}) };
+    if (options.body && !headers['Content-Length']) {
+      headers['Content-Length'] = Buffer.byteLength(options.body);
+    }
+    const opts = { hostname: '127.0.0.1', port, path: urlPath, method: options.method || 'GET', headers };
+    const req = http.request(opts, (res) => {
+      let data = '';
+      res.on('data', (chunk) => (data += chunk));
+      res.on('end', () => {
+        try { resolve({ status: res.statusCode, data: JSON.parse(data) }); }
+        catch { resolve({ status: res.statusCode, data }); }
+      });
+    });
+    req.on('error', reject);
+    if (options.body) req.write(options.body);
+    req.end();
+  });
+}
+
+async function startServer(agentDir) {
+  const server = createTestSvr(agentDir);
+  await new Promise(r => server.listen(0, r));
+  return { server, port: server.address().port };
+}
+
+describe('GET /api/rated-items', () => {
+  it('returns empty list when no items', async () => {
+    const dir = makeAgentDir();
+    const { server, port } = await startServer(dir);
+    const { status, data } = await fetchJSON(port, '/api/rated-items');
+    assert.equal(status, 200);
+    assert.deepEqual(data, []);
+    server.close();
+  });
+
+  it('filters by category and sorts newest first', async () => {
+    const dir = makeAgentDir();
+    fs.writeFileSync(path.join(dir, 'memory', 'rated-items.yaml'), yaml.dump({
+      items: [
+        { id: 'a', category: 'movies', title: 'A', rating: 'up', created_at: '2026-01-01T00:00:00Z' },
+        { id: 'b', category: 'comics', title: 'B', rating: 'up', created_at: '2026-01-02T00:00:00Z' },
+        { id: 'c', category: 'movies', title: 'C', rating: 'down', created_at: '2026-01-03T00:00:00Z' },
+      ],
+    }));
+    const { server, port } = await startServer(dir);
+    const { data } = await fetchJSON(port, '/api/rated-items?category=movies');
+    assert.equal(data.length, 2);
+    assert.equal(data[0].id, 'c');
+    assert.equal(data[1].id, 'a');
+    server.close();
+  });
+});
+
+describe('POST /api/rated-items', () => {
+  it('creates an item with generated id and timestamp', async () => {
+    const dir = makeAgentDir();
+    const { server, port } = await startServer(dir);
+    const body = JSON.stringify({ category: 'movies', title: 'The Godfather', description: '1972, Pacino', rating: 'up' });
+    const { status, data } = await fetchJSON(port, '/api/rated-items', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body });
+    assert.equal(status, 200);
+    assert.ok(data.id.startsWith('rated-'));
+    assert.equal(data.title, 'The Godfather');
+    assert.equal(data.rating, 'up');
+    assert.equal(data.processed_at, null);
+    assert.ok(data.created_at);
+
+    const persisted = yaml.load(fs.readFileSync(path.join(dir, 'memory', 'rated-items.yaml'), 'utf-8'));
+    assert.equal(persisted.items.length, 1);
+    server.close();
+  });
+
+  it('rejects missing title', async () => {
+    const dir = makeAgentDir();
+    const { server, port } = await startServer(dir);
+    const body = JSON.stringify({ category: 'movies', rating: 'up' });
+    const { status } = await fetchJSON(port, '/api/rated-items', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body });
+    assert.equal(status, 400);
+    server.close();
+  });
+
+  it('rejects invalid rating', async () => {
+    const dir = makeAgentDir();
+    const { server, port } = await startServer(dir);
+    const body = JSON.stringify({ category: 'movies', title: 'X', rating: 'maybe' });
+    const { status } = await fetchJSON(port, '/api/rated-items', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body });
+    assert.equal(status, 400);
+    server.close();
+  });
+});
+
+describe('PUT /api/rated-items', () => {
+  it('updates fields and resets processed_at', async () => {
+    const dir = makeAgentDir();
+    fs.writeFileSync(path.join(dir, 'memory', 'rated-items.yaml'), yaml.dump({
+      items: [{ id: 'x', category: 'movies', title: 'Old', description: '', rating: 'up', created_at: '2026-01-01T00:00:00Z', processed_at: '2026-01-02T00:00:00Z' }],
+    }));
+    const { server, port } = await startServer(dir);
+    const body = JSON.stringify({ id: 'x', title: 'New', rating: 'down' });
+    const { status, data } = await fetchJSON(port, '/api/rated-items', { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body });
+    assert.equal(status, 200);
+    assert.equal(data.title, 'New');
+    assert.equal(data.rating, 'down');
+    assert.equal(data.processed_at, null);
+    server.close();
+  });
+
+  it('returns 404 for unknown id', async () => {
+    const dir = makeAgentDir();
+    const { server, port } = await startServer(dir);
+    const body = JSON.stringify({ id: 'nope', title: 'x' });
+    const { status } = await fetchJSON(port, '/api/rated-items', { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body });
+    assert.equal(status, 404);
+    server.close();
+  });
+});
+
+describe('DELETE /api/rated-items', () => {
+  it('removes the item', async () => {
+    const dir = makeAgentDir();
+    fs.writeFileSync(path.join(dir, 'memory', 'rated-items.yaml'), yaml.dump({
+      items: [{ id: 'x', category: 'movies', title: 'X', rating: 'up', created_at: '2026-01-01T00:00:00Z' }],
+    }));
+    const { server, port } = await startServer(dir);
+    const body = JSON.stringify({ id: 'x' });
+    const { status } = await fetchJSON(port, '/api/rated-items', { method: 'DELETE', headers: { 'Content-Type': 'application/json' }, body });
+    assert.equal(status, 200);
+    const persisted = yaml.load(fs.readFileSync(path.join(dir, 'memory', 'rated-items.yaml'), 'utf-8'));
+    assert.equal(persisted.items.length, 0);
+    server.close();
+  });
+});


### PR DESCRIPTION
## Summary
- New `/api/rated-items` REST routes (GET/POST/PUT/DELETE) backed by `memory/rated-items.yaml`, gated on `features.library`.
- Preferences tab gets a per-category **Rated content** section: inline add form (title + description + 👍/👎), expandable rows, edit, delete.
- Items land with `processed_at: null` and a "pending" badge until the agent extracts preferences on its next cycle.

This is the onboarding-flow piece: users can teach the agent their taste by rating content the agent never recommended (e.g. "I just saw Godfather, thumbs up"), without polluting the Library (which stays = "things ContentBot found").

Agent-side disambiguation (LLM-as-graph → preferences extraction → stamp `processed_at`) is a follow-up.

## Test plan
- [x] `node --test test/rated-items.test.js` passes (8 tests covering GET filter+sort, POST validation, PUT field updates + processed_at reset, DELETE)
- [x] `node --test test/sources-preferences.test.js` still passes (no regression)
- [x] Smoke-tested live on ContentBot portal :8085: GET, POST, DELETE round-trip works
- [ ] Manual: Open Preferences tab in ContentBot, add an item, edit it, expand description, delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)