### PR TITLE
feat(scripts): health-check.sh --source flag for multi-project agents (v1.5.20)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-portal",
-  "version": "1.5.19",
+  "version": "1.5.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-portal",
-      "version": "1.5.19",
+      "version": "1.5.20",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.5.19",
+  "version": "1.5.20",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -1,23 +1,38 @@
 #!/bin/bash
 # scripts/health-check.sh — Probe agent endpoints and append results to logs/health.jsonl
 #
-# Usage: health-check.sh <agent-dir> [--threshold <ms>]
+# Usage: health-check.sh <agent-dir> [--threshold <ms>] [--source <file>]
 #
-# Reads the `endpoints:` list from <agent-dir>/agent.yaml (a list of
-# {url, type} objects), issues GET requests, measures latency, and writes
+# Default mode: reads the `endpoints:` list from <agent-dir>/agent.yaml (a list
+# of {url, type} objects), issues GET requests, measures latency, and writes
 # one canonical JSONL line per endpoint to <agent-dir>/logs/health.jsonl
 # in the schema consumed by the portal Health tab:
 #
 #   {"ts","project","endpoint","status","latency_ms","ok"}
 #
-# Exit 0 if all endpoints respond 2xx (and beat --threshold if given).
-# Exit 1 if any endpoint fails. Exit 0 with stderr warning if no endpoints
-# are configured.
+# --source <file> mode: reads endpoints from <agent-dir>/<file> using the
+# multi-project shape:
+#
+#   projects:
+#     - name: AgentDeals
+#       endpoints:
+#         - url: ...
+#           type: ...
+#
+# Each project's endpoints are probed; the JSONL `project` field uses the
+# project's `name` (not the agent's name from agent.yaml). Projects without
+# an `endpoints:` field are skipped silently.
+#
+# Exit 0 if all endpoints respond 2xx (and beat --threshold if given), or if
+# nothing is configured to probe.
+# Exit 1 if any endpoint fails, on configuration errors, or on parse errors.
+# Exit 2 if --source points to a nonexistent file.
 
 set -e
 
 AGENT_DIR=""
 THRESHOLD=""
+SOURCE_REL=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -29,8 +44,16 @@ while [ $# -gt 0 ]; do
       THRESHOLD="${1#--threshold=}"
       shift
       ;;
+    --source)
+      SOURCE_REL="$2"
+      shift 2
+      ;;
+    --source=*)
+      SOURCE_REL="${1#--source=}"
+      shift
+      ;;
     -h|--help)
-      echo "Usage: health-check.sh <agent-dir> [--threshold <ms>]"
+      echo "Usage: health-check.sh <agent-dir> [--threshold <ms>] [--source <file>]"
       exit 0
       ;;
     *)
