### PR TITLE
security: bump js-yaml 4.1.1 → 4.2.0 (merge-key DoS, GHSA-h67p-54hq-rp68)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "agent-portal",
-  "version": "1.5.20",
+  "version": "1.5.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-portal",
-      "version": "1.5.20",
+      "version": "1.5.21",
       "license": "MIT",
       "dependencies": {
-        "js-yaml": "^4.1.0"
+        "js-yaml": "^4.2.0"
       },
       "bin": {
         "agent-portal": "index.js"
@@ -25,9 +25,19 @@
       "license": "Python-2.0"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.5.20",
+  "version": "1.5.21",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {
@@ -20,6 +20,6 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "js-yaml": "^4.1.0"
+    "js-yaml": "^4.2.0"
   }
 }


### PR DESCRIPTION
## Summary

Routine security re-audit of agent-portal (the live web portal + shared framework) surfaced one moderate advisory in a **direct production dependency**:

- **GHSA-h67p-54hq-rp68** — js-yaml quadratic-complexity DoS in merge-key handling via repeated aliases (`<<: *anchor`). Affects `js-yaml <= 4.1.1`; we were pinned at 4.1.1.

This is the first security audit of agent-portal itself (prior portal work was features); the same routine that caught vulns in agentdeals (PRs #1014, #1015).

## Why it's applicable here

`js-yaml` is a **direct dependency** with **14 `yaml.load()` call sites**, several of which parse **user-mutable YAML through HTTP route handlers**:
- `lib/routes/sources.js`, `lib/routes/preferences.js`, `lib/routes/rated-items.js`, `lib/routes/library.js` (config + content the user edits via the portal)
- `lib/content-validator.js`, `scripts/publish-content.js`

A malicious or malformed config with repeated merge-key aliases is the exact attacker-reachable pattern the advisory describes.

## Fix

- **Non-breaking minor bump** within the existing `^4.x` range: lockfile `js-yaml 4.1.1 → 4.2.0`.
- Tightened `package.json` floor `^4.1.0 → ^4.2.0` to encode the security requirement.
- Portal version `1.5.20 → 1.5.21` (per the bump-every-PR convention).
- `npm audit` now reports **0 vulnerabilities**.

## Verification

- **506/506 node tests pass** — identical to the pre-change baseline (the suite exercises every route handler + validator that calls `yaml.load()`).
- **Real portal YAML parses correctly** under 4.2.0: `sources.yaml`, `preferences.yaml`, two real `agent.yaml` files.
- **Legitimate merge-key resolution intact** (the exact code area the fix touched): override-wins / inherited-keys semantics verified.
- **Mitigation sanity**: a 60-deep repeated-alias merge chain parses in ~1.5ms (no quadratic blowup).
- `npm audit --omit=dev`: clean.

## Note (out of scope)

`test/publish-content.test.sh` is **red on main** independent of this change (verified by A/B test on baseline 4.1.1 — identical failures). Root cause is environmental: the test harness's temp data-dir setup doesn't materialize `config/sources.yaml` in the sandbox (`ENOENT`) and the gate performs live network fetches. Not introduced here; left for a separate fix to keep this PR focused.

No issue is associated with this routine maintenance audit.