### PR TITLE
feat(sources): per-source notes — operator guidance for the agent

### DIFF
--- a/lib/routes/sources.js
+++ b/lib/routes/sources.js
@@ -60,6 +60,37 @@ function register(routes, config) {
     writeSources(sources);
     sendJSON(res, 200, { ok: true, id, status: 'denied' });
   };
+
+  // PATCH /api/sources/:id — partial update. Currently supports the `notes` field
+  // (operator guidance for that source: e.g. "only recommend from the $4.99 shelf").
+  // Other fields (status, hosts, type, categories) are managed through dedicated
+  // routes or by editing sources.yaml directly.
+  routes['PATCH /api/sources/:id'] = async (req, res) => {
+    const id = req.params.id;
+    let body;
+    try { body = JSON.parse(await readBody(req)); }
+    catch { return sendJSON(res, 400, { error: 'Invalid JSON' }); }
+
+    const sources = readSources();
+    const source = sources.find(s => s.id === id);
+    if (!source) return sendJSON(res, 404, { error: 'Source not found' });
+
+    if (Object.prototype.hasOwnProperty.call(body, 'notes')) {
+      const notes = body.notes;
+      if (notes !== null && typeof notes !== 'string') {
+        return sendJSON(res, 400, { error: 'notes must be a string or null' });
+      }
+      const trimmed = (notes || '').trim();
+      if (trimmed === '') {
+        delete source.notes;
+      } else {
+        source.notes = trimmed + '\n';
+      }
+    }
+
+    writeSources(sources);
+    sendJSON(res, 200, { ok: true, id, notes: source.notes || null });
+  };
 }
 
 module.exports = { register };

