### PR TITLE
feat(library): report button for non-taste rejection

### DIFF
--- a/lib/routes/library.js
+++ b/lib/routes/library.js
@@ -6,6 +6,8 @@ const path = require('path');
 const yaml = require('js-yaml');
 const { sendJSON, readBody, dataPath, getDataDir } = require('../helpers');
 
+const REPORT_CATEGORIES = ['language', 'format', 'broken-link', 'wrong-item', 'other'];
+
 function getLibraryItems(itemsDir, feedbackDir) {
   try {
     const files = fs.readdirSync(itemsDir)
@@ -155,6 +157,86 @@ function register(routes, config) {
       return new Date(item.discovered) > cutoff;
     });
     sendJSON(res, 200, recent);
+  };
+
+  // POST /api/feedback/library/:id/report — operator reports a quality/format
+  // issue with a library item. Distinct from up/down rating: a report is not
+  // a taste signal but a complaint about how the item was delivered
+  // (Spanish edition, wrong format, dead link, wrong item, etc.).
+  //
+  // On submit:
+  //   1. Item moves from <data>/content/items/<id>.yaml to
+  //      <data>/content/reported/<id>.yaml with a _report: block.
+  //   2. A feedback file lands at <data>/input/feedback/<id>.report.yaml so
+  //      the agent processes the report on its next cycle.
+  routes['POST /api/feedback/library/:id/report'] = (req, res) => {
+    const id = req.params.id;
+    if (id.includes('/') || id.includes('\\') || id.includes('..')) {
+      return sendJSON(res, 400, { error: 'Invalid id' });
+    }
+
+    readBody(req).then(body => {
+      let data;
+      try { data = JSON.parse(body); }
+      catch { return sendJSON(res, 400, { error: 'Invalid JSON' }); }
+
+      const reason = (data.reason || '').trim();
+      if (!reason) {
+        return sendJSON(res, 400, { error: 'reason is required' });
+      }
+
+      let category = (data.category || 'other').trim().toLowerCase();
+      if (!REPORT_CATEGORIES.includes(category)) {
+        return sendJSON(res, 400, {
+          error: `category must be one of: ${REPORT_CATEGORIES.join(', ')}`,
+        });
+      }
+
+      // Locate the item file (.yaml or .yml)
+      let itemPath = path.join(itemsDir, id + '.yaml');
+      if (!fs.existsSync(itemPath)) itemPath = path.join(itemsDir, id + '.yml');
+      if (!fs.existsSync(itemPath)) {
+        return sendJSON(res, 404, { error: 'Item not found in library' });
+      }
+
+      // Load + annotate with _report block
+      let item;
+      try {
+        item = yaml.load(fs.readFileSync(itemPath, 'utf-8'));
+      } catch (err) {
+        return sendJSON(res, 500, { error: 'Failed to read item: ' + err.message });
+      }
+      if (!item || typeof item !== 'object') {
+        return sendJSON(res, 500, { error: 'Item file is malformed' });
+      }
+
+      const now = new Date().toISOString();
+      const enriched = {
+        ...item,
+        _report: { reported_at: now, category, reason },
+      };
+
+      // Move into reported/
+      const reportedDir = dataPath(config, 'content', 'reported');
+      fs.mkdirSync(reportedDir, { recursive: true });
+      const reportedPath = path.join(reportedDir, id + '.yaml');
+      fs.writeFileSync(reportedPath, yaml.dump(enriched, { lineWidth: -1 }));
+      try { fs.unlinkSync(itemPath); } catch {}
+
+      // Drop a feedback file so the agent processes it next cycle
+      fs.mkdirSync(feedbackDir, { recursive: true });
+      const fbPath = path.join(feedbackDir, id + '.report.yaml');
+      const fbYaml = `item: ${id}\nreported_at: ${now}\nreport:\n  category: ${category}\n  reason: |\n${reason.split('\n').map(l => '    ' + l).join('\n')}\n`;
+      fs.writeFileSync(fbPath, fbYaml);
+
+      const agentDir = config.agentDir || '.';
+      sendJSON(res, 200, {
+        ok: true,
+        id,
+        moved_to: path.relative(agentDir, reportedPath),
+        feedback_at: path.relative(agentDir, fbPath),
+      });
+    });
   };
 }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -80,9 +80,15 @@ function createServer(config, { routes, getHTML }) {
       }
 
       // For GET requests, check response cache
