### PR TITLE
feat(publish-content): source extractors + tenant preference checking

### DIFF
--- a/lib/content-validator.js
+++ b/lib/content-validator.js
@@ -1,23 +1,33 @@
 // content-validator.js — Validate content items before they land in
 // <dataDir>/content/items/. Enforced via scripts/publish-content.sh.
 //
-// Two layers:
-//   A. Host allowlist — every URL field must match a host of an approved
-//      source in <dataDir>/config/sources.yaml. The item's primary `source`
-//      field must reference an approved source id.
+// Layers:
+//   A. Required fields + host allowlist — every URL field must match a host
+//      of an approved source in <dataDir>/config/sources.yaml. The item's
+//      primary `source` field must reference an approved source id.
 //   B. Live fetch — HEAD (GET fallback on 405) with 10s timeout and 2
 //      retries on connection errors. 2xx/3xx = pass, anything else = fail.
+//   C. Optional source-extraction + tenant-preference check — when the item's
+//      source has a registered extractor (see lib/extractors/), the
+//      extractor fetches structured facts (language, available_formats,
+//      borrowable_only, ...) and lib/preference-checker.js applies tenant
+//      constraints from <dataDir>/memory/preferences.yaml at
+//      preferences.<category>.constraints. Tenants without constraints get
+//      Layers A+B only — no change from prior behavior.
 //
 // Cover URLs (`metadata.cover_url`) are intentionally NOT validated — they
-// often come from third-party CDNs that aren't content sources. The safety
-// concern is navigational/source URLs, not thumbnails.
+// often come from third-party CDNs that aren't content sources.
 //
-// Zero external deps. Uses only Node built-ins. Designed to be reusable
-// from a CLI wrapper and, eventually, an HTTP route on the portal.
+// Designed to be reusable from a CLI wrapper and the portal.
 
 const http = require('http');
 const https = require('https');
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
 const { URL } = require('url');
+const extractors = require('./extractors');
+const preferenceChecker = require('./preference-checker');
 
 const DEFAULTS = {
   fetchTimeoutMs: 10000,
@@ -179,18 +189,50 @@ function collectReferenceUrls(item) {
 }
 
 /**
+ * Look up tenant constraints for a given category. Reads
+ * <dataRoot>/memory/preferences.yaml and returns
+ * preferences[category].constraints, or null if not configured.
+ *
+ * Returning null is the supported "no constraints for this category"
+ * path — Layer C is skipped and only Layers A+B apply. This is what
+ * keeps the framework backward-compatible for tenants that haven't
+ * adopted the constraints subtree (and what makes the framework safe
+ * to share across agents with different preference shapes).
+ */
+function loadConstraints(dataRoot, category) {
+  if (!dataRoot || !category) return null;
+  const p = path.join(dataRoot, 'memory', 'preferences.yaml');
+  let parsed;
+  try { parsed = yaml.load(fs.readFileSync(p, 'utf-8')); }
+  catch { return null; }
+  const prefs = parsed && parsed.preferences;
+  const catEntry = prefs && prefs[category];
+  return (catEntry && catEntry.constraints) || null;
+}
+
+/**
  * Validate a content item against a sources registry.
  *
  * @param {object} item — parsed YAML for the content item
  * @param {Array}  sources — entries from sources.yaml
- * @param {object} options — { skipFetch?: bool, fetchTimeoutMs?, fetchRetries?, fetchRetryDelaysMs? }
- * @returns {Promise<{ok: boolean, errors: Array<{field, url?, value?, reason}>}>}
+ * @param {object} options
+ *   - skipFetch?: bool                — skip Layer B live fetches
+ *   - skipExtraction?: bool           — skip Layer C extractor + preference check
+ *   - dataRoot?: string               — used by Layer C to find preferences.yaml
+ *   - fetchTimeoutMs?, fetchRetries?, fetchRetryDelaysMs?, userAgent?
+ * @returns {Promise<{
+ *   ok: boolean,
+ *   errors: Array<{field, url?, value?, reason}>,
+ *   warnings: Array,
+ *   extractor?: { source: string, facts: object | { _error: string } },
+ * }>}
  */
 async function validateItem(item, sources, options = {}) {
   const errors = [];
+  const warnings = [];
 
   if (!item || typeof item !== 'object') {
-    return { ok: false, errors: [{ field: '(root)', reason: 'item is not an object' }] };
+    return { ok: false, errors: [{ field: '(root)', reason: 'item is not an object' }], warnings };
   }
 
   for (const f of REQUIRED_FIELDS) {
@@ -198,7 +240,7 @@ async function validateItem(item, sources, options = {}) {
       errors.push({ field: f, reason: 'required field missing' });
     }
   }
-  if (errors.length > 0) return { ok: false, errors };
+  if (errors.length > 0) return { ok: false, errors, warnings };
 
   const approvedSources = (Array.isArray(sources) ? sources : []).filter(s => s && s.status === 'approved');
   const approvedById = new Map(approvedSources.map(s => [s.id, s]));
@@ -233,7 +275,7 @@ async function validateItem(item, sources, options = {}) {
   }
 
   // If structural checks failed, don't bother with fetches
-  if (errors.length > 0) return { ok: false, errors };
+  if (errors.length > 0) return { ok: false, errors, warnings };
 
   // Layer B: live fetch (skip in --skip-fetch mode). Sources and references
   // get the same liveness treatment — 2xx/3xx pass, anything else fails.
@@ -258,7 +300,33 @@ async function validateItem(item, sources, options = {}) {
     }
   }
 
-  return { ok: errors.length === 0, errors };
+  // Layer C: extractor + preference check. Optional and graceful — tenants
+  // without an extractor for the source's host get only A+B (no change from
+  // legacy behavior). Tenants without preferences.<cat>.constraints in
+  // memory/preferences.yaml get no preference enforcement.
+  let extractorReport;
+  if (!options.skipExtraction && errors.length === 0) {
+    const extractor = extractors.lookup(item.source_url);
+    if (extractor) {
+      const facts = await extractor.extract(item.source_url, options);
+      extractorReport = { source: item.source_url, facts };
+      if (!facts || facts._error) {
+        warnings.push({
+          field: 'source_url',
+          reason: `extractor failed: ${facts && facts._error}; preference check skipped`,
+        });
+      } else {
+        const constraints = loadConstraints(options.dataRoot, item.category);
+        if (constraints) {
+          const result = preferenceChecker.check(facts, constraints);
+          for (const e of result.errors) errors.push(e);
+          for (const w of result.warnings) warnings.push(w);
+        }
+      }
+    }
+  }
+
+  return { ok: errors.length === 0, errors, warnings, ...(extractorReport ? { extractor: extractorReport } : {}) };
 }
 