--- a/lib/ui/tabs/sources.js
+++ b/lib/ui/tabs/sources.js
@@ -9,6 +9,7 @@ async function loadSources() {
   try {
     var res = await fetch('/api/sources');
     var sources = await res.json();
+    window.__sourcesCache = sources; // used by editSourceNotes to seed the textarea
 
     var pending = sources.filter(function(s) { return s.status === 'pending'; });
     var approved = sources.filter(function(s) { return s.status === 'approved'; });
@@ -72,7 +73,10 @@ async function loadSources() {
 
 function renderSourceRow(s) {
   var statusColor = s.status === 'approved' ? '#2e7d32' : s.status === 'denied' ? '#c62828' : '#e65100';
-  var html = '<div style="display:flex;align-items:center;gap:8px;padding:8px;border-radius:4px;margin-bottom:4px;background:#fafafa;flex-wrap:wrap">';
+  var html = '<div class="source-card" data-source-id="' + escapeHtml(s.id) + '" style="padding:8px;border-radius:4px;margin-bottom:6px;background:#fafafa">';
+
+  // Top row — metadata + action buttons
+  html += '<div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">';
   html += '<strong style="font-size:13px;min-width:120px">' + escapeHtml(s.name) + '</strong>';
   html += '<a href="' + escapeHtml(s.url) + '" target="_blank" rel="noopener" style="font-size:12px;color:#1565c0">' + escapeHtml(s.url) + '</a>';
   html += '<span class="category-badge" style="background:#f5f5f5;color:#666">' + escapeHtml(s.type) + '</span>';
@@ -97,7 +101,86 @@ function renderSourceRow(s) {
   }
   html += '</div>';
   html += '</div>';
+
+  // Notes block (only shown for approved sources — operator guidance)
+  if (s.status === 'approved') {
+    html += renderNotesBlock(s);
+  }
+
+  html += '</div>';
   return html;
+}
+
+function renderNotesBlock(s) {
+  var safeId = escapeHtml(s.id);
+  var hasNotes = s.notes && s.notes.trim().length > 0;
+  var html = '<div class="source-notes" id="notes-' + safeId + '" style="margin-top:6px;font-size:12px;color:#555">';
+  if (hasNotes) {
+    html += '<div class="notes-view" style="display:flex;align-items:flex-start;gap:8px">';
+    html += '<span style="color:#888;font-weight:600;min-width:48px">Notes:</span>';
+    html += '<pre style="margin:0;flex:1;white-space:pre-wrap;font-family:inherit">' + escapeHtml(s.notes.trim()) + '</pre>';
+    html += '<button class="refresh-btn" style="padding:1px 6px;font-size:10px" onclick="editSourceNotes(\\'' + safeId + '\\')">Edit</button>';
+    html += '</div>';
+  } else {
+    html += '<div class="notes-view">';
+    html += '<button class="refresh-btn" style="padding:1px 6px;font-size:10px;color:#888" onclick="editSourceNotes(\\'' + safeId + '\\')">+ Add notes</button>';
+    html += '</div>';
+  }
+  // Hidden edit form (revealed by editSourceNotes)
+  html += '<div class="notes-edit" style="display:none;flex-direction:column;gap:4px">';
+  html += '<textarea id="notes-textarea-' + safeId + '" style="width:100%;min-height:60px;font-family:inherit;font-size:12px;padding:6px;box-sizing:border-box" placeholder="Operator guidance for this source (e.g., \\'only recommend from the $4.99 shelf\\')"></textarea>';
+  html += '<div style="display:flex;gap:6px;justify-content:flex-end">';
+  html += '<button class="refresh-btn" style="padding:2px 8px;font-size:11px" onclick="cancelSourceNotes(\\'' + safeId + '\\')">Cancel</button>';
+  html += '<button class="refresh-btn" style="padding:2px 8px;font-size:11px;background:#e3f2fd;color:#1565c0" onclick="saveSourceNotes(\\'' + safeId + '\\')">Save</button>';
+  html += '</div>';
+  html += '</div>';
+  html += '</div>';
+  return html;
+}
+
+function getSourceById(id) {
+  // Pulled from the in-memory list cached on window during loadSources
+  return (window.__sourcesCache || []).find(function(s) { return s.id === id; });
+}
+
+function editSourceNotes(id) {
+  var container = document.getElementById('notes-' + id);
+  if (!container) return;
+  var view = container.querySelector('.notes-view');
+  var edit = container.querySelector('.notes-edit');
+  var textarea = document.getElementById('notes-textarea-' + id);
+  var s = getSourceById(id);
+  textarea.value = (s && s.notes) ? s.notes.trim() : '';
+  view.style.display = 'none';
+  edit.style.display = 'flex';
+  textarea.focus();
+}
+
+function cancelSourceNotes(id) {
+  var container = document.getElementById('notes-' + id);
+  if (!container) return;
+  container.querySelector('.notes-view').style.display = '';
+  container.querySelector('.notes-edit').style.display = 'none';
+}
+
+async function saveSourceNotes(id) {
+  var textarea = document.getElementById('notes-textarea-' + id);
+  if (!textarea) return;
+  var notes = textarea.value;
+  try {
+    var res = await fetch('/api/sources/' + encodeURIComponent(id), {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ notes: notes })
+    });
+    if (!res.ok) {
+      alert('Failed to save notes: HTTP ' + res.status);
+      return;
+    }
+    loadSources();
+  } catch (err) {
+    alert('Failed to save notes: ' + (err && err.message ? err.message : 'network error'));
+  }
 }
 
 async function approveSource(id) {

--- a/test/sources-preferences.test.js
+++ b/test/sources-preferences.test.js
@@ -137,6 +137,143 @@ describe('POST /api/sources/:id/deny', () => {
   });
 });
 