-      // Skip caching for lightweight/frequently-polled endpoints
+      // Skip caching for lightweight/frequently-polled endpoints OR for endpoints
+      // whose state can be mutated by writes on a DIFFERENT pathname (cache
+      // invalidation only matches sibling paths via prefix overlap).
+      // /api/library is affected by POST /api/feedback/library/:id and
+      // /api/feedback/library/:id/report (report moves the item file out),
+      // and the cache key doesn't overlap with those write paths.
       const skipCache = pathname === '/api/badges' || pathname === '/api/status'
         || pathname === '/api/next-run' || pathname === '/api/harness/status' || pathname === '/api/claude/status'
+        || pathname === '/api/library' || pathname === '/api/library/recent'
         || pathname.startsWith('/api/media/')
         || (url.searchParams.has('after') && (pathname === '/api/journal' || pathname.endsWith('/journal')));
       if (req.method === 'GET' && !skipCache) {

--- a/lib/ui/tabs/library.js
+++ b/lib/ui/tabs/library.js
@@ -212,15 +212,20 @@ async function viewLibraryItem(id) {
       html += '</div>';
     }
 
-    html += '<div style="display:flex;gap:8px;margin-bottom:8px">';
+    html += '<div style="display:flex;gap:8px;margin-bottom:8px;align-items:center">';
     html += '<button class="refresh-btn" onclick="submitLibraryFeedback(\\'' + escapeHtml(id) + '\\', \\'up\\')" style="font-size:18px;padding:4px 12px">👍</button>';
     html += '<button class="refresh-btn" onclick="submitLibraryFeedback(\\'' + escapeHtml(id) + '\\', \\'down\\')" style="font-size:18px;padding:4px 12px">👎</button>';
+    html += '<button class="refresh-btn" onclick="openReportModal(\\'' + escapeHtml(id) + '\\')" style="font-size:13px;padding:6px 12px;margin-left:auto;background:#fff3e0;color:#bf360c;border:1px solid #ffcc80" title="Report this item as unacceptable for non-taste reasons (wrong language, bad format, broken link, wrong item)">⚐ Report</button>';
     html += '</div>';
     html += '<textarea id="lib-feedback-notes" rows="3" placeholder="What did you like or dislike about this? Your text feedback is the most valuable signal." style="width:100%;box-sizing:border-box;padding:8px;border:1px solid #ddd;border-radius:4px;font-size:13px;font-family:inherit;resize:vertical"></textarea>';
     html += '<button class="refresh-btn" onclick="submitLibraryFeedback(\\'' + escapeHtml(id) + '\\')" style="margin-top:6px">Submit feedback</button>';
     html += '</div>';
 
     html += '</div></div>';
+
+    // Report modal (hidden by default)
+    html += renderReportModal();
+
     contentEl.innerHTML = html;
     contentEl.scrollTop = 0;
   } catch (err) {
@@ -246,6 +251,88 @@ async function submitLibraryFeedback(id, rating) {
       viewLibraryItem(id);
     }
   } catch {}
