### PR TITLE
feat(routes): all route handlers resolve data paths via dataPath helper

### DIFF
--- a/lib/routes/badges.js
+++ b/lib/routes/badges.js
@@ -3,7 +3,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { sendJSON } = require('../helpers');
+const { sendJSON, dataPath } = require('../helpers');
 
 function register(routes, config) {
   const agentDir = config.agentDir || '.';
@@ -17,8 +17,8 @@ function register(routes, config) {
     // Outputs: count unreviewed
     if (tabs.includes('outputs') && config.features && config.features.outputs) {
       try {
-        const outputDir = path.join(agentDir, 'output');
-        const feedbackDir = path.join(agentDir, 'input', 'feedback');
+        const outputDir = dataPath(config, 'output');
+        const feedbackDir = dataPath(config, 'input', 'feedback');
         const processedDir = path.join(feedbackDir, 'processed');
         let files = fs.readdirSync(outputDir)
           .filter(f => f.endsWith('.md') && f !== '.gitkeep');
@@ -39,7 +39,7 @@ function register(routes, config) {
     // Requests: count pending
     if (tabs.includes('requests') && config.features && config.features.requests) {
       try {
-        const requestsDir = path.join(agentDir, 'requests');
+        const requestsDir = dataPath(config, 'requests');
         const files = fs.readdirSync(requestsDir)
           .filter(f => f.endsWith('.md') && f !== '_template.md');
         let pending = 0;
@@ -57,9 +57,9 @@ function register(routes, config) {
     const libraryBadges = typeof libraryConf === 'object' ? libraryConf.badges !== false : !!libraryConf;
     if (tabs.includes('library') && libraryConf && libraryBadges) {
       try {
-        const dataDir = (typeof config.features.library === 'object' && config.features.library.dataDir) || 'content/items';
-        const itemsDir = path.join(agentDir, dataDir);
-        const feedbackDir = path.join(agentDir, 'input', 'feedback');
+        const libraryDataDir = (typeof config.features.library === 'object' && config.features.library.dataDir) || 'content/items';
+        const itemsDir = dataPath(config, libraryDataDir);
+        const feedbackDir = dataPath(config, 'input', 'feedback');
         const files = fs.readdirSync(itemsDir)
           .filter(f => f.endsWith('.yaml') || f.endsWith('.yml'));
         const processedDir = path.join(feedbackDir, 'processed');
@@ -77,7 +77,7 @@ function register(routes, config) {
     // Todos: count open (not done)
     if (tabs.includes('todos')) {
       try {
-        const todosFile = path.join(agentDir, 'human_todos.md');
+        const todosFile = dataPath(config, 'human_todos.md');
         const content = fs.readFileSync(todosFile, 'utf-8');
         const lines = content.split('\n');
         let open = 0;

--- a/lib/routes/events.js
+++ b/lib/routes/events.js
@@ -2,10 +2,10 @@
 
 const fs = require('fs');
 const path = require('path');
-const { sendJSON, readLastLines } = require('../helpers');
+const { sendJSON, readLastLines, dataPath } = require('../helpers');
 
 function register(routes, config) {
-  const logsDir = path.join(config.agentDir, 'logs');
+  const logsDir = dataPath(config, 'logs');
 
   routes['GET /api/events'] = (req, res) => {
     const lines = readLastLines(path.join(logsDir, 'events.jsonl'), 50);

--- a/lib/routes/health.js
+++ b/lib/routes/health.js
@@ -1,16 +1,13 @@
 // routes/health.js — Serves health check data from health.jsonl
 // Registered when features.health is true
 
-const path = require('path');
-const { sendJSON, readLastLines } = require('../helpers');
+const { sendJSON, readLastLines, dataPath } = require('../helpers');
 
 function register(routes, config) {
   if (!config.features || !config.features.health) return;
 
-  const agentDir = config.agentDir || '.';
-
   routes['GET /api/health'] = (req, res) => {
-    const lines = readLastLines(path.join(agentDir, 'logs', 'health.jsonl'), 50);
+    const lines = readLastLines(dataPath(config, 'logs', 'health.jsonl'), 50);
     const entries = [];
     for (const line of lines) {
       try { entries.push(JSON.parse(line)); } catch {}

--- a/lib/routes/journal.js
+++ b/lib/routes/journal.js
@@ -2,12 +2,12 @@
 
 const fs = require('fs');
 const path = require('path');
-const { sendJSON, readBody, getAllJournalEntries, editJournalEntry } = require('../helpers');
+const { sendJSON, readBody, getAllJournalEntries, editJournalEntry, dataPath } = require('../helpers');
 
 const VALID_TAGS = ['output', 'feedback', 'outcome', 'observation', 'note', 'direction', 'question'];
 
 function register(routes, config) {
-  const journalsDir = path.join(config.agentDir, 'journals');
+  const journalsDir = dataPath(config, 'journals');
 
   routes['GET /api/journal'] = (req, res) => {
     const url = new URL(req.url, 'http://localhost');

--- a/lib/routes/library.js
+++ b/lib/routes/library.js
@@ -4,11 +4,9 @@
 const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
-const { sendJSON, readBody } = require('../helpers');
+const { sendJSON, readBody, dataPath, getDataDir } = require('../helpers');
 
-function getLibraryItems(agentDir, dataDir) {
-  const itemsDir = path.join(agentDir, dataDir);
-  const feedbackDir = path.join(agentDir, 'input', 'feedback');
+function getLibraryItems(itemsDir, feedbackDir) {
   try {
     const files = fs.readdirSync(itemsDir)
       .filter(f => f.endsWith('.yaml') || f.endsWith('.yml'));
@@ -62,13 +60,16 @@ function register(routes, config) {
   const libraryConfig = config.features && config.features.library;
   if (!libraryConfig) return;
 
-  const agentDir = config.agentDir || '.';
-  const dataDir = (typeof libraryConfig === 'object' && libraryConfig.dataDir) || 'content/items';
-  const feedbackDir = path.join(agentDir, 'input', 'feedback');
+  // features.library.dataDir is the path *under* the framework data root.
+  // With default top-level dataDir "." this resolves to <agentDir>/content/items
+  // exactly as before; with dataDir "data" it resolves to <agentDir>/data/content/items.
+  const libraryDataDir = (typeof libraryConfig === 'object' && libraryConfig.dataDir) || 'content/items';
+  const itemsDir = dataPath(config, libraryDataDir);
+  const feedbackDir = dataPath(config, 'input', 'feedback');
 
   // GET /api/library — list all content items with feedback status
   routes['GET /api/library'] = (req, res) => {
-    sendJSON(res, 200, getLibraryItems(agentDir, dataDir));
+    sendJSON(res, 200, getLibraryItems(itemsDir, feedbackDir));
   };
 
   // GET /api/library/:id — single item detail with full metadata
@@ -77,7 +78,6 @@ function register(routes, config) {
     if (id.includes('/') || id.includes('\\') || id.includes('..')) {
       return sendJSON(res, 400, { error: 'Invalid id' });
     }
-    const itemsDir = path.join(agentDir, dataDir);
     // Try both .yaml and .yml
     let filePath = path.join(itemsDir, id + '.yaml');
     if (!fs.existsSync(filePath)) {
@@ -148,7 +148,7 @@ function register(routes, config) {
 
   // GET /api/library/recent — items discovered in the last 24 hours
   routes['GET /api/library/recent'] = (req, res) => {
-    const items = getLibraryItems(agentDir, dataDir);
+    const items = getLibraryItems(itemsDir, feedbackDir);
     const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000);
     const recent = items.filter(item => {
       if (!item.discovered) return false;

--- a/lib/routes/media-files.js
+++ b/lib/routes/media-files.js
@@ -4,7 +4,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { sendJSON } = require('../helpers');
+const { sendJSON, dataPath } = require('../helpers');
 
 const MIME_TYPES = {
   // Books
@@ -41,10 +41,9 @@ const DOWNLOAD_TYPES = new Set(['.epub', '.cbz', '.cbr', '.pdf']);
 function register(routes, config) {
   if (!config.features || !config.features.library) return;
 
-  const agentDir = config.agentDir || '.';
   const libraryConfig = typeof config.features.library === 'object' ? config.features.library : {};
   const storagePaths = libraryConfig.storagePaths || {};
-  const defaultStorage = storagePaths.default || path.join(agentDir, 'media');
+  const defaultStorage = storagePaths.default || dataPath(config, 'media');
 
   function resolveStoragePath(category) {
     if (storagePaths[category]) return storagePaths[category];
@@ -138,7 +137,7 @@ function register(routes, config) {
       return sendJSON(res, 400, { error: 'Invalid id' });
     }
 
-    const coversDir = path.join(agentDir, 'media', 'covers');
+    const coversDir = dataPath(config, 'media', 'covers');
 
     // Try common image extensions
     const exts = ['.jpg', '.jpeg', '.png', '.webp'];

--- a/lib/routes/outputs.js
+++ b/lib/routes/outputs.js
@@ -3,11 +3,9 @@
 
 const fs = require('fs');
 const path = require('path');
-const { sendJSON, readBody } = require('../helpers');
+const { sendJSON, readBody, dataPath } = require('../helpers');
 
-function getOutputFiles(agentDir) {
-  const outputDir = path.join(agentDir, 'output');
-  const feedbackDir = path.join(agentDir, 'input', 'feedback');
+function getOutputFiles(outputDir, feedbackDir) {
   const processedDir = path.join(feedbackDir, 'processed');
   try {
     const files = fs.readdirSync(outputDir)
@@ -38,21 +36,20 @@ function getOutputFiles(agentDir) {
 }
 
 function register(routes, config) {
-  const agentDir = config.agentDir || '.';
-  const outputDir = path.join(agentDir, 'output');
-  const feedbackDir = path.join(agentDir, 'input', 'feedback');
+  const outputDir = dataPath(config, 'output');
+  const feedbackDir = dataPath(config, 'input', 'feedback');
 
   // --- Output routes (gated by features.outputs) ---
   if (config.features && config.features.outputs) {
     // GET /api/outputs — list all output files with review status
     routes['GET /api/outputs'] = (req, res) => {
-      sendJSON(res, 200, getOutputFiles(agentDir));
+      sendJSON(res, 200, getOutputFiles(outputDir, feedbackDir));
     };
 
     // GET /api/projects/:slug/outputs — per-project outputs
     routes['GET /api/projects/:slug/outputs'] = (req, res) => {
       const slug = req.params.slug;
-      const allOutputs = getOutputFiles(agentDir);
+      const allOutputs = getOutputFiles(outputDir, feedbackDir);
       const projectOutputs = allOutputs.filter(o => o.filename.startsWith(slug));
       sendJSON(res, 200, projectOutputs);
     };

--- a/lib/routes/preferences.js
+++ b/lib/routes/preferences.js
@@ -5,13 +5,12 @@
 const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
-const { sendJSON, readBody } = require('../helpers');
+const { sendJSON, readBody, dataPath } = require('../helpers');
 
 function register(routes, config) {
   if (!config.features || !config.features.library) return;
 
-  const agentDir = config.agentDir || '.';
-  const prefsFile = path.join(agentDir, 'memory', 'preferences.yaml');
+  const prefsFile = dataPath(config, 'memory', 'preferences.yaml');
 
   function readPrefs() {
     try {
@@ -134,7 +133,7 @@ function register(routes, config) {
         return sendJSON(res, 400, { error: 'Context required' });
       }
 
-      const feedbackDir = path.join(agentDir, 'input', 'feedback');
+      const feedbackDir = dataPath(config, 'input', 'feedback');
       if (!fs.existsSync(feedbackDir)) fs.mkdirSync(feedbackDir, { recursive: true });
 
       const category = body.category.trim().toLowerCase().replace(/\s+/g, '-');

--- a/lib/routes/projects.js
+++ b/lib/routes/projects.js
@@ -3,11 +3,9 @@
 
 const fs = require('fs');
 const path = require('path');
-const { sendJSON, readBody, parseJournal, parseFrontmatter, editJournalEntry } = require('../helpers');
+const { sendJSON, readBody, parseJournal, parseFrontmatter, editJournalEntry, dataPath } = require('../helpers');
 
-function getOutputFiles(agentDir) {
-  const outputDir = path.join(agentDir, 'output');
-  const feedbackDir = path.join(agentDir, 'input', 'feedback');
+function getOutputFiles(outputDir, feedbackDir) {
   const processedDir = path.join(feedbackDir, 'processed');
   try {
     const files = fs.readdirSync(outputDir)
@@ -24,13 +22,13 @@ function getOutputFiles(agentDir) {
   }
 }
 
-function getProjects(agentDir, journalsDir, projectsDir) {
+function getProjects(outputDir, feedbackDir, journalsDir, projectsDir) {
   try {
     const files = fs.readdirSync(projectsDir)
       .filter(f => f.endsWith('.md') && !f.startsWith('_'));
 
     const priorityOrder = { high: 0, medium: 1, low: 2 };
-    const allOutputs = getOutputFiles(agentDir);
+    const allOutputs = getOutputFiles(outputDir, feedbackDir);
 
     return files.map(f => {
       const slug = f.replace('.md', '');
@@ -80,13 +78,14 @@ function getProjects(agentDir, journalsDir, projectsDir) {
 function register(routes, config) {
   if (!config.sidebar || config.sidebar.type !== 'projects') return;
 
-  const agentDir = config.agentDir || '.';
-  const journalsDir = path.join(agentDir, 'journals');
-  const projectsDir = path.join(agentDir, config.sidebar.projectsDir || 'projects');
+  const journalsDir = dataPath(config, 'journals');
+  const projectsDir = dataPath(config, config.sidebar.projectsDir || 'projects');
+  const outputDir = dataPath(config, 'output');
+  const feedbackDir = dataPath(config, 'input', 'feedback');
 
   // GET /api/projects — list all projects with metadata
   routes['GET /api/projects'] = (req, res) => {
-    sendJSON(res, 200, getProjects(agentDir, journalsDir, projectsDir));
+    sendJSON(res, 200, getProjects(outputDir, feedbackDir, journalsDir, projectsDir));
   };
 
   // GET /api/projects/:slug/journal — per-project journal entries

--- a/lib/routes/rated-items.js
+++ b/lib/routes/rated-items.js
@@ -5,13 +5,12 @@
 const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
-const { sendJSON, readBody } = require('../helpers');
+const { sendJSON, readBody, dataPath } = require('../helpers');
 
 function register(routes, config) {
   if (!config.features || !config.features.library) return;
 
-  const agentDir = config.agentDir || '.';
-  const file = path.join(agentDir, 'memory', 'rated-items.yaml');
+  const file = dataPath(config, 'memory', 'rated-items.yaml');
 
   function read() {
     try {

--- a/lib/routes/requests.js
+++ b/lib/routes/requests.js
@@ -5,13 +5,13 @@
 
 const fs = require('fs');
 const path = require('path');
-const { sendJSON, readBody } = require('../helpers');
+const { sendJSON, readBody, dataPath } = require('../helpers');
 
 function register(routes, config) {
   if (!config.features || !config.features.requests) return;
 
-  const agentDir = config.agentDir || '.';
-  const requestsDir = path.join(agentDir, 'requests');
+  const requestsDir = dataPath(config, 'requests');
+  const journalsDir = dataPath(config, 'journals');
 
   routes['GET /api/requests'] = (req, res) => {
     const requests = [];
@@ -77,7 +77,6 @@ function register(routes, config) {
     const yyyy = now.getFullYear();
     const mm = String(now.getMonth() + 1).padStart(2, '0');
     const filename = `${yyyy}-${mm}.md`;
-    const journalsDir = path.join(agentDir, 'journals');
     const journalPath = path.join(journalsDir, filename);
     const journalText = 'Re: ' + title + '\n\n' + comment;
     const entry = `\n### ${ts} | rob | direction\n${journalText}\n`;

--- a/lib/routes/sources.js
+++ b/lib/routes/sources.js
@@ -4,13 +4,13 @@
 const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
-const { sendJSON, readBody } = require('../helpers');
+const { sendJSON, readBody, dataPath } = require('../helpers');
 
 function register(routes, config) {
   if (!config.features || !config.features.library) return;
 
-  const agentDir = config.agentDir || '.';
-  const sourcesFile = path.join(agentDir, 'config', 'sources.yaml');
+  const sourcesFile = dataPath(config, 'config', 'sources.yaml');
+  const credDir = dataPath(config, 'config', 'credentials');
 
   function readSources() {
     try {
@@ -32,7 +32,6 @@ function register(routes, config) {
   routes['GET /api/sources'] = (req, res) => {
     const sources = readSources();
     // Check credentials existence for each source
-    const credDir = path.join(agentDir, 'config', 'credentials');
     const result = sources.map(s => ({
       ...s,
       hasCredentials: fs.existsSync(path.join(credDir, (s.id || '') + '.yaml')),

--- a/lib/routes/status.js
+++ b/lib/routes/status.js
@@ -3,12 +3,13 @@
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
-const { sendJSON } = require('../helpers');
+const { sendJSON, dataPath } = require('../helpers');
 const { getNextRun, isCycleLocked } = require('../cron');
 
 function register(routes, config) {
   const agentDir = config.agentDir;
-  const logsDir = path.join(agentDir, 'logs');
+  // logs/ moves with dataDir; today.md and git ops stay at agentDir (operator-owned)
+  const logsDir = dataPath(config, 'logs');
 
   routes['GET /api/status'] = (req, res) => {
     const status = {};

--- a/lib/routes/todos.js
+++ b/lib/routes/todos.js
@@ -4,7 +4,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { sendJSON, readBody } = require('../helpers');
+const { sendJSON, readBody, dataPath } = require('../helpers');
 
 /**
  * Parse human_todos.md into structured data.
@@ -97,8 +97,7 @@ function serializeTodos(todos, notes) {
 function register(routes, config) {
   if (!config.features || !config.features.tabs || !config.features.tabs.includes('todos')) return;
 
-  const agentDir = config.agentDir || '.';
-  const todosFile = path.join(agentDir, 'human_todos.md');
+  const todosFile = dataPath(config, 'human_todos.md');
 
   function readTodosFile() {
     try {

--- a/lib/routes/tts.js
+++ b/lib/routes/tts.js
@@ -4,7 +4,7 @@
 const fs = require('fs');
 const path = require('path');
 const https = require('https');
-const { sendJSON } = require('../helpers');
+const { sendJSON, dataPath } = require('../helpers');
 
 /**
  * Strip markdown formatting to produce plain text suitable for TTS narration.
@@ -96,8 +96,7 @@ function register(routes, config) {
   const apiKey = process.env.GOOGLE_TTS_API_KEY;
   if (!apiKey) return; // Feature disabled if key absent
 
-  const agentDir = config.agentDir || '.';
-  const outputDir = path.join(agentDir, 'output');
+  const outputDir = dataPath(config, 'output');
 
   // GET /api/tts/status — check if TTS is available
   routes['GET /api/tts/status'] = (req, res) => {

--- a/lib/routes/uploads.js
+++ b/lib/routes/uploads.js
@@ -1,9 +1,9 @@
 // uploads.js — File upload and serving routes
-// Stores uploaded files in {agentDir}/uploads/ for attachment to journal entries, replies, etc.
+// Stores uploaded files in <dataDir>/uploads/ for attachment to journal entries, replies, etc.
 
 const fs = require('fs');
 const path = require('path');
-const { sendJSON, readBody } = require('../helpers');
+const { sendJSON, readBody, dataPath } = require('../helpers');
 
 const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
 
@@ -19,10 +19,9 @@ const MIME_TYPES = {
 };
 
 function register(routes, config) {
-  const agentDir = config.agentDir;
-  if (!agentDir) return;
+  if (!config.agentDir) return;
 
-  const uploadsDir = path.join(agentDir, 'uploads');
+  const uploadsDir = dataPath(config, 'uploads');
   if (!fs.existsSync(uploadsDir)) {
     fs.mkdirSync(uploadsDir, { recursive: true });
   }

--- a/test/data-dir-routes.test.js
+++ b/test/data-dir-routes.test.js
@@ -1,0 +1,346 @@
+// data-dir-routes.test.js — End-to-end coverage that every route module reads/writes
+// from <agentDir>/<dataDir>/ when dataDir is set to "data". Fixtures are copied
+// into a tmpdir under data/ so the legacy fixture tree at test/fixtures/ stays
+// canonical for the existing default-mode tests.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const http = require('http');
+const { createServer } = require('../lib/server');
+const { buildHTML } = require('../lib/ui');
+
+const FIXTURES = path.join(__dirname, 'fixtures');
+
+// Subdirs that conceptually live under dataDir. Operator files (today.md,
+// roadmap.md, minimal.json) stay at agentDir root.
+const DATA_SUBDIRS = ['memory', 'config', 'input', 'output', 'content', 'uploads', 'requests', 'journals', 'logs', 'projects'];
+const ROOT_FILES = ['today.md'];
+
+function copyDirSync(src, dest) {
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const s = path.join(src, entry.name);
+    const d = path.join(dest, entry.name);
+    if (entry.isDirectory()) copyDirSync(s, d);
+    else fs.copyFileSync(s, d);
+  }
+}
+
+function buildDataDirAgent() {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'data-dir-routes-'));
+  const agentDir = path.join(tmpRoot, 'agent');
+  const dataDir = path.join(agentDir, 'data');
+  fs.mkdirSync(dataDir, { recursive: true });
+
+  // Move conceptually-data subdirs into agentDir/data/
+  for (const sub of DATA_SUBDIRS) {
+    const fixSub = path.join(FIXTURES, sub);
+    if (fs.existsSync(fixSub)) copyDirSync(fixSub, path.join(dataDir, sub));
+  }
+  // Keep operator-owned root files at agentDir
+  for (const f of ROOT_FILES) {
+    const fixF = path.join(FIXTURES, f);
+    if (fs.existsSync(fixF)) fs.copyFileSync(fixF, path.join(agentDir, f));
+  }
+  return { tmpRoot, agentDir };
+}
+
+function bootPortal(agentDir, extraConfig = {}) {
+  const config = {
+    name: 'DataDirRoutesTest',
+    port: 0,
+    agentDir,
+    dataDir: 'data',
+    cronFile: '/nonexistent/cron',
+    lockFile: '/tmp/test-data-dir-routes.lock',
+    _serverStartTime: Date.now(),
+    authors: { rob: { color: '#000', bg: '#fff' } },
+    features: {
+      outputs: true,
+      feedback: true,
+      requests: true,
+      health: true,
+      library: { dataDir: 'content/items' },
+      tabs: ['library', 'preferences', 'sources', 'todos', 'outputs', 'requests'],
+    },
+    sidebar: { type: 'projects', projectsDir: 'projects' },
+    ...extraConfig,
+  };
+
+  const routes = {};
+  require('../lib/routes/status').register(routes, config);
+  require('../lib/routes/journal').register(routes, config);
+  require('../lib/routes/events').register(routes, config);
+  require('../lib/routes/health').register(routes, config);
+  require('../lib/routes/requests').register(routes, config);
+  require('../lib/routes/projects').register(routes, config);
+  require('../lib/routes/outputs').register(routes, config);
+  require('../lib/routes/uploads').register(routes, config);
+  require('../lib/routes/todos').register(routes, config);
+  require('../lib/routes/library').register(routes, config);
+  require('../lib/routes/sources').register(routes, config);
+  require('../lib/routes/preferences').register(routes, config);
+  require('../lib/routes/rated-items').register(routes, config);
+  require('../lib/routes/badges').register(routes, config);
+  require('../lib/routes/media-files').register(routes, config);
+  require('../lib/routes/tts').register(routes, config);
+
+  const getHTML = () => buildHTML(config);
+  const server = createServer(config, { routes, getHTML });
+  return new Promise(resolve => {
+    server.listen(0, () => {
+      const port = server.address().port;
+      resolve({ server, port, config });
+    });
+  });
+}
+
+function get(port, urlPath) {
+  return new Promise((resolve, reject) => {
+    http.get(`http://localhost:${port}${urlPath}`, res => {
+      let body = '';
+      res.on('data', c => { body += c; });
+      res.on('end', () => resolve({ status: res.statusCode, body, headers: res.headers }));
+    }).on('error', reject);
+  });
+}
+
+function postJSON(port, urlPath, payload) {
+  const body = JSON.stringify(payload);
+  return new Promise((resolve, reject) => {
+    const req = http.request({
+      hostname: 'localhost', port, path: urlPath, method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) },
+    }, res => {
+      let buf = '';
+      res.on('data', c => { buf += c; });
+      res.on('end', () => resolve({ status: res.statusCode, body: buf }));
+    });
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+describe('routes honor dataDir="data" — every handler reads/writes under <agentDir>/data/', () => {
+  let tmpRoot, agentDir, server, port;
+
+  before(async () => {
+    ({ tmpRoot, agentDir } = buildDataDirAgent());
+    ({ server, port } = await bootPortal(agentDir));
+  });
+
+  after(() => {
+    if (server) server.close();
+    if (tmpRoot) fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('GET /api/journal reads from data/journals/', async () => {
+    const res = await get(port, '/api/journal');
+    assert.equal(res.status, 200);
+    const data = JSON.parse(res.body);
+    assert.ok(Array.isArray(data.entries), 'entries should be array');
+    assert.ok(data.entries.length > 0, 'fixture journals should yield entries');
+  });
+
+  it('POST /api/journal writes into data/journals/', async () => {
+    const res = await postJSON(port, '/api/journal', { text: 'route test entry', tag: 'note' });
+    assert.equal(res.status, 200);
+    // Find the monthly file under data/journals
+    const journalsDir = path.join(agentDir, 'data', 'journals');
+    const files = fs.readdirSync(journalsDir).filter(f => /^\d{4}-\d{2}\.md$/.test(f));
+    assert.ok(files.length > 0, 'should have a monthly journal file');
+    // Verify the entry landed in *some* monthly journal under data/, NOT at root
+    const allContent = files.map(f => fs.readFileSync(path.join(journalsDir, f), 'utf-8')).join('\n');
+    assert.match(allContent, /route test entry/);
+    assert.ok(!fs.existsSync(path.join(agentDir, 'journals')), 'no root-level journals/');
+  });
+
+  it('GET /api/library reads from data/content/items/', async () => {
+    const res = await get(port, '/api/library');
+    assert.equal(res.status, 200);
+    const items = JSON.parse(res.body);
+    assert.ok(Array.isArray(items));
+    assert.ok(items.length > 0, 'fixture library has items');
+  });
+
+  it('GET /api/preferences reads from data/memory/preferences.yaml', async () => {
+    const res = await get(port, '/api/preferences');
+    assert.equal(res.status, 200);
+    const prefs = JSON.parse(res.body);
+    assert.ok(typeof prefs === 'object');
+  });
+
+  it('POST /api/preferences writes into data/memory/preferences.yaml', async () => {
+    const res = await postJSON(port, '/api/preferences', {
+      category: 'comics', section: 'likes', text: 'route-test marker',
+    });
+    assert.equal(res.status, 200);
+    const yamlContent = fs.readFileSync(path.join(agentDir, 'data', 'memory', 'preferences.yaml'), 'utf-8');
+    assert.match(yamlContent, /route-test marker/);
+  });
+
+  it('GET /api/rated-items reads from data/memory/rated-items.yaml (empty array if absent)', async () => {
+    const res = await get(port, '/api/rated-items');
+    assert.equal(res.status, 200);
+    const items = JSON.parse(res.body);
+    assert.ok(Array.isArray(items), 'response should be a list');
+  });
+
+  it('POST /api/rated-items writes into data/memory/rated-items.yaml', async () => {
+    const res = await postJSON(port, '/api/rated-items', {
+      category: 'comics', title: 'Test Title', description: 'desc', rating: 'up',
+    });
+    assert.equal(res.status, 200);
+    const filePath = path.join(agentDir, 'data', 'memory', 'rated-items.yaml');
+    assert.ok(fs.existsSync(filePath), 'rated-items.yaml should be created under data/');
+    assert.ok(!fs.existsSync(path.join(agentDir, 'memory', 'rated-items.yaml')), 'no root-level memory/');
+  });
+
+  it('GET /api/sources reads from data/config/sources.yaml', async () => {
+    const res = await get(port, '/api/sources');
+    assert.equal(res.status, 200);
+    const sources = JSON.parse(res.body);
+    assert.ok(Array.isArray(sources));
+  });
+
+  it('GET /api/outputs reads from data/output/', async () => {
+    const res = await get(port, '/api/outputs');
+    assert.equal(res.status, 200);
+    const items = JSON.parse(res.body);
+    assert.ok(Array.isArray(items));
+    assert.ok(items.length > 0, 'fixture outputs should be present');
+  });
+
+  it('POST /api/feedback writes into data/input/feedback/', async () => {
+    const res = await postJSON(port, '/api/feedback/alpha-feature-api-endpoints.md', { rating: 2, notes: 'route test' });
+    assert.equal(res.status, 200);
+    const fb = path.join(agentDir, 'data', 'input', 'feedback', 'alpha-feature-api-endpoints.feedback.yaml');
+    assert.ok(fs.existsSync(fb), 'feedback file should exist under data/');
+  });
+
+  it('GET /api/projects reads from data/projects/ and data/journals/', async () => {
+    const res = await get(port, '/api/projects');
+    assert.equal(res.status, 200);
+    const items = JSON.parse(res.body);
+    assert.ok(Array.isArray(items));
+    assert.ok(items.length > 0, 'fixture projects should be present');
+  });
+
+  it('GET /api/requests reads from data/requests/', async () => {
+    const res = await get(port, '/api/requests');
+    assert.equal(res.status, 200);
+    const data = JSON.parse(res.body);
+    assert.ok(Array.isArray(data.items));
+    assert.ok(data.items.length > 0, 'fixture requests should be present');
+  });
+
+  it('GET /api/badges reads from configured dataDir subdirs', async () => {
+    const res = await get(port, '/api/badges');
+    assert.equal(res.status, 200);
+    JSON.parse(res.body); // shape varies; just verify it parses without crashing
+  });
+
+  it('POST /api/upload writes into data/uploads/', async () => {
+    const pngBase64 = Buffer.from([0x89,0x50,0x4e,0x47,0x0d,0x0a,0x1a,0x0a]).toString('base64');
+    const res = await postJSON(port, '/api/upload', { filename: 'test.png', data: pngBase64 });
+    assert.equal(res.status, 200);
+    const uploadsDir = path.join(agentDir, 'data', 'uploads');
+    const files = fs.readdirSync(uploadsDir);
+    assert.ok(files.some(f => f.endsWith('_test.png')), 'upload landed in data/uploads/');
+    assert.ok(!fs.existsSync(path.join(agentDir, 'uploads')), 'no root-level uploads/');
+  });
+
+  it('POST /api/feedback/library/:id writes to data/input/feedback/', async () => {
+    const res = await postJSON(port, '/api/feedback/library/dark-matter-crouch', { rating: 'up' });
+    assert.equal(res.status, 200);
+    const fb = path.join(agentDir, 'data', 'input', 'feedback', 'dark-matter-crouch.feedback.yaml');
+    assert.ok(fs.existsSync(fb));
+  });
+
+  it('GET /api/today still reads agentDir root (operator-owned, not under dataDir)', async () => {
+    const res = await get(port, '/api/today');
+    assert.equal(res.status, 200);
+    const data = JSON.parse(res.body);
+    // today.md was placed at agentDir root by buildDataDirAgent, not under data/
+    assert.ok(data.content && !data.content.startsWith('*No today.md'), 'today.md should be read from agentDir root');
+  });
+
+  it('GET /api/status reads logs from data/logs/ but git ops from agentDir', async () => {
+    const res = await get(port, '/api/status');
+    assert.equal(res.status, 200);
+    const status = JSON.parse(res.body);
+    assert.ok(status.services && status.services['portal-server'].alive);
+  });
+
+  it('GET /api/events handles missing data/logs/events.jsonl gracefully', async () => {
+    const res = await get(port, '/api/events');
+    assert.equal(res.status, 200);
+    assert.ok(Array.isArray(JSON.parse(res.body)));
+  });
+
+  it('GET /api/health reads from data/logs/health.jsonl', async () => {
+    const res = await get(port, '/api/health');
+    assert.equal(res.status, 200);
+    assert.ok(Array.isArray(JSON.parse(res.body)));
+  });
+});
+
+describe('regression: routes still work with default dataDir (legacy layout)', () => {
+  let server, port;
+
+  before(async () => {
+    // Boot directly against fixtures/ with no dataDir — should behave exactly as before
+    const routes = {};
+    const config = {
+      name: 'LegacyTest', port: 0,
+      agentDir: FIXTURES,
+      cronFile: '/nonexistent/cron',
+      lockFile: '/tmp/test-data-dir-legacy.lock',
+      _serverStartTime: Date.now(),
+      authors: { rob: { color: '#000', bg: '#fff' } },
+      features: {
+        outputs: true, feedback: true, requests: true, health: true,
+        library: { dataDir: 'content/items' },
+        tabs: ['library', 'preferences', 'sources', 'outputs', 'requests'],
+      },
+      sidebar: { type: 'projects', projectsDir: 'projects' },
+    };
+    require('../lib/routes/journal').register(routes, config);
+    require('../lib/routes/library').register(routes, config);
+    require('../lib/routes/preferences').register(routes, config);
+    require('../lib/routes/sources').register(routes, config);
+    require('../lib/routes/projects').register(routes, config);
+    require('../lib/routes/requests').register(routes, config);
+    require('../lib/routes/outputs').register(routes, config);
+    require('../lib/routes/status').register(routes, config);
+    require('../lib/routes/events').register(routes, config);
+    const getHTML = () => buildHTML(config);
+    server = createServer(config, { routes, getHTML });
+    await new Promise(resolve => server.listen(0, () => { port = server.address().port; resolve(); }));
+  });
+
+  after(() => { if (server) server.close(); });
+
+  it('GET /api/journal returns fixture entries (legacy path)', async () => {
+    const res = await get(port, '/api/journal');
+    assert.equal(res.status, 200);
+    const data = JSON.parse(res.body);
+    assert.ok(data.entries.length > 0);
+  });
+
+  it('GET /api/library returns fixture items (legacy path)', async () => {
+    const res = await get(port, '/api/library');
+    assert.equal(res.status, 200);
+    assert.ok(JSON.parse(res.body).length > 0);
+  });
+
+  it('GET /api/sources returns fixture sources (legacy path)', async () => {
+    const res = await get(port, '/api/sources');
+    assert.equal(res.status, 200);
+    assert.ok(Array.isArray(JSON.parse(res.body)));
+  });
+});


### PR DESCRIPTION
## Summary

Migrates all 16 portal route handlers to use the `dataPath(config, ...)` helper introduced in #234. With default `dataDir: "."` every existing agent behaves identically — no config changes required. With `dataDir: "data"` every framework-managed write lands under `<agentDir>/data/`.

Builds on #234.

## Routes touched

- `events.js`, `journal.js` — logs/, journals/
- `preferences.js`, `rated-items.js` — memory/, input/feedback/
- `library.js` — features.library.dataDir (now under top-level data dir), input/feedback/
- `sources.js` — config/sources.yaml, config/credentials/
- `uploads.js` — uploads/
- `outputs.js`, `badges.js`, `projects.js`, `tts.js` — output/, input/feedback/
- `requests.js` — requests/, journals/
- `todos.js`, `badges.js` — human_todos.md
- `health.js` — logs/health.jsonl
- `media-files.js` — media/, media/covers/
- `status.js` — logs/ only (today.md and git ops stay at agentDir root, operator-owned)

## Untouched (operator-owned paths at agentDir root)

- `roadmap.js`, `capabilities.js`, `cycle.js`, `deploy.js`, `github.js`, `harness.js`, `onboarding.js`

## `features.library.dataDir` semantics

Now resolved relative to `<agentDir>/<top-level dataDir>`. With default top-level dataDir `"."` the absolute resolution is unchanged. With `dataDir: "data"` the library's `content/items` becomes `data/content/items` automatically without touching that field.

## Test plan

- [x] `npm test` — 419/419 node tests pass (+22 new dataDir route coverage), all shell tests pass
- [x] Layer 2 smoke test: bool a real portal with `dataDir: "data"`, hit `/api/journal /api/library /api/preferences /api/sources /api/outputs` (all 200), POST `/api/journal`, verify write lands at `data/journals/YYYY-MM.md` with no leakage to agentDir root
- [x] Regression tests confirm default-mode behavior is identical