### PR TITLE
feat(onboarding): dedicated /onboarding flow for adding a category

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ require('./lib/routes/library').register(routes, config);
 require('./lib/routes/sources').register(routes, config);
 require('./lib/routes/preferences').register(routes, config);
 require('./lib/routes/rated-items').register(routes, config);
+require('./lib/routes/onboarding').register(routes, config);
 require('./lib/routes/media-files').register(routes, config);
 require('./lib/routes/badges').register(routes, config);
 require('./lib/routes/capabilities').register(routes, config);

--- a/lib/routes/onboarding.js
+++ b/lib/routes/onboarding.js
@@ -1,0 +1,249 @@
+// routes/onboarding.js — Standalone onboarding flow for adding a new category.
+// Step 1: category name + freeform likes/dislikes description.
+// Step 2: 1+ pieces of content the user specifically likes (title + description).
+// Posts to existing /api/preferences/category-request and /api/rated-items.
+// Registered when features.library is configured.
+
+function register(routes, config) {
+  if (!config.features || !config.features.library) return;
+
+  const agentName = (config && config.name) || 'Agent';
+
+  routes['GET /onboarding'] = (req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+    res.end(renderOnboardingHTML(agentName));
+  };
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+function renderOnboardingHTML(agentName) {
+  const safeName = escapeHtml(agentName);
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Add a category — ${safeName}</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+  body { margin:0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background:#f5f5f5; color:#222; }
+  .wrap { max-width:680px; margin:0 auto; padding:32px 24px 64px; }
+  header { display:flex; align-items:center; justify-content:space-between; margin-bottom:24px; }
+  header h1 { margin:0; font-size:22px; font-weight:600; }
+  header a { color:#1a73e8; text-decoration:none; font-size:13px; }
+  header a:hover { text-decoration:underline; }
+  .card { background:#fff; border:1px solid #e0e0e0; border-radius:8px; padding:20px 22px; box-shadow:0 1px 2px rgba(0,0,0,0.03); }
+  .card + .card { margin-top:16px; }
+  .step-label { font-size:11px; text-transform:uppercase; letter-spacing:0.06em; color:#888; margin:0 0 4px; }
+  .card h2 { margin:0 0 6px; font-size:17px; font-weight:600; }
+  .card p.hint { margin:0 0 14px; font-size:13px; color:#666; line-height:1.45; }
+  label { display:block; font-size:12px; font-weight:600; color:#555; margin:10px 0 4px; }
+  input[type=text], textarea {
+    width:100%; box-sizing:border-box; padding:8px 10px; border:1px solid #ccc; border-radius:5px;
+    font-size:13px; font-family:inherit; line-height:1.45; background:#fff;
+  }
+  textarea { resize:vertical; }
+  input[type=text]:focus, textarea:focus { outline:none; border-color:#1a73e8; box-shadow:0 0 0 2px rgba(26,115,232,0.15); }
+  .row { display:flex; gap:10px; align-items:flex-start; }
+  .row > * { flex:1; }
+  .item { border:1px solid #eee; border-radius:6px; padding:12px; margin-bottom:10px; background:#fafafa; }
+  .item-head { display:flex; gap:8px; align-items:center; margin-bottom:6px; }
+  .item-head .badge { font-size:11px; color:#666; font-weight:500; }
+  .item-head .remove { margin-left:auto; background:none; border:none; color:#c62828; font-size:13px; cursor:pointer; padding:2px 6px; }
+  .add-item-btn {
+    display:inline-block; background:none; border:1px dashed #aaa; border-radius:6px; padding:8px 14px;
+    font-size:12px; color:#555; cursor:pointer;
+  }
+  .add-item-btn:hover { background:#fff; border-color:#1a73e8; color:#1a73e8; }
+  .actions { margin-top:24px; display:flex; gap:10px; align-items:center; }
+  button.primary {
+    background:#1a73e8; color:#fff; border:1px solid #1a73e8; padding:9px 18px; border-radius:5px;
+    font-size:13px; font-weight:500; cursor:pointer;
+  }
+  button.primary:hover { background:#1557b0; border-color:#1557b0; }
+  button.primary[disabled] { opacity:0.5; cursor:not-allowed; }
+  button.secondary {
+    background:#fff; color:#444; border:1px solid #ccc; padding:9px 14px; border-radius:5px;
+    font-size:13px; cursor:pointer;
+  }
+  .error { color:#c62828; font-size:12px; margin-top:8px; }
+  .success { background:#e8f5e9; border:1px solid #a5d6a7; padding:14px; border-radius:6px; font-size:13px; color:#2e7d32; }
+  .success a { color:#1565c0; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <h1>Add a category</h1>
+    <a href="/?tab=preferences" id="back-link">← Back to ${safeName}</a>
+  </header>
+
+  <div id="form-area">
+    <div class="card">
+      <div class="step-label">Step 1 of 2</div>
+      <h2>Tell us about the category</h2>
+      <p class="hint">What kind of content is this, and what shapes your taste? Be specific — formats you prefer, where you usually find this content, things you don't want.</p>
+      <label for="cat-name">Category name</label>
+      <input type="text" id="cat-name" placeholder="e.g. movies, audiobooks, games" autocomplete="off">
+      <label for="cat-context">Likes &amp; dislikes</label>
+      <textarea id="cat-context" rows="6" placeholder="I watch on Netflix and Letterboxd is my source of truth. Love mid-budget character dramas, dark comedies, anything with a director who shoots on film. Avoid superhero and most franchise tentpoles."></textarea>
+    </div>
+
+    <div class="card">
+      <div class="step-label">Step 2 of 2</div>
+      <h2>Add a few things you like</h2>
+      <p class="hint">Specific items help the agent calibrate fast. Title is required; the description is where you say which one (year, director, author...) and what you like about it.</p>
+      <div id="items"></div>
+      <button type="button" class="add-item-btn" onclick="addItemRow()">+ Add another</button>
+    </div>
+
+    <div class="actions">
+      <button type="button" class="primary" id="submit-btn" onclick="submitOnboarding()">Create category</button>
+      <button type="button" class="secondary" onclick="window.location='/?tab=preferences'">Cancel</button>
+      <span class="error" id="error-msg"></span>
+    </div>
+  </div>
+
+  <div id="success-area" style="display:none">
+    <div class="success">
+      <strong>Category created.</strong> The agent will read your items on its next cycle and extract preferences. <a id="success-link" href="/?tab=preferences">View it in Preferences →</a>
+    </div>
+  </div>
+</div>
+
+<script>
+function escapeAttr(s) { return String(s).replace(/&/g,'&amp;').replace(/"/g,'&quot;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+function escapeHtml(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+
+var itemRows = [];
+var nextRowId = 1;
+
+function addItemRow() {
+  // Preserve any values the user has typed into existing rows before re-rendering
+  captureItems();
+  var rowId = nextRowId++;
+  itemRows.push(rowId);
+  renderItems();
+  setTimeout(function() {
+    var el = document.getElementById('item-title-' + rowId);
+    if (el) el.focus();
+  }, 0);
+}
+
+function removeItemRow(rowId) {
+  // Capture user input first so renderItems doesn't blow away values
+  captureItems();
+  itemRows = itemRows.filter(function(r) { return r !== rowId; });
+  delete capturedItems[rowId];
+  if (itemRows.length === 0) addItemRow();
+  else renderItems();
+}
+
+var capturedItems = {};
+
+function captureItems() {
+  itemRows.forEach(function(rowId) {
+    var t = document.getElementById('item-title-' + rowId);
+    var d = document.getElementById('item-desc-' + rowId);
+    if (t || d) capturedItems[rowId] = { title: t ? t.value : '', description: d ? d.value : '' };
+  });
+}
+
+function renderItems() {
+  var container = document.getElementById('items');
+  var html = '';
+  itemRows.forEach(function(rowId, i) {
+    var v = capturedItems[rowId] || { title: '', description: '' };
+    html += '<div class="item">'
+      + '<div class="item-head"><span class="badge">Item ' + (i + 1) + '</span>'
+      + (itemRows.length > 1 ? '<button type="button" class="remove" onclick="removeItemRow(' + rowId + ')">Remove</button>' : '')
+      + '</div>'
+      + '<input type="text" id="item-title-' + rowId + '" placeholder="Title" value="' + escapeAttr(v.title) + '">'
+      + '<textarea id="item-desc-' + rowId + '" rows="2" placeholder="Year, author, director... and why you like it">' + escapeHtml(v.description) + '</textarea>'
+      + '</div>';
+  });
+  container.innerHTML = html;
+}
+
+function showError(msg) {
+  document.getElementById('error-msg').textContent = msg || '';
+}
+
+function slugify(s) {
+  return String(s).toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+async function submitOnboarding() {
+  showError('');
+  var nameEl = document.getElementById('cat-name');
+  var contextEl = document.getElementById('cat-context');
+  var name = nameEl.value.trim();
+  var context = contextEl.value.trim();
+
+  if (!name) { showError('Category name is required'); nameEl.focus(); return; }
+  if (!context) { showError('Tell the agent something about your taste in this category — even a sentence helps'); contextEl.focus(); return; }
+
+  captureItems();
+  var items = itemRows
+    .map(function(rowId) { return capturedItems[rowId]; })
+    .filter(function(it) { return it && it.title && it.title.trim(); });
+
+  if (items.length === 0) { showError('Add at least one piece of content you like'); return; }
+
+  var btn = document.getElementById('submit-btn');
+  btn.disabled = true; btn.textContent = 'Creating...';
+
+  var slug = slugify(name);
+
+  try {
+    // Step 1: category-request (writes feedback file + creates empty category)
+    var r1 = await fetch('/api/preferences/category-request', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ category: slug, context: context })
+    });
+    if (!r1.ok) {
+      var e1 = await r1.json().catch(function() { return {}; });
+      throw new Error(e1.error || 'Failed to create category');
+    }
+    var d1 = await r1.json();
+    var finalSlug = d1.category || slug;
+
+    // Step 2: post each rated item as 'up'
+    for (var i = 0; i < items.length; i++) {
+      var it = items[i];
+      var r2 = await fetch('/api/rated-items', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          category: finalSlug,
+          title: it.title.trim(),
+          description: (it.description || '').trim(),
+          rating: 'up',
+        })
+      });
+      if (!r2.ok) {
+        var e2 = await r2.json().catch(function() { return {}; });
+        throw new Error('Item "' + it.title + '" failed: ' + (e2.error || 'unknown'));
+      }
+    }
+
+    // Success — show confirmation, link back to Preferences with this category
+    document.getElementById('form-area').style.display = 'none';
+    document.getElementById('success-area').style.display = 'block';
+    document.getElementById('success-link').href = '/?tab=preferences&category=' + encodeURIComponent(finalSlug);
+  } catch (err) {
+    btn.disabled = false; btn.textContent = 'Create category';
+    showError(err.message || 'Something went wrong');
+  }
+}
+
+addItemRow();
+</script>
+</body>
+</html>`;
+}
+
+module.exports = { register, renderOnboardingHTML };

--- a/lib/server.js
+++ b/lib/server.js
@@ -72,15 +72,14 @@ function createServer(config, { routes, getHTML }) {
       }
     }
 
-    // API routes
-    if (pathname.startsWith('/api/')) {
-      // For mutating requests, invalidate related cache entries
+    const isApi = pathname.startsWith('/api/');
+
+    // API caching + cache invalidation (only applies to /api/ paths)
+    if (isApi) {
       if (req.method !== 'GET') {
         cache.invalidate(pathname);
       }
 
-      // For GET requests, check response cache
-      // Skip caching for lightweight/frequently-polled endpoints
       const skipCache = pathname === '/api/badges' || pathname === '/api/status'
         || pathname === '/api/next-run' || pathname === '/api/harness/status' || pathname === '/api/claude/status'
         || pathname.startsWith('/api/media/')
@@ -94,50 +93,52 @@ function createServer(config, { routes, getHTML }) {
           return;
         }
 
-        // Intercept sendJSON to capture response for caching
         const origEnd = res.end.bind(res);
         res.end = function(body) {
-          // Cache if writeHead was called with 2xx (check res.statusCode)
           if (res.statusCode >= 200 && res.statusCode < 300 && typeof body === 'string') {
             cache.set(cacheKey, res.statusCode, body);
           }
           return origEnd(body);
         };
       }
+    }
 
-      const routeKey = `${req.method} ${pathname}`;
+    const routeKey = `${req.method} ${pathname}`;
 
-      // Exact match first
-      if (routes[routeKey]) {
-        try {
-          await routes[routeKey](req, res, url);
-        } catch (err) {
-          console.error(`Route error [${routeKey}]:`, err.message);
-          sendJSON(res, 500, { error: 'Internal server error' });
-        }
+    function onError(label, err) {
+      console.error(`Route error [${label}]:`, err.message);
+      if (isApi) {
+        sendJSON(res, 500, { error: 'Internal server error' });
+      } else if (!res.headersSent) {
+        res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
+        res.end('Internal server error');
+      }
+    }
+
+    // Exact match first
+    if (routes[routeKey]) {
+      try { await routes[routeKey](req, res, url); }
+      catch (err) { onError(routeKey, err); }
+      return;
+    }
+
+    // Pattern match for parameterized routes (e.g., /api/projects/:slug/journal)
+    for (const [pattern, handler] of Object.entries(routes)) {
+      const match = matchRoute(pattern, `${req.method} ${pathname}`);
+      if (match) {
+        req.params = match;
+        try { await handler(req, res, url); }
+        catch (err) { onError(pattern, err); }
         return;
       }
+    }
 
-      // Pattern match for parameterized routes (e.g., /api/projects/:slug/journal)
-      for (const [pattern, handler] of Object.entries(routes)) {
-        const match = matchRoute(pattern, `${req.method} ${pathname}`);
-        if (match) {
-          req.params = match;
-          try {
-            await handler(req, res, url);
-          } catch (err) {
-            console.error(`Route error [${pattern}]:`, err.message);
-            sendJSON(res, 500, { error: 'Internal server error' });
-          }
-          return;
-        }
-      }
-
+    if (isApi) {
       sendJSON(res, 404, { error: 'Not found' });
       return;
     }
 
-    // SPA fallback — serve the HTML page for all non-API routes
+    // SPA fallback — serve the HTML page for all unmatched non-API routes
     const html = getHTML();
     res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
     res.end(html);

--- a/lib/ui/tabs/preferences.js
+++ b/lib/ui/tabs/preferences.js
@@ -215,8 +215,8 @@ function renderPrefsCategoryNav(activeCategory) {
       + 'onclick="renderCategoryPrefs(\\'' + escapeHtml(cat) + '\\')">'
       + escapeHtml(cat) + ' <span style="opacity:0.7">(' + count + ')</span></button>';
   });
-  // Add new category button
-  html += '<button class="refresh-btn" style="padding:4px 12px;font-size:13px;color:#888" onclick="addCategory()">+ Category</button>';
+  // Add new category — opens dedicated onboarding flow
+  html += '<button class="refresh-btn" style="padding:4px 12px;font-size:13px;color:#888" onclick="window.location.href=\\'/onboarding\\'">+ Category</button>';
   html += '</div>';
   return html;
 }
@@ -228,12 +228,16 @@ async function loadPreferences() {
     var res = await fetch('/api/preferences');
     prefsData = await res.json();
 
+    // Honor ?category=... when arriving from the onboarding flow
+    var urlCat = new URLSearchParams(window.location.search).get('category');
+    if (urlCat && prefsData[urlCat]) prefsActiveCategory = urlCat;
+
     var categories = Object.keys(prefsData).sort();
     if (categories.length === 0) {
       var html = '<div class="status-section">';
       html += '<h2 style="margin:0 0 16px;font-size:18px">Taste Profile</h2>';
       html += '<p style="color:#666;font-size:13px;margin-bottom:16px">No preferences yet. Preferences are organized per media category — the agent will create them as you give feedback, or you can add categories manually.</p>';
-      html += '<button class="refresh-btn" onclick="addCategory()">+ Add Category</button>';
+      html += '<button class="refresh-btn" onclick="window.location.href=\\'/onboarding\\'">+ Add Category</button>';
       html += '</div>';
       contentEl.innerHTML = html;
     } else {
@@ -245,66 +249,6 @@ async function loadPreferences() {
   }
 }
 
-var showingCategoryForm = false;
-
-function addCategory() {
-  if (showingCategoryForm) return;
-  showingCategoryForm = true;
-  var contentEl = document.getElementById('content');
-  var categories = Object.keys(prefsData).sort();
-
-  var html = '<div class="status-section">';
-  if (categories.length > 0) {
-    html += renderPrefsCategoryNav(null);
-  }
-  html += '<h3 style="margin:0 0 12px;font-size:16px">Add Category</h3>';
-  html += '<div style="margin-bottom:12px">';
-  html += '<label style="display:block;font-size:13px;color:#555;margin-bottom:4px;font-weight:600">Category name</label>';
-  html += '<input type="text" id="new-cat-name" placeholder="e.g. audiobooks, comics, movies..." style="width:100%;max-width:300px;padding:6px 10px;border:1px solid #ddd;border-radius:4px;font-size:13px;font-family:inherit;box-sizing:border-box">';
-  html += '</div>';
-  html += '<div style="margin-bottom:12px">';
-  html += '<label style="display:block;font-size:13px;color:#555;margin-bottom:4px;font-weight:600">Tell ContentBot about your preferences</label>';
-  html += '<textarea id="new-cat-context" rows="5" placeholder="Describe what you like in this category. You might mention:\\n- What kinds of content you enjoy\\n- Formats you prefer (epub, audiobook, cbz...)\\n- Where you currently get this content\\n- What you don\\'t want\\n\\nExample: I listen on Libby mostly. I like narrative nonfiction, author-narrated, under 12 hours. Can\\'t track complex character casts in audio." style="width:100%;box-sizing:border-box;padding:8px;border:1px solid #ddd;border-radius:4px;font-size:13px;font-family:inherit;resize:vertical;line-height:1.5"></textarea>';
-  html += '</div>';
-  html += '<div style="display:flex;gap:8px">';
-  html += '<button class="refresh-btn" style="background:#1a73e8;color:#fff;border-color:#1a73e8" onclick="submitNewCategory()">Create Category</button>';
-  html += '<button class="refresh-btn" onclick="cancelNewCategory()">Cancel</button>';
-  html += '</div>';
-  html += '</div>';
-  contentEl.innerHTML = html;
-}
-
-function cancelNewCategory() {
-  showingCategoryForm = false;
-  loadPreferences();
-}
-
-async function submitNewCategory() {
-  var nameEl = document.getElementById('new-cat-name');
-  var contextEl = document.getElementById('new-cat-context');
-  var name = nameEl ? nameEl.value.trim() : '';
-  var context = contextEl ? contextEl.value.trim() : '';
-
-  if (!name) { alert('Please enter a category name'); return; }
-  if (!context) { alert('Please describe your preferences for this category — it helps ContentBot make better recommendations from the start'); return; }
-
-  var key = name.toLowerCase().replace(/\\s+/g, '-');
-
-  try {
-    // Submit the freeform context as a category request for the agent to process
-    await fetch('/api/preferences/category-request', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ category: key, context: context })
-    });
-    showingCategoryForm = false;
-    // Also create the category locally so it appears immediately
-    if (!prefsData[key]) prefsData[key] = { likes: [], dislikes: [] };
-    renderCategoryPrefs(key);
-  } catch {
-    alert('Failed to create category');
-  }
-}
 
 async function addPref(category, section) {
   var input = document.getElementById('pref-add-' + category + '-' + section);

--- a/test/onboarding.test.js
+++ b/test/onboarding.test.js
@@ -1,0 +1,109 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { createServer } = require('../lib/server');
+
+function makeAgentDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'onboarding-'));
+  fs.mkdirSync(path.join(dir, 'memory'), { recursive: true });
+  return dir;
+}
+
+function buildServer(agentDir, configOverrides = {}) {
+  const config = {
+    name: 'TestBot',
+    port: 0,
+    agentDir,
+    cronFile: '/nonexistent/cron',
+    lockFile: '/tmp/test-ob-lock',
+    _serverStartTime: Date.now(),
+    features: { library: { dataDir: 'content/items' } },
+    ...configOverrides,
+  };
+  const routes = {};
+  require('../lib/routes/onboarding').register(routes, config);
+  require('../lib/routes/preferences').register(routes, config);
+  require('../lib/routes/rated-items').register(routes, config);
+  return createServer(config, { routes, getHTML: () => '<html>spa</html>' });
+}
+
+function fetchRaw(port, urlPath, options = {}) {
+  return new Promise((resolve, reject) => {
+    const headers = { ...(options.headers || {}) };
+    if (options.body && !headers['Content-Length']) {
+      headers['Content-Length'] = Buffer.byteLength(options.body);
+    }
+    const opts = { hostname: '127.0.0.1', port, path: urlPath, method: options.method || 'GET', headers };
+    const req = http.request(opts, (res) => {
+      let data = '';
+      res.on('data', (chunk) => (data += chunk));
+      res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body: data }));
+    });
+    req.on('error', reject);
+    if (options.body) req.write(options.body);
+    req.end();
+  });
+}
+
+async function start(agentDir, overrides) {
+  const server = buildServer(agentDir, overrides);
+  await new Promise(r => server.listen(0, r));
+  return { server, port: server.address().port };
+}
+
+describe('GET /onboarding', () => {
+  it('returns a standalone HTML page (not the SPA shell)', async () => {
+    const dir = makeAgentDir();
+    const { server, port } = await start(dir);
+    const { status, headers, body } = await fetchRaw(port, '/onboarding');
+    assert.equal(status, 200);
+    assert.match(headers['content-type'] || '', /text\/html/);
+    assert.match(body, /Add a category/);
+    assert.match(body, /id="cat-name"/);
+    assert.match(body, /id="cat-context"/);
+    assert.match(body, /id="submit-btn"/);
+    assert.doesNotMatch(body, /<html>spa<\/html>/);
+    server.close();
+  });
+
+  it('embeds the agent name from config', async () => {
+    const dir = makeAgentDir();
+    const { server, port } = await start(dir, { name: 'ContentBot' });
+    const { body } = await fetchRaw(port, '/onboarding');
+    assert.match(body, /ContentBot/);
+    server.close();
+  });
+
+  it('is gated on features.library', async () => {
+    const dir = makeAgentDir();
+    const { server, port } = await start(dir, { features: {} });
+    const { status, body } = await fetchRaw(port, '/onboarding');
+    // Without features.library, the route is not registered → SPA fallback returns the shell
+    assert.equal(status, 200);
+    assert.match(body, /<html>spa<\/html>/);
+    server.close();
+  });
+});
+
+describe('server.js non-/api dispatch', () => {
+  it('still serves SPA shell for unknown non-/api paths', async () => {
+    const dir = makeAgentDir();
+    const { server, port } = await start(dir);
+    const { status, body } = await fetchRaw(port, '/some-random-path');
+    assert.equal(status, 200);
+    assert.match(body, /<html>spa<\/html>/);
+    server.close();
+  });
+
+  it('returns 404 JSON for unknown /api paths', async () => {
+    const dir = makeAgentDir();
+    const { server, port } = await start(dir);
+    const { status, body } = await fetchRaw(port, '/api/nonexistent');
+    assert.equal(status, 404);
+    assert.match(body, /Not found/);
+    server.close();
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces the inline "+ Category" form in Preferences with a standalone `/onboarding` HTML page
- Two steps in one page: (1) name + freeform likes/dislikes, (2) 1+ pieces of content the user likes
- Step 1 posts to existing `POST /api/preferences/category-request`
- Step 2 posts to existing `POST /api/rated-items` with `rating=up`
- After success, links back to `?tab=preferences&category=<slug>`; Preferences tab now honors the `category` query param
- `server.js` dispatches non-`/api` routes through the route table before SPA fallback, so route modules can register HTML routes (caching/invalidation behavior remains `/api/`-only)

Why a separate route, not a modal: a multi-step form needs space, has to feel like its own thing, and shouldn't compete for state with the Preferences tab. Bookmarkable + cancel-safe.

## Test plan
- [x] `node --test test/*.test.js` → 363/363 pass (5 new for `/onboarding`, 358 existing — no regressions)
- [x] Headless drive with shot-scraper:
  - [x] Fill name + context + 2 items → submit → success card shown
  - [x] `memory/preferences.yaml` gets the new category, `memory/rated-items.yaml` gets both items, `input/feedback/category-<slug>.feedback.yaml` is written
  - [x] "+ Add another" preserves prior items' values (fixed mid-iteration: was wiping state on re-render)
  - [x] Remove-item button keeps neighboring items' values
  - [x] Validation: missing name, missing context, no items each show inline errors
- [ ] Manual: open ContentBot at :8085, click "+ Category" in Preferences, complete the flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)