+describe('PATCH /api/sources/:id (notes)', () => {
+  function setup() {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sources-patch-'));
+    const configDir = path.join(tmpDir, 'config');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.copyFileSync(path.join(fixturesDir, 'config', 'sources.yaml'), path.join(configDir, 'sources.yaml'));
+    return tmpDir;
+  }
+
+  it('writes notes to sources.yaml', async () => {
+    const tmpDir = setup();
+    const { server } = createTestSvr(tmpDir);
+    await new Promise(r => server.listen(0, r));
+    const port = server.address().port;
+
+    const { status, data } = await fetchJSON(port, '/api/sources/shady-torrents', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ notes: 'only recommend from approved torrent uploaders' }),
+    });
+    assert.equal(status, 200);
+    assert.match(data.notes, /approved torrent uploaders/);
+
+    // Verify persisted
+    const yaml = require('js-yaml');
+    const written = yaml.load(fs.readFileSync(path.join(tmpDir, 'config', 'sources.yaml'), 'utf-8'));
+    const updated = written.sources.find(s => s.id === 'shady-torrents');
+    assert.match(updated.notes, /approved torrent uploaders/);
+
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('clears notes when given empty string', async () => {
+    const tmpDir = setup();
+    const { server } = createTestSvr(tmpDir);
+    await new Promise(r => server.listen(0, r));
+    const port = server.address().port;
+
+    // First set
+    await fetchJSON(port, '/api/sources/shady-torrents', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ notes: 'something' }),
+    });
+    // Then clear
+    const { status, data } = await fetchJSON(port, '/api/sources/shady-torrents', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ notes: '   ' }),
+    });
+    assert.equal(status, 200);
+    assert.equal(data.notes, null);
+
+    const yaml = require('js-yaml');
+    const written = yaml.load(fs.readFileSync(path.join(tmpDir, 'config', 'sources.yaml'), 'utf-8'));
+    const updated = written.sources.find(s => s.id === 'shady-torrents');
+    assert.equal(updated.notes, undefined, 'notes should be removed from the YAML when blank');
+
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('returns 404 for unknown source id', async () => {
+    const tmpDir = setup();
+    const { server } = createTestSvr(tmpDir);
+    await new Promise(r => server.listen(0, r));
+    const port = server.address().port;
+
+    const { status } = await fetchJSON(port, '/api/sources/nonexistent', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ notes: 'x' }),
+    });
+    assert.equal(status, 404);
+
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('rejects invalid JSON body', async () => {
+    const tmpDir = setup();
+    const { server } = createTestSvr(tmpDir);
+    await new Promise(r => server.listen(0, r));
+    const port = server.address().port;
+
+    const { status, data } = await fetchJSON(port, '/api/sources/shady-torrents', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not-json-{',
+    });
+    assert.equal(status, 400);
+    assert.match(data.error, /Invalid JSON/);
+
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('rejects non-string notes value', async () => {
+    const tmpDir = setup();
+    const { server } = createTestSvr(tmpDir);
+    await new Promise(r => server.listen(0, r));
+    const port = server.address().port;
+
+    const { status, data } = await fetchJSON(port, '/api/sources/shady-torrents', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ notes: 42 }),
+    });
+    assert.equal(status, 400);
+    assert.match(data.error, /must be a string/);
+
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('GET /api/sources surfaces the saved notes', async () => {
+    const tmpDir = setup();
+    const { server } = createTestSvr(tmpDir);
+    await new Promise(r => server.listen(0, r));
+    const port = server.address().port;
+
+    await fetchJSON(port, '/api/sources/shady-torrents', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ notes: 'only the $4.99 shelf' }),
+    });
+    const { status, data } = await fetchJSON(port, '/api/sources');
+    assert.equal(status, 200);
+    const updated = data.find(s => s.id === 'shady-torrents');
+    assert.match(updated.notes, /\$4\.99 shelf/);
+
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+});
+
 // --- Preferences (per-category) ---
 
 describe('GET /api/preferences', () => {


### PR DESCRIPTION
## Summary

Adds an editable `notes:` field to each source. Operators use it to write rules like "only recommend AppleTV content from the \$4.99 shelf" or "only English-language items". The agent reads notes when working with a source (CLAUDE.md instruction lands in a follow-up PR on contentbot).

## Changes

- **Schema** — new optional `notes: |` multiline field on entries in `sources.yaml`. Backwards-compatible.
- **Route** — `PATCH /api/sources/:id` with `{notes: "..."}`. Empty string clears the field. 404 for unknown ids, 400 for non-string notes or invalid JSON.
- **UI** — each approved source row gains an inline Notes block. Empty → "+ Add notes" button. Populated → preserved-whitespace block + Edit button. Click opens a textarea with Save/Cancel inline. No modal.
- **Tests** — 6 new unit tests on PATCH (write, clear, 404, 400×2, GET round-trip).

## Test plan

- [x] `npm test` — 456/456 node tests pass
- [x] Layer 2 API round-trip against the running contentbot portal: PATCH writes notes to YAML; subsequent GET surfaces them; empty string removes the key from YAML; 404 on unknown id
- [x] Rendered HTML contains the new UI symbols (`renderNotesBlock`, `editSourceNotes`, `saveSourceNotes`, etc.) and the JS parses cleanly
- [ ] **Full DOM interaction not verified** — Playwright isn't installed in this dev environment. The JS structure and API contract are tested; the click-flow Add → textarea → Save → reload was not exercised in a real browser. Please open the sources tab in your browser to confirm the affordance behaves as expected.