### PR TITLE
feat(scripts): shell + Python scripts honor DATA_DIR

### DIFF
--- a/scripts/clear-done-todos.sh
+++ b/scripts/clear-done-todos.sh
@@ -3,9 +3,17 @@
 # Usage: clear-done-todos.sh <agent-dir>
 # Run at end of cycle (post-cycle hook) to clear completed todos.
 # Only acts if human_todos.md exists and has checked items.
+# Respects portal.config.json's dataDir (default ".").
 
 AGENT_DIR="${1:-.}"
-TODOS_FILE="$AGENT_DIR/human_todos.md"
+FRAMEWORK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+if [ -z "$DATA_DIR" ] && [ -f "$AGENT_DIR/portal.config.json" ]; then
+  eval "$(bash "$FRAMEWORK_DIR/scripts/read-harness-config.sh" "$AGENT_DIR" 2>/dev/null | grep '^export DATA_DIR=')"
+fi
+DATA_DIR="${DATA_DIR:-.}"
+
+TODOS_FILE="$AGENT_DIR/$DATA_DIR/human_todos.md"
 
 if [ ! -f "$TODOS_FILE" ]; then
   exit 0

--- a/scripts/consolidate-memory.sh
+++ b/scripts/consolidate-memory.sh
@@ -20,13 +20,19 @@ FRAMEWORK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 AGENT_DIR="${1:?Usage: consolidate-memory.sh <agent-dir> [--force]}"
 FORCE="${2:-}"
 
+# Resolve DATA_DIR from portal.config.json (defaults to ".")
+if [ -z "$DATA_DIR" ] && [ -f "$AGENT_DIR/portal.config.json" ]; then
+  eval "$(bash "$FRAMEWORK_DIR/scripts/read-harness-config.sh" "$AGENT_DIR" 2>/dev/null | grep '^export DATA_DIR=')"
+fi
+DATA_DIR="${DATA_DIR:-.}"
+
 # ── PATHS ──
 
-CONFIG_FILE="$AGENT_DIR/memory/config.yaml"
-INSIGHTS_FILE="$AGENT_DIR/memory/consolidated-insights.yaml"
-OPERATIONAL_FILE="$AGENT_DIR/memory/operational.yaml"
-EVENTS_FILE="$AGENT_DIR/logs/events.jsonl"
-JOURNALS_DIR="$AGENT_DIR/journals"
+CONFIG_FILE="$AGENT_DIR/$DATA_DIR/memory/config.yaml"
+INSIGHTS_FILE="$AGENT_DIR/$DATA_DIR/memory/consolidated-insights.yaml"
+OPERATIONAL_FILE="$AGENT_DIR/$DATA_DIR/memory/operational.yaml"
+EVENTS_FILE="$AGENT_DIR/$DATA_DIR/logs/events.jsonl"
+JOURNALS_DIR="$AGENT_DIR/$DATA_DIR/journals"
 
 # ── CONFIG ──
 

--- a/scripts/cron-setup.sh
+++ b/scripts/cron-setup.sh
@@ -14,13 +14,19 @@ cd "$AGENT_DIR"
 # Read agent config
 eval "$(node "$FRAMEWORK_DIR/scripts/read-config.js" "$AGENT_DIR/agent.yaml")"
 
+# Resolve DATA_DIR from portal.config.json (defaults to ".")
+if [ -z "$DATA_DIR" ] && [ -f "$AGENT_DIR/portal.config.json" ]; then
+  eval "$(bash "$FRAMEWORK_DIR/scripts/read-harness-config.sh" "$AGENT_DIR" 2>/dev/null | grep '^export DATA_DIR=')"
+fi
+DATA_DIR="${DATA_DIR:-.}"
+
 # Environment sourcing prefix for cron jobs:
 # - Sandcat profile scripts (env vars + NODE_EXTRA_CA_CERTS)
 # - nvm so claude/node are on PATH
 CRON_ENV='for f in /etc/profile.d/sandcat-*.sh; do [ -r "$f" ] && . "$f"; done; export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" &&'
 
