### PR TITLE
feat(publish): URL validator gate for content publishing

### DIFF
--- a/instructions/data-layout.md
+++ b/instructions/data-layout.md
@@ -101,3 +101,29 @@ Symlinks would have let the framework continue using bare paths like `logs/` whi
 - `commit.sh` still runs `git add -A` — gitignoring `data/` is what keeps cycle writes out of the code repo.
 - Agent prompts (`CLAUDE.md`, `agent.yaml`) are not auto-rewritten; the framework doesn't read them. You update those when you migrate.
 - Other agents that don't set `dataDir` keep working with no changes.
+
+## Content publishing gate (`publish-content.sh`)
+
+For agents that have a `features.library` and a `<dataDir>/config/sources.yaml`, the framework provides a validation gate to prevent the agent from publishing recommendations that link to unapproved or fabricated URLs:
+
+```bash
+bash ../agent-portal/scripts/publish-content.sh <agent-dir> <yaml-path> [--dry-run] [--skip-fetch]
+```
+
+Pass scenarios → moves the draft into `<dataDir>/content/items/<id>.yaml`.
+Fail scenarios → moves the draft into `<dataDir>/content/rejected/<id>.yaml` with a `_validation:` block listing every error.
+
+### Two validation layers
+
+1. **Host allowlist.** Every URL in `source_url` and `sources[].url` must trace to an approved source's host. Sources declare hosts via a `hosts:` field in `sources.yaml`; the validator falls back to the hostname parsed from `url:` for backwards compat. Pending sources (`status: pending`) are rejected — only `status: approved` qualifies.
+2. **Live fetch.** HEAD (GET fallback on 405) with a 10s timeout per URL, 2 retries on connection errors. 2xx/3xx = pass; anything else = fail. Cover URLs are *not* validated — they often come from third-party CDNs and aren't the safety concern. Only navigational URLs are checked.
+
+### Agent integration
+
+The agent's `CLAUDE.md` should instruct: write content YAML to a scratch path (e.g. `/tmp/item-<id>.yaml`), then call `publish-content.sh`. Never `Write` into `<dataDir>/content/items/` directly — the gate cannot enforce against bypasses.
+
+When `publish-content.sh` exits non-zero, the agent should read the `_validation` block in the quarantined file, fix the offending URLs (or skip the item entirely), and retry. The `--dry-run` flag lets the agent self-check without touching the filesystem.
+
+### Backwards compat
+
+Agents that don't have `features.library` configured can ignore the gate. The script reads `<dataDir>/config/sources.yaml`; if that file is absent, validation fails with exit code 2 and a clear error pointing at the missing registry.

