### PR TITLE
docs(dataDir): migration guide + README expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,25 @@ Add `data/` to `.gitignore` so cycle writes don't pollute git history. For a loc
 
 `features.library.dataDir` (and similar per-feature path overrides) are resolved relative to `<agentDir>/<dataDir>`. With default `dataDir: "."` the absolute resolution is identical to the legacy layout, so no agent needs to change its config to keep working — opt in when you're ready.
 
+**Migrating an existing agent** (see [`instructions/data-layout.md`](instructions/data-layout.md) for the full guide):
+
+1. Set `"dataDir": "data"` in `portal.config.json`.
+2. `git mv` your data directories into `data/`:
+   ```bash
+   mkdir -p data
+   for d in logs journals memory content config input output uploads requests; do
+     [ -d "$d" ] && git mv "$d" "data/$d"
+   done
+   ```
+3. `git rm --cached -r data/`, then add `data/` to `.gitignore`.
+4. Update `CLAUDE.md` and `agent.yaml` path references (the framework doesn't read these — the model does).
+5. Smoke-test a respond cycle to confirm writes land at the new locations.
+
+The framework reads `dataDir` from `portal.config.json` and propagates it via three mechanisms:
+- **Node routes** call `dataPath(config, ...)` from `lib/helpers.js`
+- **Shell scripts** source `read-harness-config.sh` (exports `DATA_DIR`)
+- **Python scripts** (`memory-index.py`, `memory-search.py`) accept `--data-dir` or the `DATA_DIR` env var
+
 ### Features
 
 The `features` object controls which tabs and routes are enabled. Omit a key to disable it.

--- a/instructions/data-layout.md
+++ b/instructions/data-layout.md
@@ -1,0 +1,103 @@
+# Data Layout
+
+Every agent has a *code* surface (operator-edited, version-controlled) and a *data* surface (the agent's mutable state). The framework can keep these separated under one root directory via the optional `dataDir` field in `portal.config.json`.
+
+## The two modes
+
+### Legacy (default — `dataDir: "."` or omitted)
+
+All paths resolve under the agent root. This is the original layout — every existing agent works this way and nothing forces a migration.
+
+```
+<agentDir>/
+├── CLAUDE.md           # operator-owned
+├── agent.yaml
+├── portal.config.json
+├── scripts/, skills/
+├── logs/               # data: events.jsonl, cycles/, health.jsonl, ...
+├── journals/           # data: YYYY-MM.md
+├── memory/             # data: preferences.yaml, rated-items.yaml, ...
+├── content/items/      # data
+├── config/             # data: sources.yaml, categories.yaml, credentials/
+├── input/feedback/     # data
+├── output/             # data
+├── uploads/            # data
+└── requests/           # data
+```
+
+### dataDir layout (`dataDir: "data"`)
+
+All framework-managed mutable state moves under `<agentDir>/<dataDir>/`. Operator-owned files stay at the agent root. This is the layout for hosted deployments (per-user data on a mounted volume) and self-hosted users who want a clean `.gitignore` boundary.
+
+```
+<agentDir>/                 # code repo (pushed)
+├── CLAUDE.md
+├── agent.yaml
+├── portal.config.json     # has "dataDir": "data"
+├── scripts/, skills/
+└── data/                  # gitignored, mounted volume, etc.
+    ├── logs/
+    ├── journals/
+    ├── memory/
+    ├── content/items/
+    ├── config/
+    ├── input/feedback/
+    ├── output/
+    ├── uploads/
+    └── requests/
+```
+
+## What lives where
+
+| Path | Under `dataDir` | Reason |
+|------|------------------|--------|
+| `logs/`, `journals/`, `memory/`, `output/`, `uploads/`, `input/`, `requests/` | yes | written every cycle |
+| `content/items/` (or whatever `features.library.dataDir` is set to) | yes | agent-curated state |
+| `config/sources.yaml`, `config/categories.yaml`, `config/credentials/` | yes | user-mutable via the portal |
+| `human_todos.md` | yes | portal writes via `/api/todos` |
+| `pending_notification.txt` | yes | written by the agent each cycle |
+| `today.md`, `roadmap.md` | no — stays at root | read-only operator docs |
+| `CLAUDE.md`, `agent.yaml`, `portal.config.json` | no | operator/code |
+| `scripts/`, `skills/`, `tools/`, `.mcp.json` | no | operator/code |
+| `.env`, `.gitignore` | no | operator/code |
+
+## Migrating an existing agent
+
+1. Set `"dataDir": "data"` in `portal.config.json`.
+2. `git mv` each data directory into `data/`:
+   ```bash
+   mkdir -p data
+   for d in logs journals memory content config input output uploads requests; do
+     [ -d "$d" ] && git mv "$d" "data/$d"
+   done
+   ```
+3. `git rm --cached -r data/` so future writes under `data/` aren't tracked, then add `data/` to `.gitignore`.
+4. Update `CLAUDE.md` path references — `memory/...` → `data/memory/...`, etc. The framework resolves paths via `dataDir`, but the agent itself reads paths from its own prompt.
+5. Update `agent.yaml`'s `wake-prompt` and `respond-prompt` path references.
+6. Run a smoke cycle (`bash scripts/respond.sh .`) to confirm writes land at the right place.
+
+For a local rollback safety net, run `git init` inside `data/` as a separate, non-pushed repo.
+
+## How resolution works
+
+The framework reads `dataDir` from `portal.config.json` (defaulting to `"."`) and exposes it two ways:
+
+- **Node routes** call `dataPath(config, ...parts)` from `lib/helpers.js`, which returns `path.join(config.agentDir, config.dataDir || '.', ...parts)`.
+- **Shell scripts** source `read-harness-config.sh`, which exports `DATA_DIR`. Each script prefixes its hardcoded paths with `$DATA_DIR/`.
+- **Python scripts** (`memory-index.py`, `memory-search.py`) accept a `--data-dir` flag and fall back to the `DATA_DIR` env var.
+
+`features.library.dataDir` (currently `"content/items"`) is resolved *under* the top-level `dataDir`. With `dataDir: "data"` the library auto-resolves to `data/content/items` without you touching that field.
+
+## Why not symlinks?
+
+Symlinks would have let the framework continue using bare paths like `logs/` while the actual storage lived in `data/logs/`. They were rejected because:
+
+- Hosted deployments need a clean filesystem boundary — symlinks complicate per-user volume mounting.
+- A stray `rm -rf data/` against a symlink target is silently catastrophic.
+- The explicit field is easier to reason about across language boundaries (Node + shell + Python).
+
+## What this does not change
+
+- `commit.sh` still runs `git add -A` — gitignoring `data/` is what keeps cycle writes out of the code repo.
+- Agent prompts (`CLAUDE.md`, `agent.yaml`) are not auto-rewritten; the framework doesn't read them. You update those when you migrate.
+- Other agents that don't set `dataDir` keep working with no changes.

--- a/lib/schemas/source.yaml
+++ b/lib/schemas/source.yaml
@@ -1,5 +1,6 @@
 # Source schema — defines the fields that agent-portal understands
-# for content sources in config/sources.yaml.
+# for content sources in <dataDir>/config/sources.yaml
+# (legacy layout: <agentDir>/config/sources.yaml).
 #
 # Agents may add additional fields beyond this schema. Unknown fields
 # pass through the API (GET /api/sources) but are not rendered in the
@@ -61,7 +62,7 @@ fields:
       Use the Archive.org thumbnail API: https://archive.org/services/img/{identifier}
       where {identifier} is the last path segment of the item URL.
 
-# File format: config/sources.yaml
+# File format: <dataDir>/config/sources.yaml (legacy: <agentDir>/config/sources.yaml)
 # ─────────────────────────────────
 # sources:
 #   - id: archive-org


### PR DESCRIPTION
## Summary

Adds the migration documentation that was deferred from #234.

- `instructions/data-layout.md` (new) — canonical reference for the two layouts (legacy vs `dataDir: "data"`), table of what lives where, step-by-step migration recipe, and resolution mechanics across Node/shell/Python.
- `README.md` — expands the `dataDir` section with inline migration steps so operators see the path without chasing a link, plus a brief description of the three propagation mechanisms.
- `lib/schemas/source.yaml` — comments updated to reference `<dataDir>/config/sources.yaml`.

Builds on #234 + #235 + #236.

## Test plan

- [x] `npm test` — 419/419 node tests pass, all shell tests pass (no code touched, doc-only PR)