-# Main wake entry from agent.yaml
-WAKE_LINE="${AGENT_CRON_SCHEDULE} root ${CRON_ENV} cd ${AGENT_DIR} && bash ${FRAMEWORK_DIR}/scripts/wake.sh ${AGENT_DIR} >> logs/cycles/cron-wake.log 2>&1"
+# Main wake entry from agent.yaml — cron-wake.log lives under <DATA_DIR>/logs/cycles
+WAKE_LINE="${AGENT_CRON_SCHEDULE} root ${CRON_ENV} cd ${AGENT_DIR} && bash ${FRAMEWORK_DIR}/scripts/wake.sh ${AGENT_DIR} >> ${DATA_DIR}/logs/cycles/cron-wake.log 2>&1"
 
 # Build all cron lines
 CRON_LINES="$WAKE_LINE"

--- a/scripts/log-event.sh
+++ b/scripts/log-event.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # scripts/log-event.sh — Append a JSON event to the agent's events.jsonl
 # Usage: log-event.sh <agent-dir> <type> <summary> [project]
+#
+# Respects portal.config.json's dataDir field (default "."). Writes to
+# <agent-dir>/<DATA_DIR>/logs/events.jsonl.
 set -e
 
 AGENT_DIR="$1"
@@ -13,9 +16,16 @@ if [ -z "$AGENT_DIR" ] || [ -z "$TYPE" ] || [ -z "$SUMMARY" ]; then
   exit 1
 fi
 
+# Resolve DATA_DIR from portal.config.json (defaults to ".")
+FRAMEWORK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+if [ -z "$DATA_DIR" ] && [ -f "$AGENT_DIR/portal.config.json" ]; then
+  eval "$(bash "$FRAMEWORK_DIR/scripts/read-harness-config.sh" "$AGENT_DIR" 2>/dev/null | grep '^export DATA_DIR=')"
+fi
+DATA_DIR="${DATA_DIR:-.}"
+
 ENTRY="{\"ts\":\"$(date -Iseconds)\",\"type\":\"$TYPE\",\"summary\":\"$SUMMARY\""
 [ -n "$PROJECT" ] && ENTRY="$ENTRY,\"project\":\"$PROJECT\""
 ENTRY="$ENTRY}"
 
-mkdir -p "$AGENT_DIR/logs"
-echo "$ENTRY" >> "$AGENT_DIR/logs/events.jsonl"
+mkdir -p "$AGENT_DIR/$DATA_DIR/logs"
+echo "$ENTRY" >> "$AGENT_DIR/$DATA_DIR/logs/events.jsonl"

--- a/scripts/log-journal.sh
+++ b/scripts/log-journal.sh
@@ -2,7 +2,9 @@
 # scripts/log-journal.sh — Append a timestamped journal entry
 # Usage: log-journal.sh <agent-dir> <journal-file> <author> <tag> <content>
 #
-# journal-file is relative to agent-dir/journals/ (e.g., "bobbo.md" or "ai-research.md")
+# journal-file is relative to <agent-dir>/<DATA_DIR>/journals/
+# (e.g., "bobbo.md" or "ai-research.md"). DATA_DIR resolves from
+# portal.config.json's dataDir field (default ".").
 set -e
 
 AGENT_DIR="$1"