--- a/lib/content-validator.js
+++ b/lib/content-validator.js
@@ -1,0 +1,229 @@
+// content-validator.js — Validate content items before they land in
+// <dataDir>/content/items/. Enforced via scripts/publish-content.sh.
+//
+// Two layers:
+//   A. Host allowlist — every URL field must match a host of an approved
+//      source in <dataDir>/config/sources.yaml. The item's primary `source`
+//      field must reference an approved source id.
+//   B. Live fetch — HEAD (GET fallback on 405) with 10s timeout and 2
+//      retries on connection errors. 2xx/3xx = pass, anything else = fail.
+//
+// Cover URLs (`metadata.cover_url`) are intentionally NOT validated — they
+// often come from third-party CDNs that aren't content sources. The safety
+// concern is navigational/source URLs, not thumbnails.
+//
+// Zero external deps. Uses only Node built-ins. Designed to be reusable
+// from a CLI wrapper and, eventually, an HTTP route on the portal.
+
+const http = require('http');
+const https = require('https');
+const { URL } = require('url');
+
+const DEFAULTS = {
+  fetchTimeoutMs: 10000,
+  fetchRetries: 2,
+  fetchRetryDelaysMs: [1000, 3000],
+  followRedirects: 5,
+  userAgent: 'agent-portal-publish-validator/1.0',
+};
+
+const REQUIRED_FIELDS = ['id', 'title', 'category', 'source', 'source_url', 'status'];
+
+const RECOVERABLE_ERROR_CODES = new Set([
+  'ENOTFOUND', 'ECONNRESET', 'ETIMEDOUT', 'EHOSTUNREACH', 'EAI_AGAIN', 'ECONNREFUSED',
+]);
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Build a host → source map from an approved-sources list.
+ * Uses each source's `hosts:` field, falling back to the hostname parsed
+ * from `url:` for backwards compat with sources that haven't declared hosts.
+ */
+function buildHostsMap(approvedSources) {
+  const hosts = new Map();
+  for (const s of approvedSources) {
+    let sourceHosts = Array.isArray(s.hosts) ? [...s.hosts] : [];
+    if (sourceHosts.length === 0 && s.url) {
+      try { sourceHosts.push(new URL(s.url).hostname); } catch {}
+    }
+    for (const h of sourceHosts) {
+      if (typeof h === 'string' && h) hosts.set(h.toLowerCase(), s);
+    }
+  }
+  return hosts;
+}
+
+/**
+ * Single HTTP(S) request. Returns { ok, status, reason, recoverable }.
+ */
+function singleRequest(targetUrl, method, options, redirectsRemaining) {
+  return new Promise(resolve => {
+    let parsed;
+    try { parsed = new URL(targetUrl); }
+    catch { return resolve({ ok: false, status: null, reason: 'invalid URL', recoverable: false }); }
+
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return resolve({ ok: false, status: null, reason: `unsupported protocol '${parsed.protocol}'`, recoverable: false });
+    }
+
+    const client = parsed.protocol === 'https:' ? https : http;
+    const headers = { 'User-Agent': options.userAgent };
+    if (method === 'GET') headers['Range'] = 'bytes=0-1023';
+
+    const req = client.request(parsed, {
+      method,
+      headers,
+      timeout: options.fetchTimeoutMs,
+    }, res => {
+      const status = res.statusCode;
+      res.resume();
+
+      // Follow redirects
+      if (status >= 300 && status < 400 && res.headers.location && redirectsRemaining > 0) {
+        const nextUrl = new URL(res.headers.location, parsed).href;
+        return resolve(singleRequest(nextUrl, method, options, redirectsRemaining - 1));
+      }
+
+      const ok = status >= 200 && status < 400;
+      resolve({ ok, status, reason: ok ? null : `HTTP ${status}`, recoverable: false });
+    });
+
+    req.on('error', err => {
+      const recoverable = RECOVERABLE_ERROR_CODES.has(err.code);
+      resolve({ ok: false, status: null, reason: err.code || err.message, recoverable });
+    });
+
+    req.on('timeout', () => {
+      req.destroy();
+      resolve({ ok: false, status: null, reason: 'timeout', recoverable: true });
+    });
+
+    req.end();
+  });
+}
+
+/**
+ * Fetch a URL with HEAD→GET fallback and retry on recoverable connection errors.
+ */
+async function fetchUrl(targetUrl, options = {}) {
+  // Spread DEFAULTS first, then only the defined entries from options.
+  // Plain spread would let `undefined` values shadow defaults.
+  const definedOptions = Object.fromEntries(
+    Object.entries(options).filter(([, v]) => v !== undefined)
+  );
+  const opts = { ...DEFAULTS, ...definedOptions };
+  let lastResult = null;
+
+  for (let attempt = 0; attempt <= opts.fetchRetries; attempt++) {
+    if (attempt > 0) {
+      const delay = opts.fetchRetryDelaysMs[attempt - 1] ?? opts.fetchRetryDelaysMs[opts.fetchRetryDelaysMs.length - 1];
+      await sleep(delay);
+    }
+
+    let result = await singleRequest(targetUrl, 'HEAD', opts, opts.followRedirects);
+    if (result.status === 405) {
+      // HEAD disallowed — try GET
+      result = await singleRequest(targetUrl, 'GET', opts, opts.followRedirects);
+    }
+
+    lastResult = result;
+    if (result.ok || !result.recoverable) return result;
+    // Recoverable failure — fall through to next retry
+  }
+
+  return lastResult;
+}
+
+/**
+ * Collect (field, url) pairs from an item — every URL we will validate.
+ * Cover URLs and arbitrary metadata.* URLs are NOT collected.
+ */
+function collectUrls(item) {
+  const checks = [];
+  if (item.source_url) checks.push({ field: 'source_url', url: item.source_url });
+  if (Array.isArray(item.sources)) {
+    item.sources.forEach((s, i) => {
+      if (s && typeof s.url === 'string' && s.url) {
+        checks.push({ field: `sources[${i}].url`, url: s.url });
+      }
+    });
+  }
+  return checks;
+}
+
+/**
+ * Validate a content item against a sources registry.
+ *
+ * @param {object} item — parsed YAML for the content item
+ * @param {Array}  sources — entries from sources.yaml
+ * @param {object} options — { skipFetch?: bool, fetchTimeoutMs?, fetchRetries?, fetchRetryDelaysMs? }
+ * @returns {Promise<{ok: boolean, errors: Array<{field, url?, value?, reason}>}>}
+ */
+async function validateItem(item, sources, options = {}) {
+  const errors = [];
+
+  if (!item || typeof item !== 'object') {
+    return { ok: false, errors: [{ field: '(root)', reason: 'item is not an object' }] };
+  }
+
+  for (const f of REQUIRED_FIELDS) {
+    if (item[f] === undefined || item[f] === null || item[f] === '') {
+      errors.push({ field: f, reason: 'required field missing' });
+    }
+  }
+  if (errors.length > 0) return { ok: false, errors };
+
+  const approvedSources = (Array.isArray(sources) ? sources : []).filter(s => s && s.status === 'approved');
+  const approvedById = new Map(approvedSources.map(s => [s.id, s]));
+  const hostsMap = buildHostsMap(approvedSources);
+
+  // Primary source must reference an approved registry entry
+  if (!approvedById.has(item.source)) {
+    errors.push({
+      field: 'source',
+      value: item.source,
+      reason: `source id '${item.source}' is not in any approved registry entry (must be present in sources.yaml with status: approved)`,
+    });
+  }
+
+  const urlChecks = collectUrls(item);
+
+  // Layer A: host allowlist
+  for (const c of urlChecks) {
+    let host;
+    try { host = new URL(c.url).hostname.toLowerCase(); }
+    catch { errors.push({ field: c.field, url: c.url, reason: 'invalid URL' }); continue; }
+    if (!hostsMap.has(host)) {
+      errors.push({ field: c.field, url: c.url, reason: `host '${host}' is not in any approved source` });
+    }
+  }
+
+  // If host check failed, don't bother with fetches — re-publish with fixed URLs first
+  if (errors.length > 0) return { ok: false, errors };
+
+  // Layer B: live fetch (skip in --skip-fetch mode)
+  if (!options.skipFetch && urlChecks.length > 0) {
+    const fetchOpts = {
+      fetchTimeoutMs: options.fetchTimeoutMs,
+      fetchRetries: options.fetchRetries,
+      fetchRetryDelaysMs: options.fetchRetryDelaysMs,
+      userAgent: options.userAgent,
+      followRedirects: options.followRedirects,
+    };
+    const results = await Promise.all(
+      urlChecks.map(c => fetchUrl(c.url, fetchOpts).then(r => ({ ...c, ...r })))
+    );
+    for (const r of results) {
+      if (!r.ok) {
+        errors.push({ field: r.field, url: r.url, reason: r.status ? `HTTP ${r.status}` : r.reason });
+      }
+    }
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+module.exports = { validateItem, fetchUrl, collectUrls, buildHostsMap, DEFAULTS };

--- a/scripts/publish-content.js
+++ b/scripts/publish-content.js
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+// publish-content.js — Validate a drafted content item and either move it
+// into <dataDir>/content/items/ (pass) or quarantine it under
+// <dataDir>/content/rejected/ with a _validation block (fail).
+//
+// Usage: node publish-content.js <yaml-path> [--agent-dir <dir>] [--dry-run] [--skip-fetch]
+// Typically invoked via scripts/publish-content.sh from an agent cycle.
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const { validateItem } = require('../lib/content-validator');
+
+function parseArgs(argv) {
+  const args = { positional: [], dryRun: false, skipFetch: false, agentDir: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--dry-run') args.dryRun = true;
+    else if (a === '--skip-fetch') args.skipFetch = true;
+    else if (a === '--agent-dir') args.agentDir = argv[++i];
+    else if (a === '--help' || a === '-h') args.help = true;
+    else args.positional.push(a);
+  }
+  return args;
+}
+
+function usage(stream = process.stderr) {
+  stream.write('Usage: publish-content.js <yaml-path> [--agent-dir <dir>] [--dry-run] [--skip-fetch]\n');
+}
+
+function readDataDirFromConfig(agentDir) {
+  const cfgPath = path.join(agentDir, 'portal.config.json');
+  try {
+    const c = JSON.parse(fs.readFileSync(cfgPath, 'utf-8'));
+    return c.dataDir || '.';
+  } catch { return '.'; }
+}
+
+function formatErrors(errors) {
+  return errors.map(e => {
+    const url = e.url ? ` ${e.url}` : e.value ? ` ${JSON.stringify(e.value)}` : '';
+    return `  - ${e.field}:${url} ${e.reason}`;
+  }).join('\n');
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help || args.positional.length < 1) {
+    usage(args.help ? process.stdout : process.stderr);
+    process.exit(args.help ? 0 : 2);
+  }
+
+  const yamlPath = path.resolve(args.positional[0]);
+  const agentDir = args.agentDir ? path.resolve(args.agentDir) : process.cwd();
+  const dataDir = process.env.DATA_DIR || readDataDirFromConfig(agentDir);
+  const dataRoot = path.join(agentDir, dataDir);
+  const sourcesPath = path.join(dataRoot, 'config', 'sources.yaml');
+  const itemsDir = path.join(dataRoot, 'content', 'items');
+  const rejectedDir = path.join(dataRoot, 'content', 'rejected');
+
+  // Load the draft YAML
+  let item;
+  try {
+    item = yaml.load(fs.readFileSync(yamlPath, 'utf-8'));
+  } catch (err) {
+    process.stderr.write(`Failed to read draft ${yamlPath}: ${err.message}\n`);
+    process.exit(2);
+  }
+
+  // Load the sources registry
+  let sources;
+  try {
+    const sourcesYaml = yaml.load(fs.readFileSync(sourcesPath, 'utf-8'));
+    sources = (sourcesYaml && sourcesYaml.sources) || [];
+  } catch (err) {
+    process.stderr.write(`Failed to read sources registry ${sourcesPath}: ${err.message}\n`);
+    process.exit(2);
+  }
+
+  const { ok, errors } = await validateItem(item, sources, { skipFetch: args.skipFetch });
+
+  if (ok) {
+    process.stdout.write(`PASS '${item.id}'\n`);
+    if (args.dryRun) {
+      process.stdout.write('(dry-run: no filesystem changes)\n');
+      process.exit(0);
+    }
+    fs.mkdirSync(itemsDir, { recursive: true });
+    const destPath = path.join(itemsDir, `${item.id}.yaml`);
+    fs.writeFileSync(destPath, yaml.dump(item, { lineWidth: -1 }));
+    if (path.resolve(yamlPath) !== path.resolve(destPath)) {
+      try { fs.unlinkSync(yamlPath); } catch {}
+    }
+    process.stdout.write(`-> ${destPath}\n`);
+    process.exit(0);
+  }
+
+  // Validation failed
+  process.stderr.write(`FAIL '${item.id || '(no id)'}' (${errors.length} error${errors.length === 1 ? '' : 's'}):\n`);
+  process.stderr.write(formatErrors(errors) + '\n');
+
+  if (args.dryRun) {
+    process.stderr.write('(dry-run: no filesystem changes)\n');
+    process.exit(1);
+  }
+
+  fs.mkdirSync(rejectedDir, { recursive: true });
+  const rejectedId = item.id || `unknown-${Date.now()}`;
+  const rejectedPath = path.join(rejectedDir, `${rejectedId}.yaml`);
+  const enriched = {
+    ...item,
+    _validation: { rejected_at: new Date().toISOString(), errors },
+  };
+  fs.writeFileSync(rejectedPath, yaml.dump(enriched, { lineWidth: -1 }));
+  if (path.resolve(yamlPath) !== path.resolve(rejectedPath)) {
+    try { fs.unlinkSync(yamlPath); } catch {}
+  }
+  process.stderr.write(`-> quarantined at ${rejectedPath}\n`);
+  process.exit(1);
+}
+
+main().catch(err => {
+  process.stderr.write(`Unexpected error: ${err.stack || err.message}\n`);
+  process.exit(2);
+});

--- a/scripts/publish-content.sh
+++ b/scripts/publish-content.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# scripts/publish-content.sh — Validate a drafted content item and publish it
+# into <dataDir>/content/items/ (pass) or quarantine to
+# <dataDir>/content/rejected/ (fail).
+#
+# Usage: publish-content.sh <agent-dir> <yaml-path> [--dry-run] [--skip-fetch]
+#
+# The agent's typical pattern:
+#   1. Draft a YAML to /tmp/item-<id>.yaml
+#   2. bash ../agent-portal/scripts/publish-content.sh . /tmp/item-<id>.yaml
+#   3. On exit 0, the item is published. On exit 1, read the _validation
+#      block in <dataDir>/content/rejected/<id>.yaml, fix URLs, retry.
+set -e
+
+FRAMEWORK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+AGENT_DIR="${1:?Usage: publish-content.sh <agent-dir> <yaml-path> [--dry-run] [--skip-fetch]}"
+YAML_PATH="${2:?Usage: publish-content.sh <agent-dir> <yaml-path> [--dry-run] [--skip-fetch]}"
+shift 2
+
+# Resolve DATA_DIR from portal.config.json (defaults to ".")
+if [ -z "$DATA_DIR" ] && [ -f "$AGENT_DIR/portal.config.json" ]; then
+  eval "$(bash "$FRAMEWORK_DIR/scripts/read-harness-config.sh" "$AGENT_DIR" 2>/dev/null | grep '^export DATA_DIR=')"
+fi
+export DATA_DIR="${DATA_DIR:-.}"
+
+exec node "$FRAMEWORK_DIR/scripts/publish-content.js" "$YAML_PATH" --agent-dir "$AGENT_DIR" "$@"

--- a/test/content-validator.test.js
+++ b/test/content-validator.test.js
@@ -1,0 +1,266 @@
+// content-validator.test.js — Unit tests for the publish-content validator.
+// Spins up a local HTTP test server that produces deterministic responses
+// per path, then drives validateItem against synthetic items.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('http');
+const { validateItem, fetchUrl } = require('../lib/content-validator');
+
+function startTestServer() {
+  return new Promise(resolve => {
+    const server = http.createServer((req, res) => {
+      const url = new URL(req.url, 'http://localhost');
+      const p = url.pathname;
+      if (p === '/200') { res.writeHead(200); res.end('ok'); return; }
+      if (p === '/404') { res.writeHead(404); res.end('nope'); return; }
+      if (p === '/500') { res.writeHead(500); res.end('boom'); return; }
+      if (p === '/head-405') {
+        if (req.method === 'HEAD') { res.writeHead(405); res.end(); }
+        else { res.writeHead(200); res.end('ok'); }
+        return;
+      }
+      if (p === '/redirect') { res.writeHead(302, { Location: '/200' }); res.end(); return; }
+      if (p === '/redirect-loop') { res.writeHead(302, { Location: '/redirect-loop' }); res.end(); return; }
+      if (p === '/slow') { /* never respond */ return; }
+      res.writeHead(200); res.end('default');
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const port = server.address().port;
+      resolve({ server, port });
+    });
+  });
+}
+
+let server, port, base;
+before(async () => {
+  ({ server, port } = await startTestServer());
+  base = `http://127.0.0.1:${port}`;
+});
+after(() => server && server.close());
+
+function makeItem(overrides = {}) {
+  return {
+    id: 'test-item',
+    title: 'Test',
+    category: 'comics',
+    format: 'cbz',
+    source: 'test-source',
+    source_url: `${base}/200`,
+    status: 'linked',
+    sources: [{ name: 'Test Source', url: `${base}/200`, type: 'downloadable' }],
+    ...overrides,
+  };
+}
+
+function makeSources(overrides = {}) {
+  return [
+    {
+      id: 'test-source',
+      name: 'Test Source',
+      url: base,
+      status: 'approved',
+      hosts: ['127.0.0.1'],
+      ...overrides,
+    },
+  ];
+}
+
+describe('validateItem — required fields', () => {
+  it('passes a fully-populated item with all valid URLs', async () => {
+    const r = await validateItem(makeItem(), makeSources());
+    assert.equal(r.ok, true, JSON.stringify(r.errors));
+  });
+
+  it('rejects when id is missing', async () => {
+    const r = await validateItem(makeItem({ id: '' }), makeSources(), { skipFetch: true });
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some(e => e.field === 'id' && /required/i.test(e.reason)));
+  });
+
+  it('rejects when source is missing', async () => {
+    const r = await validateItem(makeItem({ source: '' }), makeSources(), { skipFetch: true });
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some(e => e.field === 'source'));
+  });
+
+  it('rejects a non-object item', async () => {
+    const r = await validateItem(null, makeSources(), { skipFetch: true });
+    assert.equal(r.ok, false);
+    assert.match(r.errors[0].reason, /not an object/);
+  });
+});
+
+describe('validateItem — primary source lookup', () => {
+  it('rejects when item.source references an unknown source id', async () => {
+    const r = await validateItem(makeItem({ source: 'unknown-source' }), makeSources(), { skipFetch: true });
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some(e => e.field === 'source' && /not in any approved registry/.test(e.reason)));
+  });
+
+  it('rejects pending sources (status != approved)', async () => {
+    const pending = makeSources({ status: 'pending' });
+    const r = await validateItem(makeItem(), pending, { skipFetch: true });
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some(e => e.field === 'source'));
+  });
+});
+
+describe('validateItem — host allowlist', () => {
+  it('rejects URLs whose host is not in any approved source', async () => {
+    const r = await validateItem(
+      makeItem({ source_url: 'https://aggregator-fakehulu.example/show' }),
+      makeSources(),
+      { skipFetch: true }
+    );
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some(e => e.field === 'source_url' && /host .* is not in any approved/.test(e.reason)));
+  });
+
+  it('rejects each unapproved URL inside sources[]', async () => {
+    const r = await validateItem(
+      makeItem({
+        sources: [
+          { name: 'Test Source', url: `${base}/200`, type: 'downloadable' },
+          { name: 'Aggregator', url: 'https://aggregator-fakehulu.example/show', type: 'link-only' },
+        ],
+      }),
+      makeSources(),
+      { skipFetch: true }
+    );
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some(e => e.field === 'sources[1].url'));
+  });
+
+  it('derives the host from `url:` when `hosts:` is absent (backwards compat)', async () => {
+    const legacy = [{ id: 'test-source', name: 'Test', url: base, status: 'approved' }];
+    const r = await validateItem(makeItem(), legacy, { skipFetch: true });
+    assert.equal(r.ok, true, JSON.stringify(r.errors));
+  });
+
+  it('flags an invalid URL string', async () => {
+    const r = await validateItem(makeItem({ source_url: 'not a url' }), makeSources(), { skipFetch: true });
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some(e => /invalid URL/.test(e.reason)));
+  });
+});
+
+describe('validateItem — live fetch (skipFetch=false)', () => {
+  it('passes 2xx responses', async () => {
+    const r = await validateItem(makeItem(), makeSources(), { fetchTimeoutMs: 2000 });
+    assert.equal(r.ok, true, JSON.stringify(r.errors));
+  });
+
+  it('rejects 404 responses with the status code in the reason', async () => {
+    const r = await validateItem(
+      makeItem({ source_url: `${base}/404`, sources: [{ name: 'Test', url: `${base}/404`, type: 'downloadable' }] }),
+      makeSources(),
+      { fetchTimeoutMs: 2000 }
+    );
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some(e => /HTTP 404/.test(e.reason)));
+  });
+
+  it('rejects 5xx responses', async () => {
+    const r = await validateItem(
+      makeItem({ source_url: `${base}/500`, sources: [{ name: 'Test', url: `${base}/500`, type: 'downloadable' }] }),
+      makeSources(),
+      { fetchTimeoutMs: 2000 }
+    );
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some(e => /HTTP 500/.test(e.reason)));
+  });
+
+  it('falls back to GET when HEAD returns 405', async () => {
+    const r = await validateItem(
+      makeItem({ source_url: `${base}/head-405`, sources: [{ name: 'Test', url: `${base}/head-405`, type: 'downloadable' }] }),
+      makeSources(),
+      { fetchTimeoutMs: 2000 }
+    );
+    assert.equal(r.ok, true, JSON.stringify(r.errors));
+  });
+
+  it('follows 3xx redirects', async () => {
+    const r = await validateItem(
+      makeItem({ source_url: `${base}/redirect`, sources: [{ name: 'Test', url: `${base}/redirect`, type: 'downloadable' }] }),
+      makeSources(),
+      { fetchTimeoutMs: 2000 }
+    );
+    assert.equal(r.ok, true, JSON.stringify(r.errors));
+  });
+
+  it('rejects on timeout (short timeout against /slow)', async () => {
+    const r = await validateItem(
+      makeItem({ source_url: `${base}/slow`, sources: [{ name: 'Test', url: `${base}/slow`, type: 'downloadable' }] }),
+      makeSources(),
+      { fetchTimeoutMs: 200, fetchRetries: 0 }
+    );
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some(e => /timeout/i.test(e.reason)));
+  });
+
+  it('retries recoverable failures', async () => {
+    // 0 retries: should fail
+    const noRetry = await validateItem(
+      makeItem({ source_url: `${base}/slow`, sources: [{ name: 'Test', url: `${base}/slow`, type: 'downloadable' }] }),
+      makeSources(),
+      { fetchTimeoutMs: 100, fetchRetries: 0 }
+    );
+    assert.equal(noRetry.ok, false);
+
+    // 2 retries with tiny delay: still fails (slow never responds), but exercises the loop
+    const withRetry = await validateItem(
+      makeItem({ source_url: `${base}/slow`, sources: [{ name: 'Test', url: `${base}/slow`, type: 'downloadable' }] }),
+      makeSources(),
+      { fetchTimeoutMs: 100, fetchRetries: 2, fetchRetryDelaysMs: [10, 10] }
+    );
+    assert.equal(withRetry.ok, false);
+    assert.ok(withRetry.errors.some(e => /timeout/i.test(e.reason)));
+  });
+});
+
+describe('validateItem — skipFetch mode', () => {
+  it('passes a 404 URL when skipFetch is true (host check only)', async () => {
+    const r = await validateItem(
+      makeItem({ source_url: `${base}/404`, sources: [{ name: 'Test', url: `${base}/404`, type: 'downloadable' }] }),
+      makeSources(),
+      { skipFetch: true }
+    );
+    assert.equal(r.ok, true, JSON.stringify(r.errors));
+  });
+
+  it('still rejects unapproved hosts in skipFetch mode', async () => {
+    const r = await validateItem(
+      makeItem({ source_url: 'https://aggregator-fakehulu.example/show' }),
+      makeSources(),
+      { skipFetch: true }
+    );
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some(e => /host .* is not in any approved/.test(e.reason)));
+  });
+});
+
+describe('fetchUrl', () => {
+  it('returns ok=true for 200', async () => {
+    const r = await fetchUrl(`${base}/200`, { fetchTimeoutMs: 2000 });
+    assert.equal(r.ok, true);
+    assert.equal(r.status, 200);
+  });
+
+  it('returns ok=false with reason for 500', async () => {
+    const r = await fetchUrl(`${base}/500`, { fetchTimeoutMs: 2000 });
+    assert.equal(r.ok, false);
+    assert.equal(r.status, 500);
+  });
+
+  it('falls back to GET on HEAD 405', async () => {
+    const r = await fetchUrl(`${base}/head-405`, { fetchTimeoutMs: 2000 });
+    assert.equal(r.ok, true);
+  });
+
+  it('rejects unsupported protocol (file://)', async () => {
+    const r = await fetchUrl('file:///etc/passwd', { fetchTimeoutMs: 1000 });
+    assert.equal(r.ok, false);
+    assert.match(r.reason, /unsupported protocol/);
+  });
+});

