### PR TITLE
wake.sh: retry on zero-work cycles (harness exits 0 but no events)

### DIFF
--- a/scripts/wake.sh
+++ b/scripts/wake.sh
@@ -286,6 +286,19 @@ fi
 # Close lock fd before piping to harness to prevent fd leak into child processes
 step "$HARNESS_CMD starting"
 
+# Zero-work detection: if the harness exits 0 but the agent wrote no
+# events (no cycle_end summary, no journal entry, no anything), we
+# treat that as a soft failure and retry. Catches the failure mode
+# where the harness swallows a mid-cycle error and exits cleanly with
+# no work landed (e.g. goose hitting a stream-decode error from the
+# upstream API, printing "Ran into this error" and exit 0).
+#
+# Mechanism: snapshot the events.jsonl line count BEFORE the harness
+# invocation. After each attempt, if exit==0 but the line count is
+# unchanged, the agent wrote nothing — set HARNESS_EXIT to a non-zero
+# sentinel so the retry loop fires.
+EVENTS_FILE="$AGENT_DIR/$DATA_DIR/logs/events.jsonl"
+
 MAX_RETRIES=2
 RETRY=0
 HARNESS_EXIT=1
@@ -299,9 +312,23 @@ while [ "$HARNESS_EXIT" -ne 0 ] && [ "$RETRY" -lt "$MAX_RETRIES" ]; do
     sleep 30
   fi
 
+  EVENTS_BEFORE=$(wc -l < "$EVENTS_FILE" 2>/dev/null || echo 0)
+
   cat "$WAKE_PROMPT_FILE" 200>&- | $HARNESS_CMD $HARNESS_EXTRA_FLAGS \
     200>&- 2>&1 | tee 200>&- "$CYCLE_LOG"
   HARNESS_EXIT=${PIPESTATUS[1]}
+
+  # Zero-work check: harness exited 0 but agent wrote no events
+  if [ "$HARNESS_EXIT" -eq 0 ]; then
+    EVENTS_AFTER=$(wc -l < "$EVENTS_FILE" 2>/dev/null || echo 0)
+    if [ "$EVENTS_AFTER" -eq "$EVENTS_BEFORE" ]; then
+      step "harness exited 0 but agent wrote no events — treating as failure (zero-work cycle)"
+      bash "$FRAMEWORK_DIR/scripts/log-event.sh" "$AGENT_DIR" warning \
+        "Harness exited 0 with no agent events; retrying (attempt $((RETRY+1)))" \
+        2>/dev/null || true
+      HARNESS_EXIT=98   # non-zero sentinel so the while loop retries
+    fi
+  fi
 
   RETRY=$((RETRY + 1))
 done


### PR DESCRIPTION
## Summary

Catches the failure mode where the harness exits cleanly (exit 0) but the agent wrote no events. Concrete case from contentbot production: goose hit a \"Stream decode error\" from the OpenRouter response, printed \"Ran into this error\" and exited 0. wake.sh treated that as a successful cycle, ran post-cycle hooks, committed (no-op since data/ is gitignored), and **13 minutes of in-flight research + pref extractions + URL verifications were silently lost**.

## Mechanism

Snapshot the agent's \`events.jsonl\` line count before each harness attempt. After the attempt, if the harness exited 0 **but the line count is unchanged**, the agent wrote nothing — set \`HARNESS_EXIT\` to 98 (non-zero sentinel) so the existing retry loop fires. Log a warning event so the cause is visible in \`events.jsonl\`.

This is harness-agnostic by design — works for claude-code, goose, letta-code, etc. The agent calling \`log-event.sh\` / \`log-journal.sh\` (per the AGENTS.md \"On Completing Work\" instructions) is the canonical \"did anything happen\" signal.

## Edge cases handled

- **Fresh agent with no events.jsonl**: \`wc\` returns 0 both before and after, so a fully-no-op cycle still retries (correct — even a bootstrapping cycle should log something).
- **Healthy cycle**: agent's \`cycle_end\` + any other events push the count up, no retry.
- **Agent writes journal but not events**: still triggers retry. Tagging journal writes as events would close this gap; that's a separate concern (could be added to \`log-journal.sh\`).

## Related changes in contentbot

- [contentbot#80](https://github.com/robhunter/contentbot/pull/80) — wraps goose's output through tee and detects \`Ran into this error\` / \`Stream decode error\` patterns, exits non-zero to trigger this retry. Same problem, different layer.
- [contentbot#80](https://github.com/robhunter/contentbot/pull/80) — wake-prompt instruction to commit work as you go + always-write-journal even on partial-work cycles.

## Test plan

- [x] Syntax check
- [ ] Verify zero-work detection fires correctly: induce a goose stream-decode error (or use a wrapper that exits 0 without writing events) and confirm wake.sh retries
- [ ] Verify healthy path: a normal cycle that writes events ends without retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)