@@ -19,7 +21,14 @@ if [ -z "$AGENT_DIR" ] || [ -z "$JOURNAL_FILE" ] || [ -z "$AUTHOR" ] || [ -z "$T
   exit 1
 fi
 
-JOURNAL_PATH="$AGENT_DIR/journals/$JOURNAL_FILE"
+# Resolve DATA_DIR from portal.config.json (defaults to ".")
+FRAMEWORK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+if [ -z "$DATA_DIR" ] && [ -f "$AGENT_DIR/portal.config.json" ]; then
+  eval "$(bash "$FRAMEWORK_DIR/scripts/read-harness-config.sh" "$AGENT_DIR" 2>/dev/null | grep '^export DATA_DIR=')"
+fi
+DATA_DIR="${DATA_DIR:-.}"
+
+JOURNAL_PATH="$AGENT_DIR/$DATA_DIR/journals/$JOURNAL_FILE"
 mkdir -p "$(dirname "$JOURNAL_PATH")"
 
 {

--- a/scripts/memory-index.py
+++ b/scripts/memory-index.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python3
 """Index journal entries and events into SQLite for semantic search.
 
-Usage: memory-venv/bin/python scripts/memory-index.py /path/to/agent-dir
+Usage: memory-venv/bin/python scripts/memory-index.py /path/to/agent-dir [--data-dir DATA_DIR]
 
 Parses journal markdown files and events.jsonl, generates embeddings via
 fastembed (nomic-embed-text-v1.5), and stores in SQLite with FTS5 for
 keyword search and numpy-based vector similarity. Incremental: only
 indexes new entries since last run.
+
+--data-dir defaults to "." (legacy layout — journals/, logs/, memory/ at
+agent-dir root). Set to "data" for the dataDir layout where they live
+under <agent-dir>/data/. The DATA_DIR environment variable is honored
+when --data-dir is absent (matches what read-harness-config.sh exports).
 """
 
 import json
@@ -173,13 +178,24 @@ def set_last_indexed(conn: sqlite3.Connection, key: str, value: str):
 
 def main():
     if len(sys.argv) < 2:
-        print("Usage: memory-index.py /path/to/agent-dir", file=sys.stderr)
+        print("Usage: memory-index.py /path/to/agent-dir [--data-dir DATA_DIR]", file=sys.stderr)
         sys.exit(1)
 
     agent_dir = Path(sys.argv[1])
-    journal_dir = agent_dir / "journals"
-    events_path = agent_dir / "logs" / "events.jsonl"
-    memory_dir = agent_dir / "memory"
+
+    # Resolve data-dir (CLI flag wins; else $DATA_DIR; else ".")
+    data_dir = "."
+    if "--data-dir" in sys.argv:
+        idx = sys.argv.index("--data-dir")
+        if idx + 1 < len(sys.argv):
+            data_dir = sys.argv[idx + 1]
+    else:
+        data_dir = os.environ.get("DATA_DIR", ".")
+
+    root = agent_dir / data_dir
+    journal_dir = root / "journals"
+    events_path = root / "logs" / "events.jsonl"
+    memory_dir = root / "memory"
     memory_dir.mkdir(exist_ok=True)
     db_path = memory_dir / "memory.db"
 

--- a/scripts/memory-search.py
+++ b/scripts/memory-search.py
@@ -154,12 +154,24 @@ def format_results(results: list[dict]) -> str:
 
 def main():
     if len(sys.argv) < 2:
-        print('Usage: memory-search.py "query text" [/path/to/agent-dir]', file=sys.stderr)
+        print('Usage: memory-search.py "query text" [/path/to/agent-dir] [--data-dir DATA_DIR]', file=sys.stderr)
         sys.exit(1)
 
     query = sys.argv[1]
-    agent_dir = Path(sys.argv[2]) if len(sys.argv) > 2 else Path.cwd()
-    db_path = agent_dir / "memory" / "memory.db"
+    # Positional agent_dir is the first non-flag arg after the query
+    args = sys.argv[2:]
+    agent_dir = Path(args[0]) if args and not args[0].startswith("--") else Path.cwd()
+
+    # Resolve data-dir (CLI flag wins; else $DATA_DIR; else ".")
+    data_dir = "."
+    if "--data-dir" in args:
+        idx = args.index("--data-dir")
+        if idx + 1 < len(args):
+            data_dir = args[idx + 1]
+    else:
+        data_dir = os.environ.get("DATA_DIR", ".")
+
+    db_path = agent_dir / data_dir / "memory" / "memory.db"
 
     if not db_path.exists():
         print(f"Memory database not found at {db_path}. Run memory-index.py first.", file=sys.stderr)

--- a/scripts/respond.sh
+++ b/scripts/respond.sh
@@ -22,7 +22,8 @@ fi
 # Read agent config
 eval "$(node "$FRAMEWORK_DIR/scripts/read-config.js" "$AGENT_DIR/agent.yaml")"
 
-# Read harness config from portal.config.json (defaults to claude-code)
+# Read harness + data dir config from portal.config.json
+# (defaults: harness=claude-code, DATA_DIR=".")
 eval "$(bash "$FRAMEWORK_DIR/scripts/read-harness-config.sh" "$AGENT_DIR")"
 
 # Mutex — prevent overlapping with a full cycle
@@ -35,8 +36,8 @@ fi
 rm -f "${AGENT_LOCK_FILE}.starting"
 
 CYCLE_TS="$(date +%Y%m%d-%H%M)"
-CYCLE_LOG="logs/cycles/${CYCLE_TS}-respond.log"
-mkdir -p logs/cycles
+CYCLE_LOG="$DATA_DIR/logs/cycles/${CYCLE_TS}-respond.log"
+mkdir -p "$DATA_DIR/logs/cycles"
 
 CYCLE_START_EPOCH=$(date +%s)
 
@@ -116,6 +117,6 @@ fi
 CYCLE_END_EPOCH=$(date +%s)
 CYCLE_DURATION_S=$((CYCLE_END_EPOCH - CYCLE_START_EPOCH))
 CYCLE_DURATION_M=$((CYCLE_DURATION_S / 60))
-echo "{\"ts\":\"$(date -Iseconds)\",\"type\":\"cycle_end\",\"summary\":\"Respond cycle complete\",\"duration_s\":${CYCLE_DURATION_S},\"duration_m\":${CYCLE_DURATION_M}}" >> "$AGENT_DIR/logs/events.jsonl"
+echo "{\"ts\":\"$(date -Iseconds)\",\"type\":\"cycle_end\",\"summary\":\"Respond cycle complete\",\"duration_s\":${CYCLE_DURATION_S},\"duration_m\":${CYCLE_DURATION_M}}" >> "$AGENT_DIR/$DATA_DIR/logs/events.jsonl"
 
 bash "$FRAMEWORK_DIR/scripts/commit.sh" "$AGENT_DIR" "respond cycle"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -19,8 +19,14 @@ fi
 # Read agent config
 eval "$(node "$FRAMEWORK_DIR/scripts/read-config.js" "$AGENT_DIR/agent.yaml")"
 
-LOG_FILE="logs/supervisor.log"
-mkdir -p logs
+# Resolve DATA_DIR from portal.config.json (defaults to ".")
+if [ -z "$DATA_DIR" ] && [ -f "$AGENT_DIR/portal.config.json" ]; then
+  eval "$(bash "$FRAMEWORK_DIR/scripts/read-harness-config.sh" "$AGENT_DIR" 2>/dev/null | grep '^export DATA_DIR=')"
+fi
+DATA_DIR="${DATA_DIR:-.}"
+
+LOG_FILE="$DATA_DIR/logs/supervisor.log"
+mkdir -p "$DATA_DIR/logs"
 
 log() {
   echo "$(date -Iseconds) [supervisor] $*" >> "$LOG_FILE"

--- a/scripts/telegram-respond.sh
+++ b/scripts/telegram-respond.sh
@@ -36,21 +36,22 @@ exec 200>"$AGENT_LOCK_FILE"
 flock -w 120 200 || { echo "Agent busy — cycle didn't complete in 2min"; exit 1; }
 
 # Ensure conversation log exists
-touch logs/conversation.jsonl
+mkdir -p "$DATA_DIR/logs"
+touch "$DATA_DIR/logs/conversation.jsonl"
 
 # Append human message to conversation buffer
-echo "{\"ts\":\"$(date -Iseconds)\",\"role\":\"human\",\"text\":$(echo "$MESSAGE" | jq -Rs .)}" >> logs/conversation.jsonl
+echo "{\"ts\":\"$(date -Iseconds)\",\"role\":\"human\",\"text\":$(echo "$MESSAGE" | jq -Rs .)}" >> $DATA_DIR/logs/conversation.jsonl
 
 # Build recent conversation context (last 20 messages)
-RECENT_CONVO=$(tail -20 logs/conversation.jsonl | jq -r '"[\(.role)] \(.text)"')
+RECENT_CONVO=$(tail -20 $DATA_DIR/logs/conversation.jsonl | jq -r '"[\(.role)] \(.text)"')
 
 # Log cycle start
 bash "$FRAMEWORK_DIR/scripts/log-event.sh" "$AGENT_DIR" responsive_cycle "Telegram message received"
 
 # Cycle logging (matching wake.sh pattern)
 CYCLE_TS="$(date +%Y%m%d-%H%M)"
-CYCLE_LOG="logs/cycles/${CYCLE_TS}-respond.log"
-mkdir -p logs/cycles
+CYCLE_LOG="$DATA_DIR/logs/cycles/${CYCLE_TS}-respond.log"
+mkdir -p "$DATA_DIR/logs/cycles"
 
 echo "Running $HARNESS_TYPE..."
 
@@ -84,10 +85,10 @@ set +e
 case "$HARNESS_TYPE" in
   claude-code)
     # Claude Code: explicit session management via --resume / --session-id
-    SESSION_FILE="logs/telegram_session_id"
+    SESSION_FILE="$DATA_DIR/logs/telegram_session_id"
     SESSION_ARGS=""
 
-    PREV_HUMAN_TS=$(grep '"role":"human"' logs/conversation.jsonl | tail -2 | head -1 | jq -r '.ts // ""')
+    PREV_HUMAN_TS=$(grep '"role":"human"' $DATA_DIR/logs/conversation.jsonl | tail -2 | head -1 | jq -r '.ts // ""')
     if [ -n "$PREV_HUMAN_TS" ] && [ -f "$SESSION_FILE" ]; then
       PREV_EPOCH=$(date -d "$PREV_HUMAN_TS" +%s 2>/dev/null || echo 0)
       NOW_EPOCH=$(date +%s)
@@ -110,7 +111,7 @@ case "$HARNESS_TYPE" in
       echo "$FULL_PROMPT" | claude --print --effort max \
         --allowedTools "Bash" "Edit" "Write" "Read" "Glob" "Grep" "WebSearch" "WebFetch" \
         "$@" \
-        2>>logs/respond_errors.log
+        2>>"$DATA_DIR/logs/respond_errors.log"
     }
 
     if echo "$SESSION_ARGS" | grep -q -- '--resume'; then
@@ -134,13 +135,13 @@ case "$HARNESS_TYPE" in
   letta-code)
     # Letta Code: persistent agent memory provides session continuity.
     # --name targets the right agent; each invocation auto-creates a fresh conversation.
