### PR TITLE
feat(publish): validate references[] for liveness without host allowlist

### DIFF
--- a/instructions/data-layout.md
+++ b/instructions/data-layout.md
@@ -113,10 +113,21 @@ bash ../agent-portal/scripts/publish-content.sh <agent-dir> <yaml-path> [--dry-r
 Pass scenarios → moves the draft into `<dataDir>/content/items/<id>.yaml`.
 Fail scenarios → moves the draft into `<dataDir>/content/rejected/<id>.yaml` with a `_validation:` block listing every error.
 
-### Two validation layers
+### Validation layers
 
-1. **Host allowlist.** Every URL in `source_url` and `sources[].url` must trace to an approved source's host. Sources declare hosts via a `hosts:` field in `sources.yaml`; the validator falls back to the hostname parsed from `url:` for backwards compat. Pending sources (`status: pending`) are rejected — only `status: approved` qualifies.
-2. **Live fetch.** HEAD (GET fallback on 405) with a 10s timeout per URL, 2 retries on connection errors. 2xx/3xx = pass; anything else = fail. Cover URLs are *not* validated — they often come from third-party CDNs and aren't the safety concern. Only navigational URLs are checked.
+**Source URLs (`source_url` and every `sources[].url`)** — these are where the user consumes the content. Both checks apply:
+
+1. **Host allowlist.** Every URL must trace to an approved source's host. Sources declare hosts via a `hosts:` field in `sources.yaml`; the validator falls back to the hostname parsed from `url:` for backwards compat. Pending sources (`status: pending`) are rejected — only `status: approved` qualifies.
+2. **Live fetch.** HEAD (GET fallback on 405) with a 10s timeout per URL, 2 retries on connection errors. 2xx/3xx = pass; anything else = fail.
+
+**Reference URLs (`references[].url`, optional)** — supplemental informational links that complement the recommendation (Wikipedia, IMDb, Letterboxd reviews, etc.). They are NOT places where the user consumes content. Only the live-fetch check applies:
+
+- **No host allowlist** — references can come from any host. They're not a recommendation surface; they're context.
+- **Live fetch** — same liveness check as source URLs (2xx/3xx required).
+
+A reference that 404s is rejected; a reference on an unfamiliar host is accepted as long as it returns 200.
+
+**Cover URLs (`metadata.cover_url`)** — not validated. Often served from third-party CDNs that aren't sources.
 
 ### Agent integration
 

--- a/lib/content-validator.js
+++ b/lib/content-validator.js
@@ -138,8 +138,13 @@ async function fetchUrl(targetUrl, options = {}) {
 }
 
 /**
- * Collect (field, url) pairs from an item — every URL we will validate.
- * Cover URLs and arbitrary metadata.* URLs are NOT collected.
+ * Collect (field, url) pairs from an item that must trace to an APPROVED
+ * source. These are the navigational URLs the user clicks to consume the
+ * content: source_url and every entry in sources[]. Both host-allowlisted
+ * and live-fetched.
+ *
+ * Cover URLs (metadata.cover_url) and arbitrary metadata.* URLs are NOT
+ * collected — covers come from anywhere.
  */
 function collectUrls(item) {
   const checks = [];
@@ -148,6 +153,25 @@ function collectUrls(item) {
     item.sources.forEach((s, i) => {
       if (s && typeof s.url === 'string' && s.url) {
         checks.push({ field: `sources[${i}].url`, url: s.url });
+      }
+    });
+  }
+  return checks;
+}
+
+/**
+ * Collect (field, url) pairs from references[] — supplemental informational
+ * links (e.g., Wikipedia, IMDb, Letterboxd reviews) that complement a
+ * recommendation. NOT consumption URLs. These are live-fetched but the host
+ * is NOT checked against the approved-sources registry — references can
+ * come from any host. Liveness is still required.
+ */
+function collectReferenceUrls(item) {
+  const checks = [];
+  if (Array.isArray(item.references)) {
+    item.references.forEach((r, i) => {
+      if (r && typeof r.url === 'string' && r.url) {
+        checks.push({ field: `references[${i}].url`, url: r.url });
       }
     });
   }
@@ -190,8 +214,9 @@ async function validateItem(item, sources, options = {}) {
   }
 
   const urlChecks = collectUrls(item);
+  const referenceChecks = collectReferenceUrls(item);
 
-  // Layer A: host allowlist
+  // Layer A: host allowlist (sources only — references are not host-restricted)
   for (const c of urlChecks) {
     let host;
     try { host = new URL(c.url).hostname.toLowerCase(); }
@@ -201,11 +226,18 @@ async function validateItem(item, sources, options = {}) {
     }
   }
 
-  // If host check failed, don't bother with fetches — re-publish with fixed URLs first
+  // Validate reference URLs are parseable (we'll fetch them in Layer B if so)
+  for (const c of referenceChecks) {
+    try { new URL(c.url); }
+    catch { errors.push({ field: c.field, url: c.url, reason: 'invalid URL' }); }
+  }
+
+  // If structural checks failed, don't bother with fetches
   if (errors.length > 0) return { ok: false, errors };
 
-  // Layer B: live fetch (skip in --skip-fetch mode)
-  if (!options.skipFetch && urlChecks.length > 0) {
+  // Layer B: live fetch (skip in --skip-fetch mode). Sources and references
+  // get the same liveness treatment — 2xx/3xx pass, anything else fails.
+  if (!options.skipFetch) {
     const fetchOpts = {
       fetchTimeoutMs: options.fetchTimeoutMs,
       fetchRetries: options.fetchRetries,
@@ -213,12 +245,15 @@ async function validateItem(item, sources, options = {}) {
       userAgent: options.userAgent,
       followRedirects: options.followRedirects,
     };
-    const results = await Promise.all(
-      urlChecks.map(c => fetchUrl(c.url, fetchOpts).then(r => ({ ...c, ...r })))
-    );
-    for (const r of results) {
-      if (!r.ok) {
-        errors.push({ field: r.field, url: r.url, reason: r.status ? `HTTP ${r.status}` : r.reason });
+    const allChecks = [...urlChecks, ...referenceChecks];
+    if (allChecks.length > 0) {
+      const results = await Promise.all(
+        allChecks.map(c => fetchUrl(c.url, fetchOpts).then(r => ({ ...c, ...r })))
+      );
+      for (const r of results) {
+        if (!r.ok) {
+          errors.push({ field: r.field, url: r.url, reason: r.status ? `HTTP ${r.status}` : r.reason });
+        }
       }
     }
   }
@@ -226,4 +261,4 @@ async function validateItem(item, sources, options = {}) {
   return { ok: errors.length === 0, errors };
 }
 
-module.exports = { validateItem, fetchUrl, collectUrls, buildHostsMap, DEFAULTS };
+module.exports = { validateItem, fetchUrl, collectUrls, collectReferenceUrls, buildHostsMap, DEFAULTS };

--- a/test/content-validator.test.js
+++ b/test/content-validator.test.js
@@ -240,6 +240,88 @@ describe('validateItem — skipFetch mode', () => {
   });
 });
 
+describe('validateItem — references[] (supplemental links)', () => {
+  it('passes when references[] is absent', async () => {
+    const item = makeItem();
+    delete item.references;
+    const r = await validateItem(item, makeSources(), { fetchTimeoutMs: 2000 });
+    assert.equal(r.ok, true, JSON.stringify(r.errors));
+  });
+
+  it('passes when references[] is empty array', async () => {
+    const r = await validateItem(makeItem({ references: [] }), makeSources(), { fetchTimeoutMs: 2000 });
+    assert.equal(r.ok, true, JSON.stringify(r.errors));
+  });
+
+  it('passes when references[] is on a host NOT in approved sources (no host check)', async () => {
+    // example.com is not in the approved sources list — references should still pass host-wise
+    const r = await validateItem(
+      makeItem({ references: [{ name: 'Wikipedia', url: `${base}/200` }] }),
+      makeSources({ hosts: ['some-other-host'] }), // approved hosts doesn't include 127.0.0.1
+      { fetchTimeoutMs: 2000, skipFetch: true }
+    );
+    // source_url is on 127.0.0.1 which is NOT in approved hosts → expect a source_url failure
+    // BUT references should not contribute a host error
+    const refErrors = r.errors.filter(e => e.field && e.field.startsWith('references'));
+    assert.equal(refErrors.length, 0, 'references should not trigger host-allowlist errors');
+  });
+
+  it('rejects references[].url that returns 404', async () => {
+    const r = await validateItem(
+      makeItem({ references: [{ name: 'Wikipedia', url: `${base}/404` }] }),
+      makeSources(),
+      { fetchTimeoutMs: 2000 }
+    );
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some(e => e.field === 'references[0].url' && /HTTP 404/.test(e.reason)));
+  });
+
+  it('rejects references[].url that times out', async () => {
+    const r = await validateItem(
+      makeItem({ references: [{ name: 'Slow', url: `${base}/slow` }] }),
+      makeSources(),
+      { fetchTimeoutMs: 200, fetchRetries: 0 }
+    );
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some(e => e.field === 'references[0].url' && /timeout/i.test(e.reason)));
+  });
+
+  it('reports both source and reference failures', async () => {
+    const r = await validateItem(
+      makeItem({
+        source_url: `${base}/500`,
+        sources: [{ name: 'Test', url: `${base}/500`, type: 'downloadable' }],
+        references: [{ name: 'Wikipedia', url: `${base}/404` }],
+      }),
+      makeSources(),
+      { fetchTimeoutMs: 2000 }
+    );
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some(e => e.field === 'source_url' && /HTTP 500/.test(e.reason)));
+    assert.ok(r.errors.some(e => e.field === 'references[0].url' && /HTTP 404/.test(e.reason)));
+  });
+
+  it('flags invalid URL in references[]', async () => {
+    const r = await validateItem(
+      makeItem({ references: [{ name: 'Broken', url: 'not a url' }] }),
+      makeSources(),
+      { skipFetch: true }
+    );
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some(e => e.field === 'references[0].url' && /invalid URL/.test(e.reason)));
+  });
+
+  it('skipFetch bypasses reference liveness too', async () => {
+    const r = await validateItem(
+      makeItem({ references: [{ name: 'Wikipedia', url: `${base}/404` }] }),
+      makeSources(),
+      { skipFetch: true }
+    );
+    // /404 host (127.0.0.1) isn't checked for refs, and skipFetch bypasses fetch — should pass
+    assert.equal(r.ok, true, JSON.stringify(r.errors));
+  });
+});
+
 describe('fetchUrl', () => {
   it('returns ok=true for 200', async () => {
     const r = await fetchUrl(`${base}/200`, { fetchTimeoutMs: 2000 });

--- a/test/publish-content.test.sh
+++ b/test/publish-content.test.sh
@@ -145,6 +145,75 @@ echo "## Test 8: honors DATA_DIR env override"
 DATA_DIR=data bash "$SCRIPT" "$TMP" "$TMP/draft7-missing.yaml" 2>/tmp/pc-8.err && true
 grep -q "Failed to read draft" /tmp/pc-8.err && ok "DATA_DIR env propagates to the node script" || fail "DATA_DIR not honored"
 
+echo "## Test 9: references[] with a non-approved host passes (no host check on refs)"
+cat > "$TMP/draft-refs.yaml" <<EOF
+id: refs-good
+title: Refs Test
+category: comics
+format: cbz
+source: test-source
+source_url: http://127.0.0.1:$PORT/200
+status: linked
+sources:
+  - name: Test
+    url: http://127.0.0.1:$PORT/200
+    type: downloadable
+references:
+  - name: Wikipedia (not in approved sources)
+    url: http://127.0.0.1:$PORT/200
+EOF
+if bash "$SCRIPT" "$TMP" "$TMP/draft-refs.yaml" > /tmp/pc-9.out 2> /tmp/pc-9.err; then
+  ok "references on non-approved host accepted"
+else
+  fail "refs rejected: $(cat /tmp/pc-9.err)"
+fi
+
+echo "## Test 10: references[] with a dead URL → quarantined"
+cat > "$TMP/draft-refs-dead.yaml" <<EOF
+id: refs-dead
+title: Refs Dead Test
+category: comics
+format: cbz
+source: test-source
+source_url: http://127.0.0.1:$PORT/200
+status: linked
+sources:
+  - name: Test
+    url: http://127.0.0.1:$PORT/200
+    type: downloadable
+references:
+  - name: Dead reference
+    url: http://127.0.0.1:$PORT/404
+EOF
+if bash "$SCRIPT" "$TMP" "$TMP/draft-refs-dead.yaml" > /tmp/pc-10.out 2> /tmp/pc-10.err; then
+  fail "expected reject on dead reference URL"
+else
+  ok "exit nonzero on dead reference URL"
+fi
+[ -f "$TMP/data/content/rejected/refs-dead.yaml" ] && ok "quarantined under rejected/" || fail "missing from rejected/"
+grep -q "references\[0\]" "$TMP/data/content/rejected/refs-dead.yaml" && ok "_validation block names references[0]" || fail "no references field in validation block"
+
+echo "## Test 11: empty references[] is fine"
+cat > "$TMP/draft-empty-refs.yaml" <<EOF
+id: empty-refs
+title: Empty Refs
+category: comics
+format: cbz
+source: test-source
+source_url: http://127.0.0.1:$PORT/200
+status: linked
+sources:
+  - name: Test
+    url: http://127.0.0.1:$PORT/200
+    type: downloadable
+references: []
+EOF
+if bash "$SCRIPT" "$TMP" "$TMP/draft-empty-refs.yaml" > /tmp/pc-11.out 2> /tmp/pc-11.err; then
+  ok "empty references[] accepted"
+else
+  fail "empty refs rejected: $(cat /tmp/pc-11.err)"
+fi
+
 # Cleanup
 rm -rf "$TMP"
 echo ""


### PR DESCRIPTION
## Summary

Adds support for an optional `references[]` field on content items — supplemental informational links (Wikipedia, IMDb, Letterboxd, etc.) that complement a recommendation but are NOT consumption surfaces.

Rule (per design discussion):

| Field | Host allowlist | Live fetch |
|-------|---------------|-----------|
| `source_url`, `sources[].url` | yes | yes |
| `references[].url` | no | yes |
| `metadata.cover_url` | no | no |

References can link to any host as long as the URL returns 2xx/3xx. A reference that 404s is rejected; a reference on an unfamiliar host is accepted as long as it's alive.

## Why

ContentBot's CLAUDE.md previously prescribed a "fall back to Wikipedia/IMDb as canonical reference" when the agent couldn't find a streamer URL. That fallback put Wikipedia in the navigational URL slot — but a Wikipedia link isn't where the user watches the movie. The fallback is being stripped on the contentbot side (separate PR) and replaced with this `references[]` slot for supplemental context, kept distinct from the consumption URLs.

## Changes

- `lib/content-validator.js` — new `collectReferenceUrls()` helper; `validateItem` now fetches sources AND references in one batch, but only applies the host check to sources.
- `test/content-validator.test.js` — 8 new unit tests
- `test/publish-content.test.sh` — 3 new shell smoke tests
- `instructions/data-layout.md` — explicit "Validation layers" section distinguishing source URLs, reference URLs, and cover URLs.

## Test plan

- [x] 450/450 node tests pass (+8 new for references)
- [x] All shell tests pass (publish-content smoke: 24/24, +3 new)
- [x] References on non-approved hosts accepted when alive
- [x] Dead references quarantined with the `references[N].url` field named in `_validation`
- [x] Empty references[] is fine
- [x] Mixed failures (source AND reference) both reported