-module.exports = { validateItem, fetchUrl, collectUrls, collectReferenceUrls, buildHostsMap, DEFAULTS };
+module.exports = { validateItem, fetchUrl, collectUrls, collectReferenceUrls, buildHostsMap, loadConstraints, DEFAULTS };

--- a/lib/extractors/archive-org.js
+++ b/lib/extractors/archive-org.js
@@ -1,0 +1,163 @@
+// extractors/archive-org.js — Generic Archive.org metadata extractor.
+//
+// Given an Archive.org `details` URL, fetches the public metadata API and
+// returns structured facts about the item. No agent-specific or user-specific
+// rules live here — extractors only report what the page says. Tenant
+// preference enforcement happens in lib/preference-checker.js.
+//
+// Reusable across any category that consumes Archive.org (comics today,
+// audiobooks and books later — same site, same extractor).
+//
+// Public API: extract(url, opts) -> Promise<facts | { _error }>.
+
+const https = require('https');
+const { URL } = require('url');
+
+const METADATA_API = 'https://archive.org/metadata/';
+const DEFAULTS = {
+  fetchTimeoutMs: 10000,
+  userAgent: 'agent-portal-publish-validator/1.0',
+};
+
+// Map Archive.org file `format` strings to lowercase extension tokens we can
+// compare against preference constraints. Substring match; case-insensitive.
+const FORMAT_TOKEN_RULES = [
+  { token: 'cbz', match: /comic book zip|^cbz$|\.cbz$/i },
+  { token: 'cbr', match: /comic book rar|^cbr$|\.cbr$/i },
+  { token: 'pdf', match: /text pdf|^pdf$|\.pdf$/i },
+  { token: 'epub', match: /^epub$|\.epub$/i },
+  { token: 'mp3', match: /vbr mp3|mp3/i },
+  { token: 'mp4', match: /mpeg-?4|mp4/i },
+];
+
+function extractArchiveOrgId(sourceUrl) {
+  try {
+    const u = new URL(sourceUrl);
+    if (!/^archive\.org$/i.test(u.hostname)) return null;
+    const m = u.pathname.match(/^\/details\/([^/?#]+)/);
+    return m ? decodeURIComponent(m[1]) : null;
+  } catch {
+    return null;
+  }
+}
+
+function fetchJson(url, opts) {
+  return new Promise(resolve => {
+    let parsed;
+    try { parsed = new URL(url); }
+    catch { return resolve({ _error: `invalid URL: ${url}` }); }
+
+    const req = https.request(parsed, {
+      method: 'GET',
+      headers: { 'User-Agent': opts.userAgent, Accept: 'application/json' },
+      timeout: opts.fetchTimeoutMs,
+    }, res => {
+      const status = res.statusCode;
+      if (status < 200 || status >= 300) {
+        res.resume();
+        return resolve({ _error: `HTTP ${status} from ${url}` });
+      }
+      const chunks = [];
+      res.on('data', c => chunks.push(c));
+      res.on('end', () => {
+        const body = Buffer.concat(chunks).toString('utf-8');
+        try { resolve(JSON.parse(body)); }
+        catch (e) { resolve({ _error: `JSON parse failed: ${e.message}` }); }
+      });
+    });
+    req.on('error', err => resolve({ _error: err.code || err.message }));
+    req.on('timeout', () => { req.destroy(); resolve({ _error: 'timeout' }); });
+    req.end();
+  });
+}
+
+function normaliseLanguage(lang) {
+  if (lang == null) return null;
+  if (Array.isArray(lang)) lang = lang[0];
+  if (typeof lang !== 'string') return null;
+  return lang.trim().toLowerCase() || null;
+}
+
+function normaliseYear(year, date) {
+  for (const v of [year, date]) {
+    if (v == null) continue;
+    const s = String(v);
+    const m = s.match(/(\d{4})/);
+    if (m) return parseInt(m[1], 10);
+  }
+  return null;
+}
+
+function tokeniseFormats(files) {
+  if (!Array.isArray(files)) return [];
+  const tokens = new Set();
+  for (const f of files) {
+    const fmt = (f && f.format) || '';
+    const name = (f && f.name) || '';
+    for (const rule of FORMAT_TOKEN_RULES) {
+      if (rule.match.test(fmt) || rule.match.test(name)) {
+        tokens.add(rule.token);
+      }
+    }
+  }
+  return [...tokens];
+}
+
+function detectBorrowableOnly(raw, formats) {
+  // Heuristic: Archive.org "borrowable" items are flagged either explicitly
+  // (`access-restricted-item: true`) or implicitly (no freely-downloadable
+  // file formats present — only ACS-encrypted PDFs/EPUBs).
+  const meta = raw.metadata || {};
+  const restricted = String(meta['access-restricted-item'] || '').toLowerCase() === 'true';
+  const freelyDownloadable = formats.length > 0;
+  return restricted || !freelyDownloadable;
+}
+
+/**
+ * Extract structured facts for an Archive.org item.
+ * @param {string} sourceUrl — any Archive.org URL (`/details/<id>` form expected).
+ * @param {object} opts — { fetchTimeoutMs?, userAgent? }
+ * @returns {Promise<{
+ *   identifier: string,
+ *   language: string | null,
+ *   available_formats: string[],
+ *   borrowable_only: boolean,
+ *   title: string | null,
+ *   creator: string | null,
+ *   year: number | null,
+ *   thumbnail_url: string | null,
+ *   raw_metadata: object,
+ * } | { _error: string }>}
+ */
+async function extract(sourceUrl, opts = {}) {
+  const identifier = extractArchiveOrgId(sourceUrl);
+  if (!identifier) {
+    return { _error: `not an archive.org details URL: ${sourceUrl}` };
+  }
+
+  const definedOpts = Object.fromEntries(
+    Object.entries(opts).filter(([, v]) => v !== undefined)
+  );
+  const merged = { ...DEFAULTS, ...definedOpts };
+
+  const raw = await fetchJson(METADATA_API + encodeURIComponent(identifier), merged);
+  if (raw._error) return { _error: raw._error };
+
+  const meta = raw.metadata || {};
+  const files = raw.files || [];
+  const formats = tokeniseFormats(files);
+
+  return {
+    identifier,
+    language: normaliseLanguage(meta.language),
+    available_formats: formats,
+    borrowable_only: detectBorrowableOnly(raw, formats),
+    title: typeof meta.title === 'string' ? meta.title.trim() : null,
+    creator: typeof meta.creator === 'string' ? meta.creator : (Array.isArray(meta.creator) ? meta.creator.join(', ') : null),
+    year: normaliseYear(meta.year, meta.date),
+    thumbnail_url: `https://archive.org/services/img/${encodeURIComponent(identifier)}`,
+    raw_metadata: meta,
+  };
+}
+
+module.exports = { extract, extractArchiveOrgId, tokeniseFormats, normaliseLanguage };

--- a/lib/extractors/index.js
+++ b/lib/extractors/index.js
@@ -1,0 +1,28 @@
+// extractors/index.js — Hostname → extractor registry.
+//
+// Source extractors are reusable across categories and tenants. They report
+// facts about a URL with no judgment about whether those facts are
+// "acceptable" — that's the preference-checker's job (see
+// lib/preference-checker.js).
+//
+// To add a new extractor: drop a module under lib/extractors/<name>.js that
+// exports an `extract(url, opts)` function, then register its hostnames
+// here. No agent-specific or per-tenant code lives in this file.
+
+const archiveOrg = require('./archive-org');
+
+const REGISTRY = [
+  { hosts: ['archive.org'], extractor: archiveOrg },
+];
+
+function lookup(url) {
+  let host;
+  try { host = new URL(url).hostname.toLowerCase(); }
+  catch { return null; }
+  for (const entry of REGISTRY) {
+    if (entry.hosts.includes(host)) return entry.extractor;
+  }
+  return null;
+}
+
+module.exports = { lookup, REGISTRY };

--- a/lib/preference-checker.js
+++ b/lib/preference-checker.js
@@ -1,0 +1,126 @@
+// preference-checker.js — Generic tenant-preference enforcement.
+//
+// Applies a tenant's per-category constraints to extractor-derived facts.
+// No tenant-specific values live here; the constraints come from the
+// caller (typically <agentDir>/<dataDir>/memory/preferences.yaml at the path
+// `preferences.<category>.constraints`).
+//
+// This module is shared framework code in agent-portal — it MUST NOT contain
+// any agent-specific preferences. Multi-tenant safety depends on that.
+//
+// Constraints schema (v1):
+//
+//   formats:
+//     accept: [string, ...]      # tokens like cbz, cbr, pdf — case-insensitive
+//   languages:
+//     accept: [string, ...]      # ISO 639-1/2 codes — "en", "eng", "english"
+//                                # are treated as equivalent
+//   borrowable_ok: bool          # if false, facts.borrowable_only=true is rejected
+//   unknown_field_policy:        # what to do when a fact is null/undefined
+//     language: reject | warn | accept   (default: warn)
+//     formats:  reject | warn | accept   (default: warn)
+//     borrowable_only: reject | warn | accept  (default: warn)
+//
+// Returns { errors: [...], warnings: [...] } where each entry is
+// { field, reason, value? } in the same shape used by content-validator.
+
+const LANGUAGE_ALIASES = {
+  en: 'en', eng: 'en', english: 'en',
+  es: 'es', spa: 'es', spanish: 'es',
+  fr: 'fr', fre: 'fr', fra: 'fr', french: 'fr',
+  de: 'de', ger: 'de', deu: 'de', german: 'de',
+  ja: 'ja', jpn: 'ja', japanese: 'ja',
+  zh: 'zh', chi: 'zh', zho: 'zh', chinese: 'zh',
+};
+
+function normLang(s) {
+  if (s == null) return null;
+  const k = String(s).trim().toLowerCase();
+  return LANGUAGE_ALIASES[k] || k;
+}
+
+function getUnknownPolicy(constraints, key) {
+  const p = (constraints.unknown_field_policy || {})[key];
+  if (p === 'reject' || p === 'warn' || p === 'accept') return p;
+  return 'warn';
+}
+
+function pushUnknown(out, field, policy) {
+  if (policy === 'accept') return;
+  const entry = { field, reason: 'fact unavailable from extractor; cannot verify against constraints' };
+  if (policy === 'reject') out.errors.push(entry);
+  else out.warnings.push(entry);
+}
+
+function checkLanguage(facts, constraints, out) {
+  const accept = (constraints.languages && Array.isArray(constraints.languages.accept))
+    ? constraints.languages.accept.map(normLang)
+    : null;
+  if (!accept || accept.length === 0) return; // no constraint configured
+
+  if (facts.language == null) {
+    pushUnknown(out, 'language', getUnknownPolicy(constraints, 'language'));
+    return;
+  }
+  const got = normLang(facts.language);
+  if (!accept.includes(got)) {
+    out.errors.push({
+      field: 'language',
+      value: facts.language,
+      reason: `language '${facts.language}' not in accept list ${JSON.stringify(constraints.languages.accept)}`,
+    });
+  }
+}
+
+function checkFormats(facts, constraints, out) {
+  const accept = (constraints.formats && Array.isArray(constraints.formats.accept))
+    ? constraints.formats.accept.map(s => String(s).toLowerCase())
+    : null;
+  if (!accept || accept.length === 0) return;
+
+  const available = Array.isArray(facts.available_formats) ? facts.available_formats : null;
+  if (!available || available.length === 0) {
+    pushUnknown(out, 'formats', getUnknownPolicy(constraints, 'formats'));
+    return;
+  }
+  const intersect = available.map(s => s.toLowerCase()).filter(t => accept.includes(t));
+  if (intersect.length === 0) {
+    out.errors.push({
+      field: 'formats',
+      value: facts.available_formats,
+      reason: `available formats ${JSON.stringify(facts.available_formats)} do not intersect accept list ${JSON.stringify(constraints.formats.accept)}`,
+    });
+  }
+}
+
+function checkBorrowable(facts, constraints, out) {
+  if (constraints.borrowable_ok !== false) return; // default: borrowable allowed
+  if (facts.borrowable_only == null) {
+    pushUnknown(out, 'borrowable_only', getUnknownPolicy(constraints, 'borrowable_only'));
+    return;
+  }
+  if (facts.borrowable_only === true) {
+    out.errors.push({
+      field: 'borrowable_only',
+      reason: 'item is borrowable-only and tenant policy is borrowable_ok=false',
+    });
+  }
+}
+
+/**
+ * Check facts against a tenant's category-level constraints.
+ * @param {object} facts — extractor output (see lib/extractors/*).
+ * @param {object} constraints — preferences.<category>.constraints subtree.
+ * @returns {{ errors: Array, warnings: Array }}
+ */
+function check(facts, constraints) {
+  const out = { errors: [], warnings: [] };
+  if (!constraints || typeof constraints !== 'object') return out;
+  if (!facts || typeof facts !== 'object') return out;
+  checkLanguage(facts, constraints, out);
+  checkFormats(facts, constraints, out);
+  checkBorrowable(facts, constraints, out);
+  return out;
+}
+
+module.exports = { check, normLang };

--- a/scripts/publish-content.js
+++ b/scripts/publish-content.js
@@ -12,11 +12,16 @@ const yaml = require('js-yaml');
 const { validateItem } = require('../lib/content-validator');
 
 function parseArgs(argv) {
-  const args = { positional: [], dryRun: false, skipFetch: false, agentDir: null };
+  const args = {
+    positional: [], dryRun: false, skipFetch: false, skipExtraction: false,
+    json: false, agentDir: null,
+  };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--dry-run') args.dryRun = true;
     else if (a === '--skip-fetch') args.skipFetch = true;
+    else if (a === '--skip-extraction') args.skipExtraction = true;
+    else if (a === '--json') args.json = true;
     else if (a === '--agent-dir') args.agentDir = argv[++i];
     else if (a === '--help' || a === '-h') args.help = true;
     else args.positional.push(a);
@@ -25,7 +30,7 @@ function parseArgs(argv) {
 }
 
 function usage(stream = process.stderr) {
-  stream.write('Usage: publish-content.js <yaml-path> [--agent-dir <dir>] [--dry-run] [--skip-fetch]\n');
+  stream.write('Usage: publish-content.js <yaml-path> [--agent-dir <dir>] [--dry-run] [--skip-fetch] [--skip-extraction] [--json]\n');
 }
 
 function readDataDirFromConfig(agentDir) {
@@ -77,45 +82,70 @@ async function main() {
     process.exit(2);
   }
 
-  const { ok, errors } = await validateItem(item, sources, { skipFetch: args.skipFetch });
+  const validation = await validateItem(item, sources, {
+    skipFetch: args.skipFetch,
+    skipExtraction: args.skipExtraction,
+    dataRoot,
+  });
+  const { ok, errors, warnings = [], extractor } = validation;
+
+  // Build a machine-readable result envelope used by the eval orchestrator
+  // (Type B / Type E scoring). Same shape regardless of pass/fail.
+  const result = {
+    ok,
+    id: item.id || null,
+    errors,
+    warnings,
+    extractor: extractor || null,
+    path: null,
+    dry_run: args.dryRun,
+  };
 
   if (ok) {
-    process.stdout.write(`PASS '${item.id}'\n`);
-    if (args.dryRun) {
-      process.stdout.write('(dry-run: no filesystem changes)\n');
-      process.exit(0);
+    if (!args.dryRun) {
+      fs.mkdirSync(itemsDir, { recursive: true });
+      const destPath = path.join(itemsDir, `${item.id}.yaml`);
+      fs.writeFileSync(destPath, yaml.dump(item, { lineWidth: -1 }));
+      if (path.resolve(yamlPath) !== path.resolve(destPath)) {
+        try { fs.unlinkSync(yamlPath); } catch {}
+      }
+      result.path = destPath;
     }
-    fs.mkdirSync(itemsDir, { recursive: true });
-    const destPath = path.join(itemsDir, `${item.id}.yaml`);
-    fs.writeFileSync(destPath, yaml.dump(item, { lineWidth: -1 }));
-    if (path.resolve(yamlPath) !== path.resolve(destPath)) {
-      try { fs.unlinkSync(yamlPath); } catch {}
+    if (args.json) {
+      process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    } else {
+      process.stdout.write(`PASS '${item.id}'\n`);
+      if (args.dryRun) process.stdout.write('(dry-run: no filesystem changes)\n');
+      else process.stdout.write(`-> ${result.path}\n`);
+      if (warnings.length) process.stdout.write(`(${warnings.length} warning${warnings.length === 1 ? '' : 's'})\n`);
     }
-    process.stdout.write(`-> ${destPath}\n`);
     process.exit(0);
   }
 
   // Validation failed
-  process.stderr.write(`FAIL '${item.id || '(no id)'}' (${errors.length} error${errors.length === 1 ? '' : 's'}):\n`);
-  process.stderr.write(formatErrors(errors) + '\n');
-
-  if (args.dryRun) {
-    process.stderr.write('(dry-run: no filesystem changes)\n');
-    process.exit(1);
+  if (!args.dryRun) {
+    fs.mkdirSync(rejectedDir, { recursive: true });
+    const rejectedId = item.id || `unknown-${Date.now()}`;
+    const rejectedPath = path.join(rejectedDir, `${rejectedId}.yaml`);
+    const enriched = {
+      ...item,
+      _validation: { rejected_at: new Date().toISOString(), errors, warnings },
+    };
+    fs.writeFileSync(rejectedPath, yaml.dump(enriched, { lineWidth: -1 }));
+    if (path.resolve(yamlPath) !== path.resolve(rejectedPath)) {
+      try { fs.unlinkSync(yamlPath); } catch {}
+    }
+    result.path = rejectedPath;
   }
 
-  fs.mkdirSync(rejectedDir, { recursive: true });
-  const rejectedId = item.id || `unknown-${Date.now()}`;
-  const rejectedPath = path.join(rejectedDir, `${rejectedId}.yaml`);
-  const enriched = {
-    ...item,
-    _validation: { rejected_at: new Date().toISOString(), errors },
-  };
-  fs.writeFileSync(rejectedPath, yaml.dump(enriched, { lineWidth: -1 }));
-  if (path.resolve(yamlPath) !== path.resolve(rejectedPath)) {
-    try { fs.unlinkSync(yamlPath); } catch {}
+  if (args.json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+  } else {
+    process.stderr.write(`FAIL '${item.id || '(no id)'}' (${errors.length} error${errors.length === 1 ? '' : 's'}):\n`);
+    process.stderr.write(formatErrors(errors) + '\n');
+    if (args.dryRun) process.stderr.write('(dry-run: no filesystem changes)\n');
+    else process.stderr.write(`-> quarantined at ${result.path}\n`);
   }
-  process.stderr.write(`-> quarantined at ${rejectedPath}\n`);
   process.exit(1);
 }
 

--- a/test/content-validator-layer-c.test.js
+++ b/test/content-validator-layer-c.test.js
@@ -1,0 +1,175 @@
+// content-validator-layer-c.test.js — Tests for Layer C of validateItem
+// (extractor + tenant preference check).
+//
+// Layer C is opt-in: tenants without preferences.<cat>.constraints in
+// memory/preferences.yaml get only Layers A+B and no behavior change vs.
+// the legacy validator. These tests cover both the opt-in path (constraints
+// present → enforcement applied) and the opt-out path (no constraints →
+// silent skip).
+//
+// The Archive.org extractor is the registered extractor used here. Tests
+// run against the live Archive.org metadata API; set SKIP_LIVE_TESTS=1 to
+// skip them. The extractor's own pure-function tests live in
+// extractor-archive-org.test.js.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const yaml = require('js-yaml');
+const { validateItem, loadConstraints } = require('../lib/content-validator');
+
+const LIVE_URL = 'https://archive.org/details/blackhammervolum0000lemi';
+
+function makeApprovedArchiveSource() {
+  return [{
+    id: 'archive-org',
+    name: 'Archive.org',
+    url: 'https://archive.org',
+    hosts: ['archive.org'],
+    status: 'approved',
+  }];
+}
+
+function makeItem(overrides = {}) {
+  return {
+    id: 'test-bhv1',
+    title: 'Black Hammer Vol. 1',
+    category: 'comics',
+    format: 'pdf',
+    source: 'archive-org',
+    source_url: LIVE_URL,
+    status: 'linked',
+    sources: [{ name: 'Archive.org', url: LIVE_URL, type: 'downloadable' }],
+    ...overrides,
+  };
+}
+
+function makeTempDataRoot(preferencesYaml) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pref-check-'));
+  fs.mkdirSync(path.join(dir, 'memory'), { recursive: true });
+  if (preferencesYaml != null) {
+    fs.writeFileSync(path.join(dir, 'memory', 'preferences.yaml'), preferencesYaml);
+  }
+  return dir;
+}
+
+describe('loadConstraints', () => {
+  it('returns null when memory/preferences.yaml does not exist', () => {
+    const dir = makeTempDataRoot(null);
+    assert.equal(loadConstraints(dir, 'comics'), null);
+  });
+  it('returns null when category has no constraints subtree', () => {
+    const dir = makeTempDataRoot(yaml.dump({
+      preferences: { comics: { likes: [], dislikes: [] } },
+    }));
+    assert.equal(loadConstraints(dir, 'comics'), null);
+  });
+  it('returns the constraints subtree when configured', () => {
+    const constraints = { formats: { accept: ['cbz', 'cbr'] } };
+    const dir = makeTempDataRoot(yaml.dump({
+      preferences: { comics: { constraints } },
+    }));
+    assert.deepEqual(loadConstraints(dir, 'comics'), constraints);
+  });
+});
+
+describe('validateItem — Layer C (extractor + preference check)', () => {
+  // These tests hit live archive.org. Skip in offline environments.
+  const skipReason = process.env.SKIP_LIVE_TESTS === '1' ? 'SKIP_LIVE_TESTS=1' : null;
+
+  it('passes when no constraints are configured (backward compat)', async (t) => {
+    if (skipReason) { t.skip(skipReason); return; }
+    const dataRoot = makeTempDataRoot(null);  // no preferences.yaml
+    const r = await validateItem(makeItem(), makeApprovedArchiveSource(), {
+      dataRoot,
+      // Layers A+B still run; this verifies no regression for legacy tenants.
+    });
+    assert.equal(r.ok, true, JSON.stringify(r.errors));
+  });
+
+  it('passes when constraints allow the item (e.g., pdf permitted)', async (t) => {
+    if (skipReason) { t.skip(skipReason); return; }
+    const dataRoot = makeTempDataRoot(yaml.dump({
+      preferences: {
+        comics: {
+          constraints: {
+            formats: { accept: ['pdf'] },
+            languages: { accept: ['en'] },
+          },
+        },
+      },
+    }));
+    const r = await validateItem(makeItem(), makeApprovedArchiveSource(), { dataRoot });
+    assert.equal(r.ok, true, JSON.stringify(r.errors));
+    assert.ok(r.extractor, 'extractor report should be populated');
+    assert.equal(r.extractor.facts.language, 'eng');
+  });
+
+  it('rejects when constraints exclude the available format', async (t) => {
+    if (skipReason) { t.skip(skipReason); return; }
+    const dataRoot = makeTempDataRoot(yaml.dump({
+      preferences: {
+        comics: {
+          constraints: {
+            formats: { accept: ['cbz', 'cbr'] },  // pdf NOT accepted
+            languages: { accept: ['en'] },
+          },
+        },
+      },
+    }));
+    // black-hammer-vol1 on archive.org is PDF/EPUB only — no CBZ/CBR.
+    // Expected: Layer C rejects on formats.
+    const r = await validateItem(makeItem(), makeApprovedArchiveSource(), { dataRoot });
+    if (r.ok) {
+      // If the extractor failed (network), the layer is graceful; allow.
+      const warned = r.warnings && r.warnings.some(w => /extractor failed/.test(w.reason));
+      assert.ok(warned, 'expected either rejection or extractor-failed warning');
+      return;
+    }
+    assert.ok(r.errors.some(e => e.field === 'formats'),
+      `expected formats error; got ${JSON.stringify(r.errors)}`);
+  });
+
+  it('skipExtraction=true bypasses Layer C entirely', async (t) => {
+    if (skipReason) { t.skip(skipReason); return; }
+    const dataRoot = makeTempDataRoot(yaml.dump({
+      preferences: {
+        comics: {
+          constraints: { formats: { accept: ['cbz'] } },  // would reject pdf
+        },
+      },
+    }));
+    const r = await validateItem(makeItem(), makeApprovedArchiveSource(), {
+      dataRoot,
+      skipExtraction: true,
+    });
+    assert.equal(r.ok, true, 'skipExtraction should disable Layer C');
+    assert.equal(r.extractor, undefined);
+  });
+});
+
+describe('validateItem — Layer C for non-extractor sources', () => {
+  it('skips Layer C when source has no registered extractor (e.g., Netflix)', async () => {
+    const dataRoot = makeTempDataRoot(yaml.dump({
+      preferences: { movies: { constraints: { formats: { accept: ['link'] } } } },
+    }));
+    const sources = [{
+      id: 'netflix', name: 'Netflix', url: 'https://www.netflix.com',
+      hosts: ['www.netflix.com'], status: 'approved',
+    }];
+    const item = {
+      id: 'm1', title: 'Test', category: 'movies', source: 'netflix',
+      source_url: 'https://www.netflix.com/title/123',
+      status: 'linked', format: 'link',
+      sources: [{ name: 'Netflix', url: 'https://www.netflix.com/title/123', type: 'link-only' }],
+    };
+    // skipFetch so we don't actually hit netflix.com; Layer C is what we're
+    // testing — it should be silently skipped (no extractor registered for
+    // netflix.com → no facts → no preference enforcement).
+    const r = await validateItem(item, sources, { dataRoot, skipFetch: true });
+    assert.equal(r.ok, true, JSON.stringify(r.errors));
+    assert.equal(r.extractor, undefined);
+  });
+});

--- a/test/extractor-archive-org.test.js
+++ b/test/extractor-archive-org.test.js
@@ -1,0 +1,114 @@
+// extractor-archive-org.test.js — Unit tests for the Archive.org extractor.
+//
+// Pure-function helpers (token mapping, language/year normalization, id
+// extraction) are exercised directly. The HTTPS fetch path is exercised
+// indirectly — there's no built-in way to stub `https.request` without
+// mocking, and the extractor's contract is "return facts or {_error}",
+// which is small enough that the unit tests focus on the parsing side.
+// The integration via validateItem against a real Archive.org item is
+// covered separately under content-validator.test.js (live network).
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  extract, extractArchiveOrgId, tokeniseFormats, normaliseLanguage,
+} = require('../lib/extractors/archive-org');
+
+describe('extractArchiveOrgId', () => {
+  it('extracts the identifier from a standard /details/ URL', () => {
+    assert.equal(
+      extractArchiveOrgId('https://archive.org/details/blackhammervolum0000lemi'),
+      'blackhammervolum0000lemi',
+    );
+  });
+  it('strips a sub-path segment', () => {
+    assert.equal(
+      extractArchiveOrgId('https://archive.org/details/foo/file.pdf'),
+      'foo',
+    );
+  });
+  it('strips query and fragment', () => {
+    assert.equal(extractArchiveOrgId('https://archive.org/details/foo?x=1'), 'foo');
+    assert.equal(extractArchiveOrgId('https://archive.org/details/foo#bar'), 'foo');
+  });
+  it('returns null for non-archive.org hosts', () => {
+    assert.equal(extractArchiveOrgId('https://example.com/details/foo'), null);
+  });
+  it('returns null for archive.org without /details/', () => {
+    assert.equal(extractArchiveOrgId('https://archive.org/'), null);
+  });
+  it('returns null for invalid URLs', () => {
+    assert.equal(extractArchiveOrgId('not a url'), null);
+    assert.equal(extractArchiveOrgId(''), null);
+  });
+});
+
+describe('tokeniseFormats', () => {
+  it('detects cbz / cbr / pdf from Archive.org `format` strings', () => {
+    const files = [
+      { format: 'Comic Book ZIP' },
+      { format: 'Comic Book RAR' },
+      { format: 'Text PDF' },
+      { format: 'JSON' },
+    ];
+    const tokens = tokeniseFormats(files).sort();
+    assert.deepEqual(tokens, ['cbr', 'cbz', 'pdf']);
+  });
+  it('detects EPUB and MP3 too', () => {
+    const tokens = tokeniseFormats([{ format: 'EPUB' }, { format: 'VBR MP3' }]).sort();
+    assert.deepEqual(tokens, ['epub', 'mp3']);
+  });
+  it('returns [] for empty input', () => {
+    assert.deepEqual(tokeniseFormats([]), []);
+    assert.deepEqual(tokeniseFormats(null), []);
+  });
+  it('falls back to file name when format is missing', () => {
+    const tokens = tokeniseFormats([{ name: 'comic.cbz' }]);
+    assert.deepEqual(tokens, ['cbz']);
+  });
+});
+
+describe('normaliseLanguage', () => {
+  it('lowercases trimmed strings', () => {
+    assert.equal(normaliseLanguage('  ENG  '), 'eng');
+    assert.equal(normaliseLanguage('eng'), 'eng');
+  });
+  it('takes the first element of a list', () => {
+    assert.equal(normaliseLanguage(['eng', 'spa']), 'eng');
+  });
+  it('returns null for nullish or unusable input', () => {
+    assert.equal(normaliseLanguage(null), null);
+    assert.equal(normaliseLanguage(''), null);
+    assert.equal(normaliseLanguage(42), null);
+  });
+});
+
+describe('extract — error paths (no network needed)', () => {
+  it('returns {_error} for a non-archive.org URL', async () => {
+    const r = await extract('https://example.com/details/foo');
+    assert.equal(typeof r._error, 'string');
+    assert.match(r._error, /not an archive\.org details URL/);
+  });
+});
+
+describe('extract — live fetch against archive.org', () => {
+  it('returns structured facts for a known item (network required)', async (t) => {
+    if (process.env.SKIP_LIVE_TESTS === '1') {
+      t.skip('SKIP_LIVE_TESTS=1');
+      return;
+    }
+    const r = await extract('https://archive.org/details/blackhammervolum0000lemi');
+    if (r._error) {
+      t.diagnostic(`live archive.org fetch failed (skipping assertions): ${r._error}`);
+      return;
+    }
+    assert.equal(r.identifier, 'blackhammervolum0000lemi');
+    assert.equal(r.language, 'eng');
+    assert.ok(Array.isArray(r.available_formats));
+    assert.ok(r.available_formats.includes('pdf'));
+    assert.equal(typeof r.title, 'string');
+    assert.equal(typeof r.borrowable_only, 'boolean');
+    assert.equal(typeof r.year, 'number');
+    assert.match(r.thumbnail_url, /archive\.org\/services\/img\//);
+  });
+});

--- a/test/preference-checker.test.js
+++ b/test/preference-checker.test.js
@@ -1,0 +1,127 @@
+// preference-checker.test.js — Unit tests for tenant-preference enforcement.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { check, normLang } = require('../lib/preference-checker');
+
+describe('normLang', () => {
+  it('aliases common English variants to "en"', () => {
+    assert.equal(normLang('en'), 'en');
+    assert.equal(normLang('eng'), 'en');
+    assert.equal(normLang('English'), 'en');
+    assert.equal(normLang('  ENGLISH  '), 'en');
+  });
+  it('aliases Spanish variants', () => {
+    assert.equal(normLang('es'), 'es');
+    assert.equal(normLang('spa'), 'es');
+    assert.equal(normLang('Spanish'), 'es');
+  });
+  it('passes unknown codes through lowercased', () => {
+    assert.equal(normLang('xx'), 'xx');
+  });
+  it('handles null', () => {
+    assert.equal(normLang(null), null);
+  });
+});
+
+describe('check — empty / missing constraints', () => {
+  it('returns no errors when constraints is null', () => {
+    const result = check({ language: 'spa' }, null);
+    assert.deepEqual(result, { errors: [], warnings: [] });
+  });
+  it('returns no errors when constraints is empty object', () => {
+    const result = check({ language: 'spa' }, {});
+    assert.deepEqual(result, { errors: [], warnings: [] });
+  });
+});
+
+describe('check — languages.accept', () => {
+  const constraints = { languages: { accept: ['en'] } };
+
+  it('accepts a fact whose language matches the accept list', () => {
+    const result = check({ language: 'eng' }, constraints);
+    assert.deepEqual(result.errors, []);
+  });
+  it('rejects a non-accepted language', () => {
+    const result = check({ language: 'spa' }, constraints);
+    assert.equal(result.errors.length, 1);
+    assert.equal(result.errors[0].field, 'language');
+    assert.match(result.errors[0].reason, /not in accept list/);
+  });
+  it('warns by default when language is unknown', () => {
+    const result = check({ language: null }, constraints);
+    assert.equal(result.errors.length, 0);
+    assert.equal(result.warnings.length, 1);
+    assert.equal(result.warnings[0].field, 'language');
+  });
+  it('rejects an unknown language when unknown_field_policy.language=reject', () => {
+    const c = { ...constraints, unknown_field_policy: { language: 'reject' } };
+    const result = check({ language: null }, c);
+    assert.equal(result.errors.length, 1);
+    assert.equal(result.warnings.length, 0);
+  });
+  it('accepts an unknown language when unknown_field_policy.language=accept', () => {
+    const c = { ...constraints, unknown_field_policy: { language: 'accept' } };
+    const result = check({ language: null }, c);
+    assert.deepEqual(result, { errors: [], warnings: [] });
+  });
+});
+
+describe('check — formats.accept', () => {
+  const constraints = { formats: { accept: ['cbz', 'cbr'] } };
+
+  it('accepts when available_formats intersects accept', () => {
+    const result = check({ available_formats: ['cbz', 'pdf'] }, constraints);
+    assert.deepEqual(result.errors, []);
+  });
+  it('rejects when available_formats does not intersect', () => {
+    const result = check({ available_formats: ['pdf', 'epub'] }, constraints);
+    assert.equal(result.errors.length, 1);
+    assert.equal(result.errors[0].field, 'formats');
+  });
+  it('is case-insensitive on available_formats', () => {
+    const result = check({ available_formats: ['CBZ'] }, constraints);
+    assert.deepEqual(result.errors, []);
+  });
+  it('warns by default when available_formats is empty', () => {
+    const result = check({ available_formats: [] }, constraints);
+    assert.equal(result.errors.length, 0);
+    assert.equal(result.warnings.length, 1);
+  });
+});
+
+describe('check — borrowable_ok', () => {
+  it('rejects borrowable_only=true when borrowable_ok=false', () => {
+    const result = check({ borrowable_only: true }, { borrowable_ok: false });
+    assert.equal(result.errors.length, 1);
+    assert.equal(result.errors[0].field, 'borrowable_only');
+  });
+  it('accepts borrowable_only=true when borrowable_ok=true', () => {
+    const result = check({ borrowable_only: true }, { borrowable_ok: true });
+    assert.deepEqual(result.errors, []);
+  });
+  it('accepts borrowable_only=false regardless of policy', () => {
+    const result = check({ borrowable_only: false }, { borrowable_ok: false });
+    assert.deepEqual(result.errors, []);
+  });
+  it('warns on null borrowable_only when borrowable_ok=false', () => {
+    const result = check({ borrowable_only: null }, { borrowable_ok: false });
+    assert.equal(result.errors.length, 0);
+    assert.equal(result.warnings.length, 1);
+  });
+});
+
+describe('check — combined', () => {
+  it('returns all violations from a multi-failure item', () => {
+    const constraints = {
+      languages: { accept: ['en'] },
+      formats: { accept: ['cbz', 'cbr'] },
+      borrowable_ok: false,
+    };
+    const facts = { language: 'spa', available_formats: ['pdf'], borrowable_only: true };
+    const result = check(facts, constraints);
+    assert.equal(result.errors.length, 3);
+    const fields = result.errors.map(e => e.field).sort();
+    assert.deepEqual(fields, ['borrowable_only', 'formats', 'language']);
+  });
+});


### PR DESCRIPTION
## Summary

Adds Layer C to the publish-content validator: when an item's source has a registered extractor, fetch structured facts (language, available_formats, borrowable_only, etc.) and apply tenant constraints from the agent's own preferences.yaml.

**Multi-tenant safe.** No agent-specific values live in agent-portal. Constraints are read from `<dataDir>/memory/preferences.yaml` at `preferences.<category>.constraints`. Tenants without that subtree get Layers A+B only — no behavior change vs. today.

## What's new

- **`lib/extractors/archive-org.js`** — generic Archive.org metadata extractor. Hits `https://archive.org/metadata/<id>`, returns facts only (no preference judgment).
- **`lib/extractors/index.js`** — hostname → extractor registry. Drop new modules under `lib/extractors/<name>.js` and add hosts here; no other changes needed elsewhere.
- **`lib/preference-checker.js`** — applies tenant constraints to facts. Returns structured errors/warnings per violated field. `unknown_field_policy` per field (reject/warn/accept) handles cases where the extractor returns null.
- **`lib/content-validator.js`** — `validateItem` runs Layer C after existing host-allowlist and live-fetch. Adds `skipExtraction` option. Result envelope now includes warnings and the extractor's facts.
- **`scripts/publish-content.js`** — adds `--json` machine-readable output (used by the harness-eval orchestrator for Type B/E scoring) and `--skip-extraction`. Quarantined items include warnings alongside errors.

## Verification

- **506/506 tests pass** — 43 new across 3 new test files; 463 pre-existing tests unchanged → zero regression.
- **End-to-end smoke against contentbot's `black-hammer-vol1.yaml`**:
  - With no constraints configured → `ok=true`, extractor facts populated (`language=eng`, `available_formats=['epub','pdf']`, `borrowable_only=true`).
  - With constraints `formats.accept=[cbz,cbr]` + `borrowable_ok=false` → `ok=false`, two structured errors: `formats` (no intersect) and `borrowable_only` (policy violation). Exactly the class of historical leak the design was meant to catch.

## Backward compat

- Tenants with no `preferences.<cat>.constraints` subtree → Layers A+B only, identical behavior.
- Sources with no registered extractor (Netflix, Hulu, etc.) → Layer C silently skipped.
- Existing `publish-content.sh` shell entry point unchanged; new behavior is purely additive.

## Why this is the framework change, not a contentbot change

The extractor + preference-checker pattern is generic infrastructure. Bobbo/flenderson get Layer C for free if they ever configure their own per-category constraints. No tenant-specific data lives in agent-portal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)