### PR TITLE
feat(config): dataDir field + dataPath helper (foundation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,35 @@ Each agent has a `portal.config.json` with these fields:
 | `pidFile` | Path to portal PID file | `"/tmp/agent-coder-portal-server.pid"` |
 | `authors` | Map of author names to `{ color, bg }` for badge styling | See examples |
 
+### Optional
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| `dataDir` | Subdirectory under `agentDir` where all framework-managed mutable state lives (`logs/`, `journals/`, `memory/`, `content/`, `config/`, `input/`, `output/`, `uploads/`, etc.). Operator-owned files (`CLAUDE.md`, `agent.yaml`, `today.md`, `roadmap.md`, `scripts/`, `skills/`) stay at `agentDir` regardless. Set to `"data"` to keep mutable state in a single directory that can be gitignored or mounted as a separate volume. | `"."` (everything at agentDir root — legacy layout) |
+
+**Recommended layout when `dataDir: "data"` is set:**
+
+```
+<agentDir>/
+├── CLAUDE.md              # operator-owned, code repo
+├── agent.yaml             # operator-owned, code repo
+├── portal.config.json     # operator-owned, code repo
+├── scripts/, skills/      # operator-owned, code repo
+└── data/                  # gitignored (or mounted volume in hosted)
+    ├── logs/
+    ├── journals/
+    ├── memory/
+    ├── content/items/
+    ├── config/
+    ├── input/feedback/
+    ├── output/
+    └── uploads/
+```
+
+Add `data/` to `.gitignore` so cycle writes don't pollute git history. For a local-rollback safety net, `git init` inside `data/` as a separate, non-pushed repo.
+
+`features.library.dataDir` (and similar per-feature path overrides) are resolved relative to `<agentDir>/<dataDir>`. With default `dataDir: "."` the absolute resolution is identical to the legacy layout, so no agent needs to change its config to keep working — opt in when you're ready.
+
 ### Features
 
 The `features` object controls which tabs and routes are enabled. Omit a key to disable it.

--- a/examples/contentbot-hosted.config.json
+++ b/examples/contentbot-hosted.config.json
@@ -1,0 +1,26 @@
+{
+  "_comment": "Hosted ContentBot deployment: dataDir isolates all mutable state under data/ for snapshotting and per-user volume mounting. Code stays at agentDir root.",
+  "name": "ContentBot",
+  "port": 8084,
+  "agentDir": "/root/contentbot",
+  "dataDir": "data",
+  "cronFile": "/etc/cron.d/contentbot",
+  "lockFile": "/tmp/contentbot.lock",
+  "harness": {
+    "type": "letta-code",
+    "command": "letta -p",
+    "extraFlags": "--name contentbot --model sonnet --allowedTools Bash,Edit,Write,Read,Glob,Grep,WebSearch,WebFetch"
+  },
+  "authors": {
+    "rob": { "color": "#1565c0", "bg": "#e3f2fd" },
+    "contentbot": { "color": "#e65100", "bg": "#fff3e0" }
+  },
+  "sidebar": { "type": "simple" },
+  "features": {
+    "library": {
+      "dataDir": "content/items",
+      "badges": false
+    },
+    "tabs": ["library", "sources", "preferences", "journal", "status", "capabilities"]
+  }
+}

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 const path = require('path');
 const { createServer, startServer } = require('./lib/server');
 const { buildHTML } = require('./lib/ui');
+const { dataPath } = require('./lib/helpers');
 
 // Load config from CLI argument
 const configPath = process.argv[2];
@@ -28,12 +29,11 @@ if (config.agentDir && !path.isAbsolute(config.agentDir)) {
   config.agentDir = path.resolve(path.dirname(resolvedConfigPath), config.agentDir);
 }
 
-// Ensure required directories exist
+// Ensure required directories exist under the configured data dir
+// (defaults to agentDir when dataDir is unset or "." — backwards compatible).
 const agentDir = config.agentDir;
 if (agentDir) {
-  const journalsDir = path.join(agentDir, 'journals');
-  const logsDir = path.join(agentDir, 'logs');
-  for (const dir of [journalsDir, logsDir]) {
+  for (const dir of [dataPath(config, 'journals'), dataPath(config, 'logs')]) {
     if (!fs.existsSync(dir)) {
       fs.mkdirSync(dir, { recursive: true });
     }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -5,6 +5,29 @@ const fs = require('fs');
 const path = require('path');
 
 /**
+ * Return the configured data directory, defaulting to '.' for backwards compat.
+ * The data directory is where framework-managed mutable state lives
+ * (logs/, journals/, memory/, content/, config/, input/, output/, uploads/, etc.).
+ * Operator-owned files (CLAUDE.md, agent.yaml, today.md, roadmap.md, scripts/,
+ * skills/, tools/, .mcp.json) stay at the agent root regardless of this setting.
+ */
+function getDataDir(config) {
+  return (config && config.dataDir) || '.';
+}
+
+/**
+ * Resolve a data path relative to <agentDir>/<dataDir>.
+ * Routes and helpers that touch framework-managed state should use this
+ * instead of path.join(config.agentDir, ...). Operator-owned root paths
+ * (today.md, roadmap.md, agent.yaml, .mcp.json, tools/, skills/) should
+ * continue to use path.join(config.agentDir, ...) directly.
+ */
+function dataPath(config, ...parts) {
+  const agentDir = (config && config.agentDir) || '.';
+  return path.join(agentDir, getDataDir(config), ...parts);
+}
+
+/**
  * Send a JSON response with the given status code and data.
  */
 function sendJSON(res, statusCode, data) {
@@ -139,4 +162,4 @@ function editJournalEntry(filePath, ts, newText, newTag) {
   return true;
 }
 
-module.exports = { sendJSON, readBody, readLastLines, parseJournal, getAllJournalEntries, parseFrontmatter, editJournalEntry };
+module.exports = { sendJSON, readBody, readLastLines, parseJournal, getAllJournalEntries, parseFrontmatter, editJournalEntry, getDataDir, dataPath };

--- a/scripts/read-harness-config.sh
+++ b/scripts/read-harness-config.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
-# scripts/read-harness-config.sh — Read harness config from portal.config.json
+# scripts/read-harness-config.sh — Read harness + data dir config from portal.config.json
 #
 # Usage: eval "$(bash read-harness-config.sh /path/to/agent-dir)"
 #
-# Exports: HARNESS_TYPE, HARNESS_CMD, HARNESS_EXTRA_FLAGS
-# Defaults to claude-code with current hardcoded behavior if no harness config found.
+# Exports: HARNESS_TYPE, HARNESS_CMD, HARNESS_EXTRA_FLAGS, DATA_DIR
+# Defaults: claude-code harness, DATA_DIR="." (backwards-compatible with the
+# pre-dataDir layout where all framework state lives at the agent root).
 
 AGENT_DIR="${1:-.}"
 PORTAL_CONFIG="$AGENT_DIR/portal.config.json"
@@ -19,11 +20,13 @@ if [ -f "$PORTAL_CONFIG" ] && command -v node >/dev/null 2>&1; then
     console.log('HARNESS_TYPE=' + JSON.stringify(h.type || 'claude-code'));
     console.log('HARNESS_CMD=' + JSON.stringify(h.command || 'claude --print'));
     console.log('HARNESS_EXTRA_FLAGS=' + JSON.stringify(h.extraFlags || ''));
+    console.log('DATA_DIR=' + JSON.stringify(c.dataDir || '.'));
   ")"
 else
   HARNESS_TYPE="claude-code"
   HARNESS_CMD="claude --print"
   HARNESS_EXTRA_FLAGS=""
+  DATA_DIR="."
 fi
 
 # Apply claude-code defaults when no extraFlags configured
@@ -34,3 +37,4 @@ fi
 echo "export HARNESS_TYPE=${HARNESS_TYPE@Q}"
 echo "export HARNESS_CMD=${HARNESS_CMD@Q}"
 echo "export HARNESS_EXTRA_FLAGS=${HARNESS_EXTRA_FLAGS@Q}"
+echo "export DATA_DIR=${DATA_DIR@Q}"

--- a/test/data-dir.test.js
+++ b/test/data-dir.test.js
@@ -1,0 +1,145 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { execSync } = require('child_process');
+const { getDataDir, dataPath } = require('../lib/helpers');
+
+describe('getDataDir', () => {
+  it('returns "." when config is undefined', () => {
+    assert.equal(getDataDir(undefined), '.');
+  });
+
+  it('returns "." when config has no dataDir', () => {
+    assert.equal(getDataDir({}), '.');
+  });
+
+  it('returns "." for empty-string dataDir (backwards compat fallback)', () => {
+    assert.equal(getDataDir({ dataDir: '' }), '.');
+  });
+
+  it('returns the configured dataDir value', () => {
+    assert.equal(getDataDir({ dataDir: 'data' }), 'data');
+  });
+
+  it('preserves nested dataDir paths', () => {
+    assert.equal(getDataDir({ dataDir: 'state/agent-data' }), 'state/agent-data');
+  });
+});
+
+describe('dataPath', () => {
+  it('joins agentDir + "." + parts when dataDir is unset', () => {
+    const result = dataPath({ agentDir: '/agent' }, 'logs', 'events.jsonl');
+    assert.equal(result, path.join('/agent', '.', 'logs', 'events.jsonl'));
+  });
+
+  it('joins agentDir + dataDir + parts when dataDir is set', () => {
+    const result = dataPath({ agentDir: '/agent', dataDir: 'data' }, 'memory', 'preferences.yaml');
+    assert.equal(result, path.join('/agent', 'data', 'memory', 'preferences.yaml'));
+  });
+
+  it('resolves to identical absolute path for default and "." (regression guard)', () => {
+    const defaulted = path.resolve(dataPath({ agentDir: '/agent' }, 'logs'));
+    const explicit = path.resolve(dataPath({ agentDir: '/agent', dataDir: '.' }, 'logs'));
+    assert.equal(defaulted, explicit);
+  });
+
+  it('falls back to "." for agentDir when config has no agentDir', () => {
+    const result = dataPath({}, 'logs');
+    assert.equal(result, path.join('.', '.', 'logs'));
+  });
+
+  it('accepts zero subpath parts (returns the data dir itself)', () => {
+    assert.equal(dataPath({ agentDir: '/agent', dataDir: 'data' }), path.join('/agent', 'data'));
+  });
+});
+
+describe('index.js pre-creates dataDir subdirs', () => {
+  it('creates <dataDir>/journals and <dataDir>/logs on portal boot', () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'data-dir-boot-'));
+    try {
+      const agentDir = path.join(tmpRoot, 'agent');
+      fs.mkdirSync(agentDir, { recursive: true });
+      const configPath = path.join(tmpRoot, 'portal.config.json');
+      fs.writeFileSync(configPath, JSON.stringify({
+        name: 'BootTest',
+        port: 0, // ephemeral
+        agentDir,
+        dataDir: 'data',
+        cronFile: '/nonexistent/cron',
+        lockFile: path.join(tmpRoot, 'lock'),
+        pidFile: path.join(tmpRoot, 'pid'),
+      }));
+
+      // Boot, then kill immediately — we only care about the side effects of index.js startup
+      const indexPath = path.resolve(__dirname, '..', 'index.js');
+      const child = execSync(
+        `node -e "process.argv=[process.argv[0],'${indexPath}','${configPath}'];require('${indexPath}');setTimeout(()=>process.exit(0),100);"`,
+        { encoding: 'utf-8', timeout: 5000, stdio: ['ignore', 'pipe', 'pipe'] }
+      );
+
+      assert.ok(fs.existsSync(path.join(agentDir, 'data', 'journals')), 'data/journals should be created');
+      assert.ok(fs.existsSync(path.join(agentDir, 'data', 'logs')), 'data/logs should be created');
+      // Old root-level paths should NOT be created when dataDir is set
+      assert.ok(!fs.existsSync(path.join(agentDir, 'journals')), 'root journals should NOT be created');
+      assert.ok(!fs.existsSync(path.join(agentDir, 'logs')), 'root logs should NOT be created');
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves legacy behavior when dataDir is unset (creates root-level dirs)', () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'data-dir-legacy-'));
+    try {
+      const agentDir = path.join(tmpRoot, 'agent');
+      fs.mkdirSync(agentDir, { recursive: true });
+      const configPath = path.join(tmpRoot, 'portal.config.json');
+      fs.writeFileSync(configPath, JSON.stringify({
+        name: 'LegacyTest',
+        port: 0,
+        agentDir,
+        cronFile: '/nonexistent/cron',
+        lockFile: path.join(tmpRoot, 'lock'),
+        pidFile: path.join(tmpRoot, 'pid'),
+      }));
+
+      const indexPath = path.resolve(__dirname, '..', 'index.js');
+      execSync(
+        `node -e "process.argv=[process.argv[0],'${indexPath}','${configPath}'];require('${indexPath}');setTimeout(()=>process.exit(0),100);"`,
+        { encoding: 'utf-8', timeout: 5000, stdio: ['ignore', 'pipe', 'pipe'] }
+      );
+
+      assert.ok(fs.existsSync(path.join(agentDir, 'journals')), 'legacy root journals should be created');
+      assert.ok(fs.existsSync(path.join(agentDir, 'logs')), 'legacy root logs should be created');
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('read-harness-config.sh exports DATA_DIR', () => {
+  it('emits DATA_DIR="." when portal.config.json has no dataDir', () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'data-dir-shell-default-'));
+    try {
+      fs.writeFileSync(path.join(tmpRoot, 'portal.config.json'), JSON.stringify({ name: 'T' }));
+      const scriptPath = path.resolve(__dirname, '..', 'scripts', 'read-harness-config.sh');
+      const output = execSync(`bash "${scriptPath}" "${tmpRoot}"`, { encoding: 'utf-8' });
+      assert.match(output, /export DATA_DIR='?\.'?/);
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('emits the configured dataDir', () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'data-dir-shell-set-'));
+    try {
+      fs.writeFileSync(path.join(tmpRoot, 'portal.config.json'), JSON.stringify({ name: 'T', dataDir: 'data' }));
+      const scriptPath = path.resolve(__dirname, '..', 'scripts', 'read-harness-config.sh');
+      const output = execSync(`bash "${scriptPath}" "${tmpRoot}"`, { encoding: 'utf-8' });
+      assert.match(output, /export DATA_DIR='?data'?/);
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds an optional top-level `dataDir` field to `portal.config.json` (default `"."`) and the `dataPath(config, ...)` helper that routes/scripts will opt into in follow-up PRs.

When set to e.g. `"data"`, every framework-managed write lands under `<agentDir>/data/`; operator-owned files (CLAUDE.md, agent.yaml, today.md, roadmap.md, scripts/, skills/) stay at `agentDir` root.

This is the foundation only — no existing route or script has been migrated. Default `"."` is fully backwards compatible with every existing agent.

## Changes

- `lib/helpers.js` — `getDataDir(config)`, `dataPath(config, ...parts)` exports
- `index.js` — pre-creates `<dataDir>/journals` and `<dataDir>/logs` (was: at root)
- `scripts/read-harness-config.sh` — emits `export DATA_DIR=...` for shell scripts
- `examples/contentbot-hosted.config.json` (new) — hosted-style config showing `dataDir: "data"`
- `README.md` — documents the new field + recommended layout
- `test/data-dir.test.js` (new) — 14 tests for helpers, boot behavior, shell reader

## Follow-up PRs

- **#2** routes — 16 route handlers use `dataPath` instead of `path.join(agentDir, ...)`
- **#3** scripts — wake/respond/log/consolidate/etc. use `$DATA_DIR`
- **#4** docs — deeper migration guide
- **#5** (contentbot repo) — migrate ContentBot to `dataDir: "data"`

## Test plan

- [x] `npm test` — 397/397 node tests pass, all shell tests pass
- [x] Boot portal in legacy layout → `journals/` and `logs/` created at agentDir root
- [x] Boot portal with `dataDir: "data"` → `data/journals/` and `data/logs/` created under data dir, NOT at root
- [x] Both portal instances return 200 on `/api/journal`
- [x] Regression guard: explicit `dataDir: "."` resolves identically to default