+}
+
+function renderReportModal() {
+  var html = '<div id="report-modal" style="display:none;position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.5);z-index:1000;align-items:center;justify-content:center">';
+  html += '<div style="background:#fff;border-radius:8px;padding:20px;width:480px;max-width:90vw;max-height:90vh;overflow:auto;box-shadow:0 10px 40px rgba(0,0,0,0.3)">';
+  html += '<h2 style="margin:0 0 4px;font-size:18px;color:#bf360c">⚐ Report item</h2>';
+  html += '<p style="margin:0 0 16px;font-size:13px;color:#666">Use Report when an item is unacceptable for non-taste reasons — wrong language, wrong format, broken link, etc. For "I just didn\\'t like it", use 👎 instead.</p>';
+  html += '<div style="margin-bottom:12px">';
+  html += '<label style="display:block;font-size:12px;font-weight:600;color:#444;margin-bottom:4px">Reason <span style="color:#c62828">*</span></label>';
+  html += '<textarea id="report-reason" rows="4" placeholder="What\\'s wrong with this item? (Required.)" style="width:100%;box-sizing:border-box;padding:8px;border:1px solid #ddd;border-radius:4px;font-size:13px;font-family:inherit;resize:vertical"></textarea>';
+  html += '</div>';
+  html += '<div style="margin-bottom:16px">';
+  html += '<label style="display:block;font-size:12px;font-weight:600;color:#444;margin-bottom:4px">Category</label>';
+  html += '<select id="report-category" style="width:100%;padding:8px;border:1px solid #ddd;border-radius:4px;font-size:13px">';
+  html += '<option value="other">Other</option>';
+  html += '<option value="language">Language (wrong language edition)</option>';
+  html += '<option value="format">Format (wrong file type, borrowable-only, etc.)</option>';
+  html += '<option value="broken-link">Broken link (URL was valid at publish but is now dead)</option>';
+  html += '<option value="wrong-item">Wrong item (not what was recommended)</option>';
+  html += '</select>';
+  html += '</div>';
+  html += '<div style="display:flex;gap:8px;justify-content:flex-end">';
+  html += '<button class="refresh-btn" onclick="closeReportModal()" style="padding:8px 16px">Cancel</button>';
+  html += '<button class="refresh-btn" id="report-submit-btn" style="padding:8px 16px;background:#fff3e0;color:#bf360c;border:1px solid #ffcc80">Submit report</button>';
+  html += '</div>';
+  html += '</div>';
+  html += '</div>';
+  return html;
+}
+
+var __reportItemId = null;
+
+function openReportModal(id) {
+  __reportItemId = id;
+  var modal = document.getElementById('report-modal');
+  if (!modal) return;
+  modal.style.display = 'flex';
+  // Reset fields
+  var ta = document.getElementById('report-reason');
+  var cat = document.getElementById('report-category');
+  if (ta) { ta.value = ''; setTimeout(function() { ta.focus(); }, 0); }
+  if (cat) cat.value = 'other';
+  // Wire submit (re-wire each open so the closure captures the right id)
+  var btn = document.getElementById('report-submit-btn');
+  if (btn) btn.onclick = function() { submitReport(__reportItemId); };
+}
+
+function closeReportModal() {
+  __reportItemId = null;
+  var modal = document.getElementById('report-modal');
+  if (modal) modal.style.display = 'none';
+}
+
+async function submitReport(id) {
+  var ta = document.getElementById('report-reason');
+  var cat = document.getElementById('report-category');
+  var reason = ta ? ta.value.trim() : '';
+  var category = cat ? cat.value : 'other';
+  if (!reason) {
+    alert('Reason is required.');
+    if (ta) ta.focus();
+    return;
+  }
+  try {
+    var res = await fetch('/api/feedback/library/' + encodeURIComponent(id) + '/report', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ reason: reason, category: category })
+    });
+    if (!res.ok) {
+      var err = await res.json().catch(function() { return null; });
+      alert('Report failed: ' + (err && err.error ? err.error : 'HTTP ' + res.status));
+      return;
+    }
+    closeReportModal();
+    // Item is gone from the library now — return to the grid
+    if (typeof loadLibrary === 'function') {
+      loadLibrary();
+    }
+  } catch (e) {
+    alert('Report failed: ' + (e && e.message ? e.message : 'network error'));
+  }
 }
 
 async function loadLibrary() {

--- a/test/library.test.js
+++ b/test/library.test.js
@@ -272,3 +272,174 @@ describe('POST /api/feedback/library/:id', () => {
     server.close();
   });
 });
