### PR TITLE
feat(scripts): health-check.sh framework primitive (v1.5.19)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-portal",
-  "version": "1.5.18",
+  "version": "1.5.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-portal",
-      "version": "1.5.18",
+      "version": "1.5.19",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.5.18",
+  "version": "1.5.19",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# scripts/health-check.sh — Probe agent endpoints and append results to logs/health.jsonl
+#
+# Usage: health-check.sh <agent-dir> [--threshold <ms>]
+#
+# Reads the `endpoints:` list from <agent-dir>/agent.yaml (a list of
+# {url, type} objects), issues GET requests, measures latency, and writes
+# one canonical JSONL line per endpoint to <agent-dir>/logs/health.jsonl
+# in the schema consumed by the portal Health tab:
+#
+#   {"ts","project","endpoint","status","latency_ms","ok"}
+#
+# Exit 0 if all endpoints respond 2xx (and beat --threshold if given).
+# Exit 1 if any endpoint fails. Exit 0 with stderr warning if no endpoints
+# are configured.
+
+set -e
+
+AGENT_DIR=""
+THRESHOLD=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --threshold)
+      THRESHOLD="$2"
+      shift 2
+      ;;
+    --threshold=*)
+      THRESHOLD="${1#--threshold=}"
+      shift
+      ;;
+    -h|--help)
+      echo "Usage: health-check.sh <agent-dir> [--threshold <ms>]"
+      exit 0
+      ;;
+    *)
+      if [ -z "$AGENT_DIR" ]; then
+        AGENT_DIR="$1"
+      else
+        echo "Unexpected argument: $1" >&2
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$AGENT_DIR" ]; then
+  echo "Usage: health-check.sh <agent-dir> [--threshold <ms>]" >&2
+  exit 1
+fi
+
+if [ -n "$THRESHOLD" ] && ! [[ "$THRESHOLD" =~ ^[0-9]+$ ]]; then
+  echo "--threshold must be a positive integer (milliseconds), got: $THRESHOLD" >&2
+  exit 1
+fi
+
+YAML="$AGENT_DIR/agent.yaml"
+LOG_DIR="$AGENT_DIR/logs"
+LOG="$LOG_DIR/health.jsonl"
+
+if [ ! -f "$YAML" ]; then
+  echo "agent.yaml not found at $YAML" >&2
+  exit 1
+fi
+
+if [ ! -d "$LOG_DIR" ]; then
+  echo "Log dir not found at $LOG_DIR — create it before running health-check" >&2
+  exit 1
+fi
+
+# Parse name + endpoints via python3 (yaml is part of the standard agentbox image
+# and is what operational/tools/load-config.py already relies on).
+PARSED=$(python3 -c "
+import sys, yaml, json
+try:
+    with open('$YAML') as f:
+        doc = yaml.safe_load(f) or {}
+    print(json.dumps({'name': doc.get('name', ''), 'endpoints': doc.get('endpoints') or []}))
+except Exception as e:
+    print('PARSE_ERROR:' + str(e), file=sys.stderr)
+    sys.exit(1)
+") || { echo "Failed to parse $YAML" >&2; exit 1; }
+
+PROJECT=$(echo "$PARSED" | jq -r '.name')
+
+EP_COUNT=$(echo "$PARSED" | jq '.endpoints | length')
+if [ "$EP_COUNT" = "0" ]; then
+  echo "No endpoints configured in $YAML — nothing to probe" >&2
+  exit 0
+fi
+
+ALL_OK=true
+
+# Iterate endpoints. Each is a {url, type} object. type is informational
+# in v1; both http and mcp endpoints are probed via GET.
+while IFS= read -r ep; do
+  [ -z "$ep" ] && continue
+  URL=$(echo "$ep" | jq -r '.url // empty')
+
+  if [ -z "$URL" ]; then
+    echo "Endpoint missing url field: $ep" >&2
+    ALL_OK=false
+    continue
+  fi
+
+  TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+  # Capture status + total time. On connection failure curl exits non-zero;
+  # we substitute "000 0" so the run still logs a result.
+  RESULT=$(curl -s -o /dev/null -w "%{http_code} %{time_total}\n" --max-time 10 "$URL" 2>/dev/null) || RESULT="000 0"
+  STATUS=$(echo "$RESULT" | awk '{print $1}')
+  TIME_S=$(echo "$RESULT" | awk '{print $2}')
+  LATENCY_MS=$(awk -v t="$TIME_S" 'BEGIN { printf "%d", t * 1000 }')
+
+  OK=false
+  if [ "$STATUS" -ge 200 ] 2>/dev/null && [ "$STATUS" -lt 300 ] 2>/dev/null; then
+    OK=true
+  fi
+  if [ -n "$THRESHOLD" ] && [ "$LATENCY_MS" -gt "$THRESHOLD" ]; then
+    OK=false
+  fi
+
+  if [ "$OK" = "false" ]; then
+    ALL_OK=false
+  fi
+
+  jq -nc \
+    --arg ts "$TS" \
+    --arg project "$PROJECT" \
+    --arg endpoint "$URL" \
+    --argjson status "$STATUS" \
+    --argjson latency_ms "$LATENCY_MS" \
+    --argjson ok "$OK" \
+    '{ts: $ts, project: $project, endpoint: $endpoint, status: $status, latency_ms: $latency_ms, ok: $ok}' \
+    >> "$LOG"
+done < <(echo "$PARSED" | jq -c '.endpoints[]')
+
+if [ "$ALL_OK" = "true" ]; then
+  exit 0
+else
+  exit 1
+fi

--- a/test/health-check.test.sh
+++ b/test/health-check.test.sh
@@ -1,0 +1,273 @@
+#!/bin/bash
+# Test scripts/health-check.sh end-to-end against a local HTTP fixture.
+set -e
+
+PASS=0
+FAIL=0
+TESTS=0
+
+assert_eq() {
+  TESTS=$((TESTS + 1))
+  if [ "$1" = "$2" ]; then
+    PASS=$((PASS + 1))
+    echo "  ok - $3"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL - $3 (expected '$1', got '$2')"
+  fi
+}
+
+assert_contains() {
+  TESTS=$((TESTS + 1))
+  if echo "$1" | grep -qE "$2"; then
+    PASS=$((PASS + 1))
+    echo "  ok - $3"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL - $3 (pattern '$2' not in '$1')"
+  fi
+}
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+HEALTH="$SCRIPT_DIR/scripts/health-check.sh"
+
+echo "# health-check.sh tests"
+
+# ---- Spawn a configurable HTTP fixture ----
+# Routes:
+#   /200 → 200 OK
+#   /500 → 500 Internal Server Error
+#   /slow → 200 OK with 300ms delay
+PORT=$(python3 -c "import socket; s=socket.socket(); s.bind(('127.0.0.1',0)); print(s.getsockname()[1]); s.close()")
+SERVER_PID_FILE=$(mktemp)
+python3 - <<PYEOF >/dev/null 2>&1 &
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import time
+class H(BaseHTTPRequestHandler):
+    def do_GET(self):
+        path = self.path
+        if path == '/500':
+            self.send_response(500); self.end_headers(); return
+        if path == '/slow':
+            time.sleep(0.3)
+            self.send_response(200); self.end_headers(); return
+        self.send_response(200); self.end_headers()
+    def log_message(self, *args, **kwargs): pass
+HTTPServer(('127.0.0.1', $PORT), H).serve_forever()
+PYEOF
+SERVER_PID=$!
+echo "$SERVER_PID" > "$SERVER_PID_FILE"
+
+cleanup() {
+  if [ -f "$SERVER_PID_FILE" ]; then
+    kill "$(cat "$SERVER_PID_FILE")" 2>/dev/null || true
+    rm -f "$SERVER_PID_FILE"
+  fi
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+# Wait for the server to come up (loop a curl against /200 with short timeout).
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  if curl -sf -o /dev/null --max-time 1 "http://127.0.0.1:$PORT/200" 2>/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+
+TMPDIR=$(mktemp -d)
+
+write_yaml() {
+  cat > "$TMPDIR/agent.yaml"
+}
+
+reset_logs() {
+  rm -rf "$TMPDIR/logs"
+  mkdir -p "$TMPDIR/logs"
+}
+
+# --- Test 1: Happy path — two 2xx endpoints, exit 0, two log lines ---
+echo "## Test 1: Two 2xx endpoints — exit 0, schema correct"
+reset_logs
+write_yaml <<EOF
+name: testagent
+endpoints:
+  - url: http://127.0.0.1:$PORT/200
+    type: http
+  - url: http://127.0.0.1:$PORT/200
+    type: mcp
+EOF
+EXIT=0
+"$HEALTH" "$TMPDIR" >/dev/null 2>&1 || EXIT=$?
+assert_eq "0" "$EXIT" "exit 0 when all endpoints 2xx"
+LINES=$(wc -l < "$TMPDIR/logs/health.jsonl" | tr -d ' ')
+assert_eq "2" "$LINES" "two JSONL lines written"
+LINE1=$(head -n 1 "$TMPDIR/logs/health.jsonl")
+assert_eq "testagent" "$(echo "$LINE1" | jq -r '.project')" "project field set from agent.yaml name"
+assert_eq "200" "$(echo "$LINE1" | jq -r '.status')" "status 200 recorded"
+assert_eq "true" "$(echo "$LINE1" | jq -r '.ok')" "ok:true on 200"
+assert_contains "$LINE1" '"latency_ms":[0-9]+' "latency_ms field is integer"
+assert_contains "$LINE1" '"ts":"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z"' "ts is ISO-8601 UTC with Z suffix"
+assert_contains "$LINE1" "\"endpoint\":\"http://127.0.0.1:$PORT/200\"" "endpoint URL recorded"
+
+# --- Test 2: One endpoint 5xx — exit 1, ok:false on the bad one ---
+echo "## Test 2: One endpoint 5xx — exit 1, ok:false on bad endpoint"
+reset_logs
+write_yaml <<EOF
+name: testagent
+endpoints:
+  - url: http://127.0.0.1:$PORT/200
+    type: http
+  - url: http://127.0.0.1:$PORT/500
+    type: http
+EOF
+EXIT=0
+"$HEALTH" "$TMPDIR" >/dev/null 2>&1 || EXIT=$?
+assert_eq "1" "$EXIT" "exit 1 when one endpoint fails"
+OK_COUNT=$(jq -s '[.[] | select(.ok==true)] | length' "$TMPDIR/logs/health.jsonl")
+FAIL_COUNT=$(jq -s '[.[] | select(.ok==false)] | length' "$TMPDIR/logs/health.jsonl")
+assert_eq "1" "$OK_COUNT" "one ok:true line"
+assert_eq "1" "$FAIL_COUNT" "one ok:false line"
+BAD_STATUS=$(jq -s '[.[] | select(.ok==false)][0].status' "$TMPDIR/logs/health.jsonl")
+assert_eq "500" "$BAD_STATUS" "500 status recorded on bad endpoint"
+
+# --- Test 3: No endpoints field — exit 0 with stderr warning ---
+echo "## Test 3: Missing endpoints field — exit 0 with warning"
+reset_logs
+write_yaml <<EOF
+name: testagent
+EOF
+EXIT=0
+STDERR=$("$HEALTH" "$TMPDIR" 2>&1 >/dev/null) || EXIT=$?
+assert_eq "0" "$EXIT" "exit 0 when no endpoints field"
+assert_contains "$STDERR" "No endpoints" "warning printed to stderr"
+if [ -f "$TMPDIR/logs/health.jsonl" ]; then
+  LINES=$(wc -l < "$TMPDIR/logs/health.jsonl" | tr -d ' ')
+else
+  LINES=0
+fi
+assert_eq "0" "$LINES" "no log lines written when nothing to probe"
+
+# --- Test 4: Empty endpoints field — exit 0 with stderr warning ---
+echo "## Test 4: Empty endpoints field — exit 0 with warning"
+reset_logs
+write_yaml <<EOF
+name: testagent
+endpoints: []
+EOF
+EXIT=0
+STDERR=$("$HEALTH" "$TMPDIR" 2>&1 >/dev/null) || EXIT=$?
+assert_eq "0" "$EXIT" "exit 0 when endpoints is empty"
+assert_contains "$STDERR" "No endpoints" "warning printed to stderr"
+
+# --- Test 5: --threshold flag — slow endpoint flagged ok:false ---
+echo "## Test 5: --threshold flag flags slow endpoint as ok:false"
+reset_logs
+write_yaml <<EOF
+name: testagent
+endpoints:
+  - url: http://127.0.0.1:$PORT/slow
+    type: http
+EOF
+# Slow endpoint has ~300ms delay; threshold of 50ms should flag it.
+EXIT=0
+"$HEALTH" "$TMPDIR" --threshold 50 >/dev/null 2>&1 || EXIT=$?
+assert_eq "1" "$EXIT" "exit 1 when slow endpoint exceeds threshold"
+LINE=$(head -n 1 "$TMPDIR/logs/health.jsonl")
+assert_eq "200" "$(echo "$LINE" | jq -r '.status')" "status still 200 even when slow"
+assert_eq "false" "$(echo "$LINE" | jq -r '.ok')" "ok:false when latency > threshold"
+
+# --- Test 6: --threshold flag — fast endpoint stays ok:true ---
+echo "## Test 6: --threshold flag does not flag fast endpoint"
+reset_logs
+write_yaml <<EOF
+name: testagent
+endpoints:
+  - url: http://127.0.0.1:$PORT/200
+    type: http
+EOF
+# Threshold well above local fast response.
+EXIT=0
+"$HEALTH" "$TMPDIR" --threshold 5000 >/dev/null 2>&1 || EXIT=$?
+assert_eq "0" "$EXIT" "exit 0 when fast endpoint under threshold"
+assert_eq "true" "$(jq -r '.ok' "$TMPDIR/logs/health.jsonl")" "ok:true when latency < threshold"
+
+# --- Test 7: Connection refused — exit 1, ok:false logged ---
+echo "## Test 7: Unreachable endpoint — exit 1, status 0 logged"
+reset_logs
+DEAD_PORT=$(python3 -c "import socket; s=socket.socket(); s.bind(('127.0.0.1',0)); p=s.getsockname()[1]; s.close(); print(p)")
+write_yaml <<EOF
+name: testagent
+endpoints:
+  - url: http://127.0.0.1:$DEAD_PORT/
+    type: http
+EOF
+EXIT=0
+"$HEALTH" "$TMPDIR" >/dev/null 2>&1 || EXIT=$?
+assert_eq "1" "$EXIT" "exit 1 when endpoint unreachable"
+LINE=$(head -n 1 "$TMPDIR/logs/health.jsonl")
+assert_eq "0" "$(echo "$LINE" | jq -r '.status')" "status 0 recorded on connection failure"
+assert_eq "false" "$(echo "$LINE" | jq -r '.ok')" "ok:false on connection failure"
+
+# --- Test 8: Missing agent.yaml — exit 1 ---
+echo "## Test 8: Missing agent.yaml — exit 1 with clear error"
+EMPTY=$(mktemp -d)
+mkdir -p "$EMPTY/logs"
+EXIT=0
+STDERR=$("$HEALTH" "$EMPTY" 2>&1 >/dev/null) || EXIT=$?
+assert_eq "1" "$EXIT" "exit 1 when agent.yaml absent"
+assert_contains "$STDERR" "agent.yaml not found" "error message names missing file"
+rm -rf "$EMPTY"
+
+# --- Test 9: Missing logs dir — exit 1 (no auto-create per spec) ---
+echo "## Test 9: Missing logs dir — exit 1, do not auto-create"
+NO_LOGS=$(mktemp -d)
+cat > "$NO_LOGS/agent.yaml" <<EOF
+name: testagent
+endpoints:
+  - url: http://127.0.0.1:$PORT/200
+    type: http
+EOF
+EXIT=0
+STDERR=$("$HEALTH" "$NO_LOGS" 2>&1 >/dev/null) || EXIT=$?
+assert_eq "1" "$EXIT" "exit 1 when logs/ missing"
+assert_contains "$STDERR" "Log dir not found" "error message names missing logs dir"
+[ ! -d "$NO_LOGS/logs" ]
+assert_eq "0" "$?" "logs/ not auto-created"
+rm -rf "$NO_LOGS"
+
+# --- Test 10: --threshold rejects non-integer values ---
+echo "## Test 10: Invalid --threshold value rejected"
+reset_logs
+write_yaml <<EOF
+name: testagent
+endpoints:
+  - url: http://127.0.0.1:$PORT/200
+    type: http
+EOF
+EXIT=0
+STDERR=$("$HEALTH" "$TMPDIR" --threshold abc 2>&1 >/dev/null) || EXIT=$?
+assert_eq "1" "$EXIT" "exit 1 on non-integer threshold"
+assert_contains "$STDERR" "must be a positive integer" "error message describes valid format"
+
+# --- Test 11: Missing url field on an endpoint — exit 1 with stderr warning ---
+echo "## Test 11: Endpoint missing url field — exit 1"
+reset_logs
+write_yaml <<EOF
+name: testagent
+endpoints:
+  - type: http
+  - url: http://127.0.0.1:$PORT/200
+    type: http
+EOF
+EXIT=0
+STDERR=$("$HEALTH" "$TMPDIR" 2>&1 >/dev/null) || EXIT=$?
+assert_eq "1" "$EXIT" "exit 1 when an endpoint lacks url"
+assert_contains "$STDERR" "missing url field" "warning identifies bad endpoint"
+# The good endpoint still got logged.
+GOOD_COUNT=$(jq -s '[.[] | select(.ok==true)] | length' "$TMPDIR/logs/health.jsonl")
+assert_eq "1" "$GOOD_COUNT" "valid endpoint still logged ok:true"
+
+echo ""
+echo "# Results: $PASS/$TESTS passed, $FAIL failed"
+[ $FAIL -eq 0 ]


### PR DESCRIPTION
## Summary

- New `scripts/health-check.sh` — pure bash + curl + jq + python3 framework primitive. Reads `endpoints:` from `<agent-dir>/agent.yaml` and writes canonical-schema JSONL to `<agent-dir>/logs/health.jsonl`, matching what the portal Health tab already consumes.
- Supports `--threshold <ms>` to flag slow endpoints with `ok:false` even when HTTP status is 2xx.
- New 35-test shell suite (`test/health-check.test.sh`) — local Python HTTP fixture plus assertions on schema, exit codes, threshold semantics, connection failures, and error-path messaging.
- v1.5.18 → 1.5.19. Lockfile synced (op-learning #62).

Refs #230.

## Acceptance criteria

| AC | Status | Notes |
|---|---|---|
| 1. Exit 0 on all 2xx, 1 otherwise | ✅ | Verified by tests 1, 2, 7. |
| 2. Reads `endpoints:` `{url, type}` from `agent.yaml` | ✅ | python3+yaml parse; jq iteration. Matches the convention referenced in agent-pm + ContentBot operational. |
| 3. Canonical schema `{ts, project, endpoint, status, latency_ms, ok}` to `logs/health.jsonl` | ✅ | Test 1 asserts every field. End-to-end run against `agentdeals.dev/health` produced: `{"ts":"2026-05-09T05:05:20Z","project":"e2e-test","endpoint":"https://agentdeals.dev/health","status":200,"latency_ms":317,"ok":true}` — same shape as the example in the issue. |
| 4. Latency in milliseconds | ✅ | curl `time_total` × 1000. Test 1 asserts integer. |
| 5. `--threshold <ms>` flags slow endpoints `ok:false` even on 2xx | ✅ | Tests 5, 6 cover both directions. |
| 6. Empty/missing `endpoints:` → exit 0 with stderr warning | ✅ | Tests 3, 4. |
| 7. Pure bash + curl + jq, no Node deps | ⚠️ Mostly | Uses `python3 -c "import yaml"` for the YAML parse — same pattern as `scripts/memory-index.py` and contentbot's `operational/tools/load-config.py`. The implementation note in the issue explicitly allows `python3 -c` ("either is fine; matches whatever the existing scripts/ already use"). Pure-bash YAML parsing is fragile; awk/grep would only work on the simplest list shape and fail on edge cases like comments, multi-line URLs, or block-style entries. Flagging this as the one judgment call. If you prefer a strict bash-only parser, can swap in awk/grep on a follow-up. |

## Implementation notes

- `type` field is read but informational in v1 — both `http` and `mcp` endpoints are probed via GET. The minimal-MCP-initialize POST is left as a follow-up per the issue's "treat MCP same as HTTP for v1" allowance.
- Connection failures (DNS, refused, timeout) record `status: 0`, `latency_ms: 0`, `ok: false`, and contribute to exit 1. Test 7 covers this.
- `--max-time 10` on each curl so a hung endpoint can't stall the whole probe.
- Per-endpoint timestamps (captured just before each curl) — more accurate than a single per-run stamp when probing several endpoints sequentially.
- `mkdir -p logs/` is intentionally NOT done — per the issue, the script errors out with a clear message if `logs/` is missing. Test 9 covers this.

## Test plan

- [x] All 35 new shell tests pass: `bash test/health-check.test.sh`
- [x] Full agent-portal suite green: 383 node + 75 shell = 458 tests pass via `npm test`
- [x] End-to-end against real endpoint: probed `https://agentdeals.dev/health`, got the expected JSONL line.
- [x] Schema verified compatible with `lib/ui/tabs/health.js` (uses `ts`, `project`, `endpoint`, `status`, `latency_ms`, `ok` — all present).
- [ ] Optional: deploy and confirm the Health tab renders new lines correctly. Will become natural after the first agent adds `endpoints:` to its `agent.yaml` and wires the script into a cron entry.