-    RESPONSE=$(echo "$FULL_PROMPT" | $HARNESS_CMD $HARNESS_EXTRA_FLAGS 2>>logs/respond_errors.log)
+    RESPONSE=$(echo "$FULL_PROMPT" | $HARNESS_CMD $HARNESS_EXTRA_FLAGS 2>>"$DATA_DIR/logs/respond_errors.log")
     HARNESS_EXIT=$?
     ;;
 
   *)
     # Script or unknown harness: no session management
-    RESPONSE=$(echo "$FULL_PROMPT" | $HARNESS_CMD $HARNESS_EXTRA_FLAGS 2>>logs/respond_errors.log)
+    RESPONSE=$(echo "$FULL_PROMPT" | $HARNESS_CMD $HARNESS_EXTRA_FLAGS 2>>"$DATA_DIR/logs/respond_errors.log")
     HARNESS_EXIT=$?
     ;;
 esac
@@ -164,7 +165,7 @@ fi
 echo "Sending response..."
 
 # Dedup guard — skip if identical to the last agent message within 60 seconds
-LAST_AGENT_MSG=$(grep '"role":"agent"' logs/conversation.jsonl | tail -1)
+LAST_AGENT_MSG=$(grep '"role":"agent"' $DATA_DIR/logs/conversation.jsonl | tail -1)
 LAST_AGENT_TEXT=$(echo "$LAST_AGENT_MSG" | jq -r '.text // ""')
 LAST_AGENT_TS=$(echo "$LAST_AGENT_MSG" | jq -r '.ts // ""')
 