+
+describe('POST /api/feedback/library/:id/report', () => {
+  function buildAgent() {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'library-report-'));
+    const itemsDir = path.join(tmpDir, 'content', 'items');
+    fs.mkdirSync(itemsDir, { recursive: true });
+    const item = {
+      id: 'heat-1995',
+      title: 'Heat',
+      category: 'movies',
+      source: 'hulu',
+      source_url: 'https://www.hulu.com/movie/heat',
+      status: 'linked',
+    };
+    fs.writeFileSync(
+      path.join(itemsDir, 'heat-1995.yaml'),
+      require('js-yaml').dump(item, { lineWidth: -1 })
+    );
+    return tmpDir;
+  }
+
+  it('moves the item to content/reported/ with a _report block', async () => {
+    const tmpDir = buildAgent();
+    const { server } = createLibraryServer({ agentDir: tmpDir });
+    await new Promise(r => server.listen(0, r));
+    const port = server.address().port;
+
+    const { status, data } = await fetchJSON(port, '/api/feedback/library/heat-1995/report', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ reason: 'Spanish edition, not English', category: 'language' }),
+    });
+    assert.equal(status, 200);
+    assert.equal(data.ok, true);
+
+    // Item gone from items/, present in reported/ with the _report block
+    assert.ok(!fs.existsSync(path.join(tmpDir, 'content', 'items', 'heat-1995.yaml')), 'item should be gone from items/');
+    const reportedPath = path.join(tmpDir, 'content', 'reported', 'heat-1995.yaml');
+    assert.ok(fs.existsSync(reportedPath), 'item should be in reported/');
+    const reportedYaml = require('js-yaml').load(fs.readFileSync(reportedPath, 'utf-8'));
+    assert.equal(reportedYaml.id, 'heat-1995');
+    assert.equal(reportedYaml._report.category, 'language');
+    assert.match(reportedYaml._report.reason, /Spanish edition/);
+    assert.ok(reportedYaml._report.reported_at);
+
+    // Feedback file dropped for the agent
+    const fbPath = path.join(tmpDir, 'input', 'feedback', 'heat-1995.report.yaml');
+    assert.ok(fs.existsSync(fbPath), 'feedback file should be created');
+    const fbYaml = require('js-yaml').load(fs.readFileSync(fbPath, 'utf-8'));
+    assert.equal(fbYaml.item, 'heat-1995');
+    assert.equal(fbYaml.report.category, 'language');
+    assert.match(fbYaml.report.reason, /Spanish edition/);
+
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('defaults category to "other" when omitted', async () => {
+    const tmpDir = buildAgent();
+    const { server } = createLibraryServer({ agentDir: tmpDir });
+    await new Promise(r => server.listen(0, r));
+    const port = server.address().port;
+
+    const { status } = await fetchJSON(port, '/api/feedback/library/heat-1995/report', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ reason: 'just bad' }),
+    });
+    assert.equal(status, 200);
+
+    const reportedYaml = require('js-yaml').load(
+      fs.readFileSync(path.join(tmpDir, 'content', 'reported', 'heat-1995.yaml'), 'utf-8')
+    );
+    assert.equal(reportedYaml._report.category, 'other');
+
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('rejects missing reason', async () => {
+    const tmpDir = buildAgent();
+    const { server } = createLibraryServer({ agentDir: tmpDir });
+    await new Promise(r => server.listen(0, r));
+    const port = server.address().port;
+
+    const { status, data } = await fetchJSON(port, '/api/feedback/library/heat-1995/report', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ category: 'language' }),
+    });
+    assert.equal(status, 400);
+    assert.match(data.error, /reason is required/);
+
+    // Item should still be in items/
+    assert.ok(fs.existsSync(path.join(tmpDir, 'content', 'items', 'heat-1995.yaml')));
+
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('rejects whitespace-only reason', async () => {
+    const tmpDir = buildAgent();
+    const { server } = createLibraryServer({ agentDir: tmpDir });
+    await new Promise(r => server.listen(0, r));
+    const port = server.address().port;
+
+    const { status, data } = await fetchJSON(port, '/api/feedback/library/heat-1995/report', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ reason: '   \n  ' }),
+    });
+    assert.equal(status, 400);
+    assert.match(data.error, /reason is required/);
+
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('rejects invalid category', async () => {
+    const tmpDir = buildAgent();
+    const { server } = createLibraryServer({ agentDir: tmpDir });
+    await new Promise(r => server.listen(0, r));
+    const port = server.address().port;
+
+    const { status, data } = await fetchJSON(port, '/api/feedback/library/heat-1995/report', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ reason: 'x', category: 'bogus' }),
+    });
+    assert.equal(status, 400);
+    assert.match(data.error, /category must be one of/);
+
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('returns 404 for an item not in the library', async () => {
+    const tmpDir = buildAgent();
+    const { server } = createLibraryServer({ agentDir: tmpDir });
+    await new Promise(r => server.listen(0, r));
+    const port = server.address().port;
+
+    const { status, data } = await fetchJSON(port, '/api/feedback/library/no-such-item/report', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ reason: 'x', category: 'other' }),
+    });
+    assert.equal(status, 404);
+    assert.match(data.error, /not found/i);
+
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('rejects invalid id with path traversal', async () => {
+    const tmpDir = buildAgent();
+    const { server } = createLibraryServer({ agentDir: tmpDir });
+    await new Promise(r => server.listen(0, r));
+    const port = server.address().port;
+
+    const { status } = await fetchJSON(port, '/api/feedback/library/' + encodeURIComponent('../../etc/passwd') + '/report', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ reason: 'x' }),
+    });
+    assert.equal(status, 400);
+
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a Report path distinct from up/down rating. Use case: an item is unacceptable for non-taste reasons (Spanish edition when English is required, wrong format, dead link, wrong item). The user is saying "this isn't bad content, but this delivery is wrong" — which shouldn't update taste preferences.