--- a/test/publish-content.test.sh
+++ b/test/publish-content.test.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# publish-content.test.sh — shell smoke tests for the publish-content gate.
+# Spins a tiny HTTP server, builds a synthetic agent dir with dataDir: "data",
+# drives publish-content.sh through pass/fail/quarantine scenarios.
+set -e
+
+FRAMEWORK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$FRAMEWORK_DIR/scripts/publish-content.sh"
+
+OK=0; FAIL=0
+ok()   { echo "  ok - $*"; OK=$((OK+1)); }
+fail() { echo "  not ok - $*"; FAIL=$((FAIL+1)); }
+
+# ── Spin a tiny HTTP server (Node) ──
+PORT=$(node -e "const s=require('net').createServer().listen(0,()=>{console.log(s.address().port);s.close();});" 2>/dev/null)
+node -e "
+const http = require('http');
+const s = http.createServer((req, res) => {
+  const p = new URL(req.url, 'http://localhost').pathname;
+  if (p === '/200') { res.writeHead(200); res.end('ok'); return; }
+  if (p === '/404') { res.writeHead(404); res.end(); return; }
+  res.writeHead(200); res.end();
+});
+s.listen($PORT, '127.0.0.1', () => process.send && process.send('ready'));
+" > /tmp/publish-content-server.log 2>&1 &
+SERVER_PID=$!
+sleep 0.3
+trap "kill $SERVER_PID 2>/dev/null" EXIT
+
+# ── Build a synthetic agent dir ──
+TMP=$(mktemp -d -t pub-content-XXXXXX)
+mkdir -p "$TMP/data/config" "$TMP/data/content"
+
+cat > "$TMP/portal.config.json" <<EOF
+{"name":"T","port":0,"agentDir":"$TMP","dataDir":"data","cronFile":"/none","lockFile":"$TMP/lock"}
+EOF
+
+cat > "$TMP/data/config/sources.yaml" <<EOF
+sources:
+  - id: test-source
+    name: Test Source
+    url: http://127.0.0.1:$PORT
+    status: approved
+    hosts: [127.0.0.1]
+    categories: [comics]
+  - id: pending-source
+    name: Pending Source
+    url: http://127.0.0.1:$PORT
+    status: pending
+    hosts: [127.0.0.1]
+    categories: [comics]
+EOF
+
+draft() {
+  local path="$1"; shift
+  cat > "$path" <<EOF
+id: $1
+title: Test
+category: comics
+format: cbz
+source: $2
+source_url: $3
+status: linked
+sources:
+  - name: Test
+    url: $3
+    type: downloadable
+EOF
+}
+
+echo "# publish-content.sh smoke tests"
+
+echo "## Test 1: good item → publishes into data/content/items/"
+draft "$TMP/draft.yaml" "good-item" "test-source" "http://127.0.0.1:$PORT/200"
+if bash "$SCRIPT" "$TMP" "$TMP/draft.yaml" > /tmp/pc-1.out 2> /tmp/pc-1.err; then
+  ok "exit 0 on pass"
+else
+  fail "exit nonzero on pass: $(cat /tmp/pc-1.err)"
+fi
+[ -f "$TMP/data/content/items/good-item.yaml" ] && ok "item landed in items/" || fail "item missing from items/"
+[ ! -e "$TMP/draft.yaml" ] && ok "draft consumed (removed from source path)" || fail "draft not removed"
+
+echo "## Test 2: bad host → quarantined"
+draft "$TMP/draft2.yaml" "bad-host" "test-source" "https://aggregator-fakehulu.example/show"
+if bash "$SCRIPT" "$TMP" "$TMP/draft2.yaml" > /tmp/pc-2.out 2> /tmp/pc-2.err; then
+  fail "exit 0 on bad-host (should have failed)"
+else
+  ok "exit nonzero on bad-host"
+fi
+[ -f "$TMP/data/content/rejected/bad-host.yaml" ] && ok "quarantined under rejected/" || fail "missing from rejected/"
+grep -q "host" "$TMP/data/content/rejected/bad-host.yaml" && ok "_validation block mentions host failure" || fail "_validation missing host reason"
+grep -q "_validation" "$TMP/data/content/rejected/bad-host.yaml" && ok "_validation block present" || fail "_validation block missing"
+[ ! -e "$TMP/draft2.yaml" ] && ok "draft consumed on failure" || fail "draft not removed on failure"
+
+echo "## Test 3: dead URL (404) → quarantined with HTTP status in reason"
+draft "$TMP/draft3.yaml" "dead-url" "test-source" "http://127.0.0.1:$PORT/404"
+if bash "$SCRIPT" "$TMP" "$TMP/draft3.yaml" > /tmp/pc-3.out 2> /tmp/pc-3.err; then
+  fail "exit 0 on dead URL (should have failed)"
+else
+  ok "exit nonzero on dead URL"
+fi
+[ -f "$TMP/data/content/rejected/dead-url.yaml" ] && ok "quarantined under rejected/" || fail "missing from rejected/"
+grep -q "HTTP 404" "$TMP/data/content/rejected/dead-url.yaml" && ok "_validation block names HTTP 404" || fail "_validation missing 404"
+
+echo "## Test 4: pending source rejected (strict)"
+draft "$TMP/draft4.yaml" "pending" "pending-source" "http://127.0.0.1:$PORT/200"
+if bash "$SCRIPT" "$TMP" "$TMP/draft4.yaml" --skip-fetch > /tmp/pc-4.out 2> /tmp/pc-4.err; then
+  fail "exit 0 on pending source (should have failed)"
+else
+  ok "exit nonzero on pending source"
+fi
+grep -q "source" "$TMP/data/content/rejected/pending.yaml" && ok "rejected for source field" || fail "source rejection missing"
+
+echo "## Test 5: --dry-run leaves filesystem alone"
+draft "$TMP/draft5.yaml" "dry-test" "test-source" "http://127.0.0.1:$PORT/200"
+bash "$SCRIPT" "$TMP" "$TMP/draft5.yaml" --dry-run > /tmp/pc-5.out 2> /tmp/pc-5.err
+[ -f "$TMP/draft5.yaml" ] && ok "draft NOT removed on --dry-run" || fail "draft removed on dry-run"
+[ ! -e "$TMP/data/content/items/dry-test.yaml" ] && ok "no item written on dry-run pass" || fail "item written on dry-run"
+rm "$TMP/draft5.yaml"
+
+echo "## Test 6: --skip-fetch bypasses fetch but still enforces host"
+draft "$TMP/draft6.yaml" "skip-fetch-good" "test-source" "http://127.0.0.1:$PORT/404"
+if bash "$SCRIPT" "$TMP" "$TMP/draft6.yaml" --skip-fetch > /tmp/pc-6.out 2> /tmp/pc-6.err; then
+  ok "--skip-fetch passes 404 URL (host check only)"
+else
+  fail "--skip-fetch incorrectly rejected: $(cat /tmp/pc-6.err)"
+fi
+
+echo "## Test 7: missing sources.yaml → graceful error (exit 2)"
+TMP2=$(mktemp -d -t pub-content-no-sources-XXXXXX)
+mkdir -p "$TMP2/data"
+cat > "$TMP2/portal.config.json" <<EOF
+{"name":"T2","port":0,"agentDir":"$TMP2","dataDir":"data"}
+EOF
+draft "$TMP2/draft.yaml" "no-sources" "test-source" "http://127.0.0.1:$PORT/200"
+set +e
+bash "$SCRIPT" "$TMP2" "$TMP2/draft.yaml" > /tmp/pc-7.out 2> /tmp/pc-7.err
+RC=$?
+set -e
+[ "$RC" = "2" ] && ok "exit code 2 on missing sources.yaml" || fail "exit was $RC, expected 2"
+grep -q "sources" /tmp/pc-7.err && ok "stderr mentions sources" || fail "no sources mention in stderr"
+rm -rf "$TMP2"
+
+echo "## Test 8: honors DATA_DIR env override"
+DATA_DIR=data bash "$SCRIPT" "$TMP" "$TMP/draft7-missing.yaml" 2>/tmp/pc-8.err && true
+grep -q "Failed to read draft" /tmp/pc-8.err && ok "DATA_DIR env propagates to the node script" || fail "DATA_DIR not honored"
+
+# Cleanup
+rm -rf "$TMP"
+echo ""
+echo "# Results: $((OK+FAIL)) tests, $OK passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