@@ -180,7 +181,7 @@ if [ "$RESPONSE" = "$LAST_AGENT_TEXT" ] && [ -n "$LAST_AGENT_TS" ]; then
 fi
 
 # Append agent response to conversation buffer
-echo "{\"ts\":\"$(date -Iseconds)\",\"role\":\"agent\",\"text\":$(echo "$RESPONSE" | jq -Rs .)}" >> logs/conversation.jsonl
+echo "{\"ts\":\"$(date -Iseconds)\",\"role\":\"agent\",\"text\":$(echo "$RESPONSE" | jq -Rs .)}" >> $DATA_DIR/logs/conversation.jsonl
 
 if [ "$DUPLICATE" = "false" ]; then
   bash "$FRAMEWORK_DIR/scripts/notify.sh" "$RESPONSE"

--- a/scripts/wake.sh
+++ b/scripts/wake.sh
@@ -15,7 +15,9 @@ FRAMEWORK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 AGENT_DIR="${1:-$(pwd)}"
 cd "$AGENT_DIR"
 
-# Step log — written before events.jsonl so we can diagnose startup failures
+# DATA_DIR is resolved later from portal.config.json via read-harness-config.sh.
+# Until then, write the early step log at the legacy path. After we read the
+# config, we relocate STEP_LOG into <DATA_DIR>/logs/cycles/ if needed.
 STEP_LOG="logs/cycles/wake-steps.log"
 mkdir -p logs/cycles
 step() {
@@ -42,9 +44,22 @@ fi
 eval "$(node "$FRAMEWORK_DIR/scripts/read-config.js" "$AGENT_DIR/agent.yaml")"
 step "config loaded (name=$AGENT_NAME)"
 
-# Read harness config from portal.config.json (defaults to claude-code)
+# Read harness + data dir config from portal.config.json
+# (defaults: harness=claude-code, DATA_DIR=".")
 eval "$(bash "$FRAMEWORK_DIR/scripts/read-harness-config.sh" "$AGENT_DIR")"
-step "harness config loaded (type=$HARNESS_TYPE)"
+step "harness config loaded (type=$HARNESS_TYPE, DATA_DIR=$DATA_DIR)"
+
+# Now that DATA_DIR is known, relocate STEP_LOG under the data dir for
+# the remainder of the cycle. Migrate any early entries written before
+# config was loaded.
+if [ "$DATA_DIR" != "." ]; then
+  NEW_STEP_LOG="$DATA_DIR/logs/cycles/wake-steps.log"
+  mkdir -p "$(dirname "$NEW_STEP_LOG")"
+  if [ -f "$STEP_LOG" ] && [ ! -f "$NEW_STEP_LOG" ]; then
+    cat "$STEP_LOG" >> "$NEW_STEP_LOG"
+  fi
+  STEP_LOG="$NEW_STEP_LOG"
+fi
 
 # Set timezone if configured
 if [ -n "$AGENT_TIMEZONE" ]; then
@@ -183,7 +198,8 @@ fi
 
 # Track cycle timing
 CYCLE_TS="$(date +%Y%m%d-%H%M)"
-CYCLE_LOG="logs/cycles/${CYCLE_TS}.log"
+CYCLE_LOG="$DATA_DIR/logs/cycles/${CYCLE_TS}.log"
+mkdir -p "$DATA_DIR/logs/cycles"
 CYCLE_START_EPOCH=$(date +%s)
 
 # Log cycle start
@@ -234,7 +250,8 @@ step "pre-cycle hooks done"
 # ── HARNESS AUTH CHECK ──
 
 # Record auth confirmation timestamp (non-fatal)
-AUTH_CONFIRMED_FILE="$AGENT_DIR/logs/.auth-last-confirmed"
+AUTH_CONFIRMED_FILE="$AGENT_DIR/$DATA_DIR/logs/.auth-last-confirmed"
+mkdir -p "$(dirname "$AUTH_CONFIRMED_FILE")"
 case "$HARNESS_TYPE" in
   claude-code)
     if claude auth status --json 2>/dev/null | grep -q '"loggedIn": *true'; then