@@ -46,7 +69,7 @@ while [ $# -gt 0 ]; do
 done
 
 if [ -z "$AGENT_DIR" ]; then
-  echo "Usage: health-check.sh <agent-dir> [--threshold <ms>]" >&2
+  echo "Usage: health-check.sh <agent-dir> [--threshold <ms>] [--source <file>]" >&2
   exit 1
 fi
 
@@ -55,51 +78,97 @@ if [ -n "$THRESHOLD" ] && ! [[ "$THRESHOLD" =~ ^[0-9]+$ ]]; then
   exit 1
 fi
 
-YAML="$AGENT_DIR/agent.yaml"
 LOG_DIR="$AGENT_DIR/logs"
 LOG="$LOG_DIR/health.jsonl"
-
-if [ ! -f "$YAML" ]; then
-  echo "agent.yaml not found at $YAML" >&2
-  exit 1
-fi
 
 if [ ! -d "$LOG_DIR" ]; then
   echo "Log dir not found at $LOG_DIR — create it before running health-check" >&2
   exit 1
 fi
 
-# Parse name + endpoints via python3 (yaml is part of the standard agentbox image
-# and is what operational/tools/load-config.py already relies on).
-PARSED=$(python3 -c "
-import sys, yaml, json
+# Resolve and parse the configuration source. Both modes produce a flat list
+# of {project, url, type} objects so the probe loop below is shape-agnostic.
+if [ -n "$SOURCE_REL" ]; then
+  if [ "${SOURCE_REL:0:1}" = "/" ]; then
+    SOURCE_FILE="$SOURCE_REL"
+  else
+    SOURCE_FILE="$AGENT_DIR/$SOURCE_REL"
+  fi
+  if [ ! -f "$SOURCE_FILE" ]; then
+    echo "Source file not found: $SOURCE_FILE" >&2
+    exit 2
+  fi
+  PARSED=$(SOURCE_FILE="$SOURCE_FILE" python3 -c "
+import os, sys, yaml, json
 try:
-    with open('$YAML') as f:
+    with open(os.environ['SOURCE_FILE']) as f:
         doc = yaml.safe_load(f) or {}
-    print(json.dumps({'name': doc.get('name', ''), 'endpoints': doc.get('endpoints') or []}))
+    if not isinstance(doc, dict):
+        raise ValueError('top-level must be a mapping')
+    projects = doc.get('projects') or []
+    if not isinstance(projects, list):
+        raise ValueError('projects must be a list')
+    out = []
+    for p in projects:
+        if not isinstance(p, dict):
+            raise ValueError('each project must be a mapping')
+        name = p.get('name', '') or ''
+        eps = p.get('endpoints') or []
+        if not eps:
+            continue
+        if not isinstance(eps, list):
+            raise ValueError('endpoints must be a list under project ' + str(name))
+        for ep in eps:
+            if not isinstance(ep, dict):
+                raise ValueError('each endpoint must be a mapping under project ' + str(name))
+            out.append({'project': name, 'url': ep.get('url', '') or '', 'type': ep.get('type', '') or ''})
+    print(json.dumps({'pairs': out}))
+except Exception as e:
+    print('PARSE_ERROR:' + str(e), file=sys.stderr)
+    sys.exit(1)
+") || { echo "Failed to parse $SOURCE_FILE" >&2; exit 1; }
+else
+  YAML="$AGENT_DIR/agent.yaml"
+  if [ ! -f "$YAML" ]; then
+    echo "agent.yaml not found at $YAML" >&2
+    exit 1
+  fi
+  PARSED=$(YAML_FILE="$YAML" python3 -c "
+import os, sys, yaml, json
+try:
+    with open(os.environ['YAML_FILE']) as f:
+        doc = yaml.safe_load(f) or {}
+    name = doc.get('name', '') or ''
+    eps = doc.get('endpoints') or []
+    out = [{'project': name, 'url': (ep.get('url', '') or '') if isinstance(ep, dict) else '', 'type': (ep.get('type', '') or '') if isinstance(ep, dict) else ''} for ep in eps]
+    print(json.dumps({'pairs': out}))
 except Exception as e:
     print('PARSE_ERROR:' + str(e), file=sys.stderr)
     sys.exit(1)
 ") || { echo "Failed to parse $YAML" >&2; exit 1; }
+fi
 
-PROJECT=$(echo "$PARSED" | jq -r '.name')
-
-EP_COUNT=$(echo "$PARSED" | jq '.endpoints | length')
-if [ "$EP_COUNT" = "0" ]; then
-  echo "No endpoints configured in $YAML — nothing to probe" >&2
+PAIR_COUNT=$(echo "$PARSED" | jq '.pairs | length')
+if [ "$PAIR_COUNT" = "0" ]; then
+  if [ -n "$SOURCE_REL" ]; then
+    echo "No project endpoints configured in $SOURCE_FILE — nothing to probe" >&2
+  else
+    echo "No endpoints configured in $YAML — nothing to probe" >&2
+  fi
   exit 0
 fi
 
 ALL_OK=true
 
-# Iterate endpoints. Each is a {url, type} object. type is informational
-# in v1; both http and mcp endpoints are probed via GET.
-while IFS= read -r ep; do
-  [ -z "$ep" ] && continue
-  URL=$(echo "$ep" | jq -r '.url // empty')
+# Iterate the flat (project, url, type) list. type is informational in v1;
+# both http and mcp endpoints are probed via GET.
+while IFS= read -r pair; do
+  [ -z "$pair" ] && continue
+  PROJECT=$(echo "$pair" | jq -r '.project')
+  URL=$(echo "$pair" | jq -r '.url // empty')
 
   if [ -z "$URL" ]; then
-    echo "Endpoint missing url field: $ep" >&2
+    echo "Endpoint missing url field: $pair" >&2
     ALL_OK=false
     continue
   fi
@@ -134,7 +203,7 @@ while IFS= read -r ep; do
     --argjson ok "$OK" \
     '{ts: $ts, project: $project, endpoint: $endpoint, status: $status, latency_ms: $latency_ms, ok: $ok}' \
     >> "$LOG"
-done < <(echo "$PARSED" | jq -c '.endpoints[]')
+done < <(echo "$PARSED" | jq -c '.pairs[]')
 
 if [ "$ALL_OK" = "true" ]; then
   exit 0

--- a/test/health-check.test.sh
+++ b/test/health-check.test.sh
@@ -268,6 +268,158 @@ assert_contains "$STDERR" "missing url field" "warning identifies bad endpoint"
 GOOD_COUNT=$(jq -s '[.[] | select(.ok==true)] | length' "$TMPDIR/logs/health.jsonl")
 assert_eq "1" "$GOOD_COUNT" "valid endpoint still logged ok:true"
 
+# --- Test 12: --source happy path — two projects each with one endpoint ---
+echo "## Test 12: --source projects.yaml with two projects — project field uses project name"
+reset_logs
+# Use a benign minimal agent.yaml to keep the dir realistic; --source mode shouldn't read it.
+write_yaml <<EOF
+name: orchestrator
+EOF
+mkdir -p "$TMPDIR/memory"
+cat > "$TMPDIR/memory/projects.yaml" <<EOF
+projects:
+  - name: ProjectA
+    endpoints:
+      - url: http://127.0.0.1:$PORT/200
+        type: http
+  - name: ProjectB
+    endpoints:
+      - url: http://127.0.0.1:$PORT/200
+        type: mcp
+EOF
+EXIT=0
+"$HEALTH" "$TMPDIR" --source memory/projects.yaml >/dev/null 2>&1 || EXIT=$?
+assert_eq "0" "$EXIT" "exit 0 when all source endpoints 2xx"
+LINES=$(wc -l < "$TMPDIR/logs/health.jsonl" | tr -d ' ')
+assert_eq "2" "$LINES" "two JSONL lines from two projects"
+PROJECTS=$(jq -s '[.[].project] | sort | join(",")' "$TMPDIR/logs/health.jsonl")
+assert_eq "\"ProjectA,ProjectB\"" "$PROJECTS" "project field uses project name (not agent name)"
+NOT_ORCHESTRATOR=$(jq -s '[.[] | select(.project=="orchestrator")] | length' "$TMPDIR/logs/health.jsonl")
+assert_eq "0" "$NOT_ORCHESTRATOR" "agent.yaml name not leaked into project field"
+
+# --- Test 13: --source skips projects with no endpoints silently ---
+echo "## Test 13: --source skips no-endpoints projects without warning"
+reset_logs
+cat > "$TMPDIR/memory/projects.yaml" <<EOF
+projects:
+  - name: WithEndpoints
+    endpoints:
+      - url: http://127.0.0.1:$PORT/200
+        type: http
+  - name: NoEndpoints
+  - name: EmptyEndpoints
+    endpoints: []
+EOF
+EXIT=0
+STDERR=$("$HEALTH" "$TMPDIR" --source memory/projects.yaml 2>&1 >/dev/null) || EXIT=$?
+assert_eq "0" "$EXIT" "exit 0 when one project endpointed and others not"
+LINES=$(wc -l < "$TMPDIR/logs/health.jsonl" | tr -d ' ')
+assert_eq "1" "$LINES" "only the endpointed project is probed"
+ONLY=$(jq -r '.project' "$TMPDIR/logs/health.jsonl")
+assert_eq "WithEndpoints" "$ONLY" "logged project is the one with endpoints"
+# Stderr must be silent for skipped projects (no warning per AC #3).
+SKIPPED_WARN=$(echo "$STDERR" | grep -ic "noendpoints\|skipped\|skipping" || true)
+assert_eq "0" "$SKIPPED_WARN" "no warning for projects without endpoints"
+
+# --- Test 14: --source malformed YAML — exit 1 with clear error ---
+echo "## Test 14: --source malformed projects.yaml — exit 1, clear error"
+reset_logs
+cat > "$TMPDIR/memory/projects.yaml" <<'EOF'
+projects:
+  - name: Bad
+  -- this is not valid yaml :: at all
+EOF
+EXIT=0
+STDERR=$("$HEALTH" "$TMPDIR" --source memory/projects.yaml 2>&1 >/dev/null) || EXIT=$?
+assert_eq "1" "$EXIT" "exit 1 on malformed source yaml"
+assert_contains "$STDERR" "Failed to parse|PARSE_ERROR" "error message indicates parse failure"
+
+# --- Test 14b: --source where projects entries have wrong shape ---
+echo "## Test 14b: --source with non-mapping project entries — exit 1"
+reset_logs
+cat > "$TMPDIR/memory/projects.yaml" <<EOF
+projects:
+  - just-a-string
+EOF
+EXIT=0
+STDERR=$("$HEALTH" "$TMPDIR" --source memory/projects.yaml 2>&1 >/dev/null) || EXIT=$?
+assert_eq "1" "$EXIT" "exit 1 when projects entry is not a mapping"
+assert_contains "$STDERR" "Failed to parse|each project must be a mapping" "error names the structural problem"
+
+# --- Test 15: --source nonexistent file — exit 2 ---
+echo "## Test 15: --source nonexistent file — exit 2"
+reset_logs
+EXIT=0
+STDERR=$("$HEALTH" "$TMPDIR" --source memory/missing.yaml 2>&1 >/dev/null) || EXIT=$?
+assert_eq "2" "$EXIT" "exit 2 on nonexistent source file (config error)"
+assert_contains "$STDERR" "Source file not found" "error message names the missing file"
+
+# --- Test 16: --source + --threshold compose ---
+echo "## Test 16: --source + --threshold flags slow endpoint"
+reset_logs
+cat > "$TMPDIR/memory/projects.yaml" <<EOF
+projects:
+  - name: SlowProject
+    endpoints:
+      - url: http://127.0.0.1:$PORT/slow
+        type: http
+EOF
+EXIT=0
+"$HEALTH" "$TMPDIR" --source memory/projects.yaml --threshold 50 >/dev/null 2>&1 || EXIT=$?
+assert_eq "1" "$EXIT" "exit 1 when source endpoint exceeds threshold"
+LINE=$(head -n 1 "$TMPDIR/logs/health.jsonl")
+assert_eq "SlowProject" "$(echo "$LINE" | jq -r '.project')" "project field still uses project name with --threshold"
+assert_eq "false" "$(echo "$LINE" | jq -r '.ok')" "ok:false when slow endpoint exceeds threshold"
+
+# --- Test 17: --source with empty/missing projects key — exit 0 with warning ---
+echo "## Test 17: --source with no projects — exit 0 with warning"
+reset_logs
+cat > "$TMPDIR/memory/projects.yaml" <<EOF
+# no projects key
+some_other_field: irrelevant
+EOF
+EXIT=0
+STDERR=$("$HEALTH" "$TMPDIR" --source memory/projects.yaml 2>&1 >/dev/null) || EXIT=$?
+assert_eq "0" "$EXIT" "exit 0 when source has no projects"
+assert_contains "$STDERR" "No project endpoints" "warning printed when source has no project endpoints"
+
+# --- Test 18: --source path is relative to <agent-dir> ---
+echo "## Test 18: --source path resolved relative to agent-dir"
+reset_logs
+mkdir -p "$TMPDIR/custom-layout"
+cat > "$TMPDIR/custom-layout/services.yaml" <<EOF
+projects:
+  - name: Custom
+    endpoints:
+      - url: http://127.0.0.1:$PORT/200
+        type: http
+EOF
+EXIT=0
+"$HEALTH" "$TMPDIR" --source custom-layout/services.yaml >/dev/null 2>&1 || EXIT=$?
+assert_eq "0" "$EXIT" "exit 0 when --source points to non-default layout"
+LINES=$(wc -l < "$TMPDIR/logs/health.jsonl" | tr -d ' ')
+assert_eq "1" "$LINES" "single endpoint probed from custom layout"
+
+# --- Test 19: --source mode does not require agent.yaml ---
+echo "## Test 19: --source works even without agent.yaml"
+reset_logs
+NO_AGENT=$(mktemp -d)
+mkdir -p "$NO_AGENT/logs"
+mkdir -p "$NO_AGENT/memory"
+cat > "$NO_AGENT/memory/projects.yaml" <<EOF
+projects:
+  - name: Standalone
+    endpoints:
+      - url: http://127.0.0.1:$PORT/200
+        type: http
+EOF
+EXIT=0
+"$HEALTH" "$NO_AGENT" --source memory/projects.yaml >/dev/null 2>&1 || EXIT=$?
+assert_eq "0" "$EXIT" "exit 0 in --source mode without agent.yaml"
+ONLY=$(jq -r '.project' "$NO_AGENT/logs/health.jsonl")
+assert_eq "Standalone" "$ONLY" "project name correctly recorded"
+rm -rf "$NO_AGENT"
+
 echo ""
 echo "# Results: $PASS/$TESTS passed, $FAIL failed"
 [ $FAIL -eq 0 ]


### PR DESCRIPTION
## Summary

Extends `scripts/health-check.sh` (shipped #231 / v1.5.19) with a `--source <file>` flag for the multi-project YAML shape used by orchestrator agents (e.g. agent-pm's `memory/projects.yaml`). PM has been running ad-hoc curl→jsonl ~250 cycles to date — this standardizes that pattern via the same primitive.

## What changed

- `scripts/health-check.sh`: parses `--source <file>` (relative to `<agent-dir>` unless absolute). When set, reads `projects:` list and emits one JSONL line per `(project, endpoint)` pair, with the `project` field populated from each project's `name` field (NOT the agent's `name` from `agent.yaml`).
- Default mode (no `--source`) is byte-for-byte unchanged — same agent.yaml-endpoints shape as v1, same exit codes, same warning text. All 35 original tests pass without modification.
- Internally refactored to a single shape-agnostic probe loop over a flat `[{project, url, type}]` list. The two parsers (agent.yaml and projects.yaml) just produce that flat list differently.
- Python parsers now read paths from env vars (`SOURCE_FILE`, `YAML_FILE`) rather than via shell-string interpolation — small hardening since paths can now come from user-supplied flag input.

## Acceptance criteria

| AC | Met | Where |
|----|-----|-------|
| 1. `--source memory/projects.yaml` reads each project's endpoints and probes them | ✅ | scripts/health-check.sh:80-118; Test 12 |
| 2. JSONL `project` field uses the project's `name` (not agent.yaml name) | ✅ | parser line `'project': name`; Test 12 |
| 3. Skips projects without `endpoints:` silently | ✅ | parser `if not eps: continue`; Test 13 |
| 4. Default behavior preserved (no `--source` reads agent.yaml endpoints exactly as today) | ✅ | scripts/health-check.sh:120-140; all 35 original tests pass |
| 5. `--source` accepts a path relative to `<agent-dir>` | ✅ | `SOURCE_FILE=\"\$AGENT_DIR/\$SOURCE_REL\"`; Test 18 |
| 6. `--threshold` works with `--source` | ✅ | shared probe loop; Test 16 |
| 7. New tests for two-projects-each-with-endpoint, project-with-no-endpoints (silent skip), malformed projects.yaml | ✅ | Tests 12-19 (incl. 14b for non-mapping entries, 15 for nonexistent file, 17 for empty-projects, 19 for no-agent.yaml) |

## Implementation notes & deviations

1. **Parser approach: python3 + yaml** (matches #230 precedent). Same deviation justification as #230 — robust YAML parsing without a pure-bash awk approximation.
2. **Path resolution.** Implemented as: if `--source` starts with `/`, treat as absolute; else resolve relative to `<agent-dir>`. AC #5 says \"relative to `<agent-dir>`\" — accommodating absolute paths is a strict-superset and useful for ad-hoc invocations.
3. **Exit codes.** Issue spec requires exit 2 for nonexistent `--source` file. I kept exit 1 for malformed YAML (same as the existing parse-error path on agent.yaml) — a malformed file is observably present, just unparseable. If there's a preference for exit 2 across all `--source` config errors, easy follow-up.
4. **Validation strictness.** The parser explicitly rejects: top-level non-mapping, `projects` not a list, project entry not a mapping, `endpoints` not a list, endpoint not a mapping. Test 14b covers the non-mapping-project case. The intent is fail-loud on shape violations rather than silently producing garbage.
5. **agent.yaml not required in `--source` mode.** Tested explicitly (Test 19) — orchestrator agents that don't have a meaningful `name:` for themselves can omit it. The issue text said \"agent.yaml `name:` field is still the source for the agent itself when the source file has no projects with endpoints\" — but in practice the warning text doesn't reference the agent name, so agent.yaml isn't actually needed.

## Test results

- `npm test`: **481/481 pass** (383 node + 98 shell).
- health-check.sh suite alone: **58/58 pass** (35 v1 + 23 new for `--source`).
- E2E against real endpoint:
  ```
  \$ bash scripts/health-check.sh \$tmpdir --source memory/projects.yaml
  exit=0
  {\"ts\":\"2026-05-09T09:05:49Z\",\"project\":\"AgentDeals\",\"endpoint\":\"https://agentdeals.dev/health\",\"status\":200,\"latency_ms\":2634,\"ok\":true}
  ```
  AgentDeals project name comes from projects.yaml; agent.yaml `name: e2e-test` is correctly NOT leaked.

## Out of scope (per issue)

- Generic `--source` for arbitrary YAML shapes (v1 = projects-list shape only)
- Per-project threshold overrides
- Authenticated endpoints
- Auto-cron PM's own health-check (config-side step)

## Test plan

- [x] All 35 original health-check tests still pass (no behavioral change in default mode)
- [x] New: 2-projects-each-with-endpoint
- [x] New: skip silently when project has no endpoints
- [x] New: malformed YAML → exit 1 with clear error
- [x] New: non-mapping projects entry → exit 1 with structural error
- [x] New: nonexistent source file → exit 2 with \"Source file not found\"
- [x] New: --source + --threshold compose
- [x] New: empty/missing projects key → exit 0 with warning
- [x] New: --source path relative to agent-dir (custom layout)
- [x] New: --source works without agent.yaml
- [x] Full npm test suite (481/481)
- [x] E2E against agentdeals.dev/health

Refs #232