## Behavior

- `POST /api/feedback/library/:id/report` with `{ reason: <required>, category: <optional> }`
- Categories: `language | format | broken-link | wrong-item | other`
- On submit:
  - Item moves to `<dataDir>/content/reported/<id>.yaml` with a `_report:` block (reported_at, category, reason). Item disappears from `/api/library` immediately.
  - Feedback file written to `<dataDir>/input/feedback/<id>.report.yaml` so the agent processes it next cycle.

## UI

⚐ Report button on the library detail panel, next to the up/down buttons. Opens a modal with required reason textarea + category dropdown. Modal closes and library reloads on success.

## Bonus fix: stale cache on /api/library

While testing, found that `/api/library` was cached for 10s and the existing cache-invalidation logic only matches sibling pathnames via prefix overlap. A POST to `/api/feedback/library/:id/report` (or the existing `/api/feedback/library/:id` for ratings) didn't clear the `/api/library` cache. Added both library read paths to `skipCache` in `lib/server.js`.

## Test plan

- [x] `npm test` — 463/463 node tests pass (+7 new for report)
- [x] All shell tests pass
- [x] Layer 2 e2e against the running contentbot portal: synthetic item → POST report → item moved to `reported/` with correct `_report` block, feedback file written, `/api/library` immediately reflects removal (cache invalidation working)
- [x] Validation: 400 missing reason, 400 invalid category, 404 unknown id, 400 path traversal
- [x] HTML response embeds `openReportModal`, `submitReport`, `report-reason`, `report-category`, "⚐ Report"
- [ ] **Full DOM interaction not driven** — Playwright unavailable in this dev environment. API contract + HTML structure verified; please open the library detail view in your browser to confirm the modal renders + submits cleanly.

## Follow-up

Contentbot CLAUDE.md PR will add a "Processing Reports" section instructing the agent to read each `*.report.yaml` feedback file, assess what (if anything) needs updating in CLAUDE.md / source notes / verification logic, log the decision in the journal, and move the file to `processed/`.