@@ -311,7 +328,12 @@ bash "$FRAMEWORK_DIR/scripts/consolidate-memory.sh" "$AGENT_DIR" 2>&1 | while IF
   step "consolidation: skipped or failed (non-fatal)"
 
 # Dispatch pending notification
-NOTIFY_FILE="pending_notification.txt"
+# Agents write pending_notification.txt under the data dir (current state)
+# or at the agent root (legacy state). Check both for backwards compat.
+NOTIFY_FILE="$DATA_DIR/pending_notification.txt"
+if [ ! -s "$NOTIFY_FILE" ] && [ -s "pending_notification.txt" ]; then
+  NOTIFY_FILE="pending_notification.txt"
+fi
 if [ -s "$NOTIFY_FILE" ]; then
   step "sending notification"
   bash "$FRAMEWORK_DIR/scripts/notify.sh" "$(cat "$NOTIFY_FILE")"
@@ -322,7 +344,7 @@ fi
 CYCLE_END_EPOCH=$(date +%s)
 CYCLE_DURATION_S=$((CYCLE_END_EPOCH - CYCLE_START_EPOCH))
 CYCLE_DURATION_M=$((CYCLE_DURATION_S / 60))
-echo "{\"ts\":\"$(date -Iseconds)\",\"type\":\"cycle_end\",\"summary\":\"Cycle complete\",\"duration_s\":${CYCLE_DURATION_S},\"duration_m\":${CYCLE_DURATION_M}}" >> "$AGENT_DIR/logs/events.jsonl"
+echo "{\"ts\":\"$(date -Iseconds)\",\"type\":\"cycle_end\",\"summary\":\"Cycle complete\",\"duration_s\":${CYCLE_DURATION_S},\"duration_m\":${CYCLE_DURATION_M}}" >> "$AGENT_DIR/$DATA_DIR/logs/events.jsonl"
 step "cycle complete (${CYCLE_DURATION_M}m ${CYCLE_DURATION_S}s)"
 
 # Cycle succeeded — remove failure marker and update framework last-known-good