Adds a programmatic gate (`scripts/publish-content.sh`) that agents must use to publish content items into `<dataDir>/content/items/`. Catches the class of bug where a model recommends content with URLs to aggregator-impersonation sites (e.g., a \"hulu\" link going to `aggregator-fakehulu.example`) or fabricated paths on real hosts (e.g., `archive.org/details/totally-made-up-id`).

Two layers, by decision in the design discussion:

1. **Host allowlist** — every URL traces to an approved source's host in `<dataDir>/config/sources.yaml`. Pending sources (`status: pending`) are rejected — only `approved` qualifies (strict, per decision 2).
2. **Live fetch** — single HEAD per URL (GET fallback on 405), 10s timeout, **2 retries on connection errors** (per decision 3), follows up to 5 redirects. 2xx/3xx pass; anything else fails with the status code in the reason.

Cover URLs are deliberately NOT validated (decision 1c — they come from arbitrary CDNs).

Failed items quarantine to `<dataDir>/content/rejected/<id>.yaml` with a `_validation:` block. Agents read it and self-correct (decision 4). CLI inspection only for now — no portal UI tab (decision 5).

## Files

- `lib/content-validator.js` — pure validator (zero deps, reusable from a future HTTP route)
- `scripts/publish-content.{js,sh}` — entrypoints (Node + bash wrapper)
- `test/content-validator.test.js` — 23 unit tests against a local HTTP test server
- `test/publish-content.test.sh` — 19 shell smoke tests
- `instructions/data-layout.md` — new "Content publishing gate" section

## Sources.yaml schema

Adds an optional `hosts: [...]` field. Backwards compatible — when absent, the validator derives the host from `url:`. Agents already in production keep working.

## Verification (per plan)

- [x] Layer 1 (unit): 23 tests pass — required fields, primary-source lookup, pending rejection, host allowlist, invalid URLs, 2xx/4xx/5xx, HEAD-405 GET fallback, redirects, timeout, retries, skipFetch mode, unsupported protocols
- [x] Layer 2 (shell smoke): 19 tests pass — good publish, bad-host quarantine, dead-URL quarantine, pending-source rejection, --dry-run, --skip-fetch, missing sources.yaml, DATA_DIR env
- [x] Layer 3 (real item): existing `mister-miracle-tom-king.yaml` from contentbot passes both layers against live archive.org
- [x] Layer 4 (adversarial):
  - `source: hulu` + aggregator host → rejected with "host '...' is not in any approved source"
  - `source: archive-org` + fabricated path → rejected with HTTP 404
- [x] Full agent-portal suite: 442/442 node tests + all shell tests pass
- [ ] Layer 5 (e2e on contentbot) — comes in the follow-up PR

## Follow-up

PR on `robhunter/contentbot` will opt in: add `hosts:` to existing sources, seed Wikipedia/IMDb as `canonical-reference`, update CLAUDE.md to instruct agents to call publish-content.sh and never Write into items/ directly.