--- a/test/data-dir-scripts.test.sh
+++ b/test/data-dir-scripts.test.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# data-dir-scripts.test.sh — Verify shell scripts honor portal.config.json dataDir.
+# Both legacy (dataDir: ".") and new (dataDir: "data") layouts.
+set -e
+
+FRAMEWORK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPTS="$FRAMEWORK_DIR/scripts"
+
+OK=0
+FAIL=0
+ok()   { echo "  ok - $*"; OK=$((OK+1)); }
+fail() { echo "  not ok - $*"; FAIL=$((FAIL+1)); }
+
+make_agent() {
+  local mode="$1"  # "legacy" or "data"
+  local tmpdir=$(mktemp -d -t data-dir-scripts-XXXXXX)
+  if [ "$mode" = "data" ]; then
+    cat > "$tmpdir/portal.config.json" <<EOF
+{"name":"T","port":0,"agentDir":"$tmpdir","dataDir":"data","cronFile":"/nonexistent","lockFile":"$tmpdir/lock"}
+EOF
+  else
+    cat > "$tmpdir/portal.config.json" <<EOF
+{"name":"T","port":0,"agentDir":"$tmpdir","cronFile":"/nonexistent","lockFile":"$tmpdir/lock"}
+EOF
+  fi
+  # Also create an agent.yaml stub since some scripts (cron-setup.sh, start.sh) read it
+  cat > "$tmpdir/agent.yaml" <<EOF
+name: T
+port: 8099
+repo: example/test
+lock-file: $tmpdir/lock
+cron-file: $tmpdir/cron
+cron-schedule: 0 0 * * *
+wake-prompt: stub
+EOF
+  echo "$tmpdir"
+}
+
+echo "# log-event.sh respects DATA_DIR"
+echo "## Test 1: default (legacy) — writes to <agentDir>/logs/events.jsonl"
+TMP=$(make_agent legacy)
+unset DATA_DIR
+bash "$SCRIPTS/log-event.sh" "$TMP" cycle_start "smoke test"
+[ -f "$TMP/logs/events.jsonl" ] && ok "wrote to legacy logs/events.jsonl" || fail "missing legacy logs/events.jsonl"
+[ ! -e "$TMP/data/logs" ] && ok "no data/ dir created in legacy mode" || fail "unexpected data/ dir"
+grep -q "smoke test" "$TMP/logs/events.jsonl" && ok "event content recorded" || fail "event content missing"
+rm -rf "$TMP"
+
+echo "## Test 2: dataDir=data — writes to <agentDir>/data/logs/events.jsonl"
+TMP=$(make_agent data)
+unset DATA_DIR
+bash "$SCRIPTS/log-event.sh" "$TMP" cycle_start "smoke test"
+[ -f "$TMP/data/logs/events.jsonl" ] && ok "wrote to data/logs/events.jsonl" || fail "missing data/logs/events.jsonl"
+[ ! -e "$TMP/logs/events.jsonl" ] && ok "no root logs/events.jsonl in dataDir mode" || fail "unexpected root logs/"
+grep -q "smoke test" "$TMP/data/logs/events.jsonl" && ok "event content recorded under data/" || fail "event content missing"
+rm -rf "$TMP"
+
+echo "## Test 3: DATA_DIR env override beats portal.config.json"
+TMP=$(make_agent legacy)
+DATA_DIR=data bash "$SCRIPTS/log-event.sh" "$TMP" cycle_start "env override"
+[ -f "$TMP/data/logs/events.jsonl" ] && ok "env override redirected to data/" || fail "env override ignored"
+rm -rf "$TMP"
+
+echo ""
+echo "# log-journal.sh respects DATA_DIR"
+echo "## Test 4: dataDir=data — writes to <agentDir>/data/journals/"
+TMP=$(make_agent data)
+unset DATA_DIR
+bash "$SCRIPTS/log-journal.sh" "$TMP" auto rob note "test entry under data"
+MONTH=$(date +%Y-%m)
+[ -f "$TMP/data/journals/$MONTH.md" ] && ok "journal at data/journals/$MONTH.md" || fail "missing data/journals/$MONTH.md"
+[ ! -d "$TMP/journals" ] && ok "no root journals/ in dataDir mode" || fail "unexpected root journals/"
+rm -rf "$TMP"
+
+echo "## Test 5: legacy — writes to <agentDir>/journals/"
+TMP=$(make_agent legacy)
+unset DATA_DIR
+bash "$SCRIPTS/log-journal.sh" "$TMP" auto rob note "legacy journal"
+[ -f "$TMP/journals/$MONTH.md" ] && ok "journal at legacy journals/$MONTH.md" || fail "missing legacy journals/$MONTH.md"
+rm -rf "$TMP"
+
+echo ""
+echo "# read-harness-config.sh emits DATA_DIR"
+TMP=$(make_agent data)
+OUT=$(bash "$SCRIPTS/read-harness-config.sh" "$TMP")
+echo "$OUT" | grep -q "export DATA_DIR='data'" && ok "emits DATA_DIR='data'" || fail "missing DATA_DIR export"
+rm -rf "$TMP"
+
+TMP=$(make_agent legacy)
+OUT=$(bash "$SCRIPTS/read-harness-config.sh" "$TMP")
+echo "$OUT" | grep -qE "export DATA_DIR='?\.'?" && ok "emits DATA_DIR='.' for default" || fail "missing default DATA_DIR"
+rm -rf "$TMP"
+
+echo ""
+echo "# clear-done-todos.sh respects DATA_DIR"
+echo "## Test 6: dataDir=data — reads/writes data/human_todos.md"
+TMP=$(make_agent data)
+mkdir -p "$TMP/data"
+cat > "$TMP/data/human_todos.md" <<EOF
+## Todos
+
+- [x] Done item
+- [ ] Pending item
+EOF
+unset DATA_DIR
+bash "$SCRIPTS/clear-done-todos.sh" "$TMP" > /dev/null
+grep -q "Done item" "$TMP/data/human_todos.md" && fail "done item should be removed" || ok "removed done item under data/"
+grep -q "Pending item" "$TMP/data/human_todos.md" && ok "kept pending item" || fail "pending item lost"
+rm -rf "$TMP"
+
+echo ""
+echo "# cron-setup.sh writes cron-wake.log under DATA_DIR"
+TMP=$(make_agent data)
+unset DATA_DIR
+OUT=$(bash "$SCRIPTS/cron-setup.sh" "$TMP" 2>&1 || true)
+echo "$OUT" | grep -q "data/logs/cycles/cron-wake.log" && ok "cron line includes data/logs/cycles/cron-wake.log" || fail "cron-wake.log path missing DATA_DIR prefix"
+rm -rf "$TMP"
+
+echo ""
+echo "# Results: $((OK+FAIL)) tests, $OK passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

Threads the `DATA_DIR` env var emitted by `read-harness-config.sh` (#234) through every framework-managed shell and Python script. With default `DATA_DIR="."` every existing path resolves identically — no agent needs to change anything. With `DATA_DIR="data"` every framework write lands under `<agent-dir>/data/`.

Builds on #234 + #235.

## Scripts updated

- `wake.sh` — STEP_LOG, CYCLE_LOG, AUTH_CONFIRMED_FILE, NOTIFY_FILE, cycle_end event append. Early step log relocates from legacy path to `<DATA_DIR>/logs/cycles/` after config loads.
- `respond.sh` — CYCLE_LOG, cycle_end event append
- `log-event.sh` — events.jsonl write
- `log-journal.sh` — journals/ write
- `consolidate-memory.sh` — CONFIG_FILE, INSIGHTS_FILE, OPERATIONAL_FILE, EVENTS_FILE, JOURNALS_DIR
- `start.sh` — supervisor.log
- `cron-setup.sh` — cron-wake.log path inside the generated cron line
- `telegram-respond.sh` — conversation.jsonl, respond_errors.log, telegram_session_id, CYCLE_LOG
- `clear-done-todos.sh` — human_todos.md
- `memory-index.py` — accepts `--data-dir` flag, falls back to `$DATA_DIR` env, defaults to `.`
- `memory-search.py` — same

## Backwards compat detail

`pending_notification.txt` lookup in `wake.sh` checks `<DATA_DIR>/pending_notification.txt` first, then falls back to `<agentDir>/pending_notification.txt`. This handles agents mid-migration where the file might still be written at the root for one cycle.

## Test plan

- [x] `npm test` — 419/419 node tests pass, all shell tests pass
- [x] New `test/data-dir-scripts.test.sh` — 15 tests covering log-event, log-journal, read-harness-config, clear-done-todos, cron-setup in both legacy and dataDir modes plus env override