### PR TITLE
fix: escape JSON in log-event.sh to prevent events.jsonl corruption

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-portal",
-  "version": "1.5.21",
+  "version": "1.5.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-portal",
-      "version": "1.5.21",
+      "version": "1.5.22",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.5.21",
+  "version": "1.5.22",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/scripts/log-event.sh
+++ b/scripts/log-event.sh
@@ -23,9 +23,23 @@ if [ -z "$DATA_DIR" ] && [ -f "$AGENT_DIR/portal.config.json" ]; then
 fi
 DATA_DIR="${DATA_DIR:-.}"
 
-ENTRY="{\"ts\":\"$(date -Iseconds)\",\"type\":\"$TYPE\",\"summary\":\"$SUMMARY\""
-[ -n "$PROJECT" ] && ENTRY="$ENTRY,\"project\":\"$PROJECT\""
-ENTRY="$ENTRY}"
+# Build the JSON line with python3 (a hard framework dependency, used the same
+# way in wake.sh/health-check.sh) so that double-quotes, backslashes, or
+# newlines in the type/summary/project are escaped correctly. Raw string
+# interpolation here silently produced invalid JSONL whenever a summary
+# contained a `"` (common — e.g. Shipped "dark mode"), and downstream consumers
+# that JSON.parse line-by-line then dropped the event entirely.
+ENTRY="$(EVENT_TS="$(date -Iseconds)" EVENT_TYPE="$TYPE" EVENT_SUMMARY="$SUMMARY" EVENT_PROJECT="$PROJECT" python3 -c '
+import json, os
+entry = {
+    "ts": os.environ["EVENT_TS"],
+    "type": os.environ["EVENT_TYPE"],
+    "summary": os.environ["EVENT_SUMMARY"],
+}
+if os.environ.get("EVENT_PROJECT"):
+    entry["project"] = os.environ["EVENT_PROJECT"]
+print(json.dumps(entry, ensure_ascii=False, separators=(",", ":")))
+')"
 
 mkdir -p "$AGENT_DIR/$DATA_DIR/logs"
 echo "$ENTRY" >> "$AGENT_DIR/$DATA_DIR/logs/events.jsonl"

--- a/test/data-dir-scripts.test.sh
+++ b/test/data-dir-scripts.test.sh
@@ -61,6 +61,23 @@ DATA_DIR=data bash "$SCRIPTS/log-event.sh" "$TMP" cycle_start "env override"
 [ -f "$TMP/data/logs/events.jsonl" ] && ok "env override redirected to data/" || fail "env override ignored"
 rm -rf "$TMP"
 
+echo "## Test 3b: special characters in the summary produce valid JSONL (not corruption)"
+TMP=$(make_agent legacy)
+unset DATA_DIR
+TRICKY='Shipped "dark mode"; fixed C:\path, and a, comma'
+bash "$SCRIPTS/log-event.sh" "$TMP" work "$TRICKY" agentdeals
+LINE=$(tail -1 "$TMP/logs/events.jsonl")
+if printf '%s' "$LINE" | python3 -c "import json,sys; json.loads(sys.stdin.read())" 2>/dev/null; then
+  ok "summary with quotes/backslash/comma is valid JSON"
+else
+  fail "special-char summary corrupted the JSONL: $LINE"
+fi
+GOT=$(printf '%s' "$LINE" | python3 -c "import json,sys; print(json.loads(sys.stdin.read())['summary'])" 2>/dev/null)
+[ "$GOT" = "$TRICKY" ] && ok "summary round-trips exactly" || fail "summary mangled: got [$GOT] want [$TRICKY]"
+PROJ=$(printf '%s' "$LINE" | python3 -c "import json,sys; print(json.loads(sys.stdin.read())['project'])" 2>/dev/null)
+[ "$PROJ" = "agentdeals" ] && ok "project field preserved" || fail "project field lost"
+rm -rf "$TMP"
+
 echo ""
 echo "# log-journal.sh respects DATA_DIR"
 echo "## Test 4: dataDir=data — writes to <agentDir>/data/journals/"


### PR DESCRIPTION
## Problem

`scripts/log-event.sh` builds each event line by raw string interpolation:

```sh
ENTRY="{\"ts\":\"$(date -Iseconds)\",\"type\":\"$TYPE\",\"summary\":\"$SUMMARY\""
```

So any double-quote, backslash, or newline in `$SUMMARY` / `$TYPE` / `$PROJECT` produces **invalid JSONL**. Every downstream consumer (`lib/routes/events.js`, `status.js`, `memory-index.py`) parses the file line-by-line and silently skips unparseable lines — so the corrupted event vanishes from the portal event feed, cycle/cost views, and the semantic memory index.

`log-event.sh` is called several times per cycle by every agent, so this is a high-blast-radius, silent data-loss bug. It has **already bitten real data** — line 2314 of agent-coder's `events.jsonl` (2026-04-20) is permanently malformed because the summary contained `"only ten fields per form"`.

## Fix

Build the JSON line with `python3` (already a hard framework dependency — `wake.sh`, `health-check.sh`, and `reconcile-cost.sh` all call it directly, including the same `VAR="$X" python3 -c` env-passing idiom). It escapes everything correctly. Output is byte-compatible with the 2700+ existing lines: compact `separators=(",",":")`, same key order `ts/type/summary[/project]`, `ensure_ascii=False`.

## Verification

- New **Test 3b** in `data-dir-scripts.test.sh`: a summary with quotes + backslash + commas now yields valid JSON and round-trips exactly (incl. the `project` field). `data-dir-scripts.test.sh` → **18/18** (was 15).
- **Bite-test** (a test that only passes is worthless): reverted to the old `log-event.sh` and confirmed Test 3b reports `not ok` + exits 1; restored the fix → passes.
- Reproduced the original corruption (`Shipped "dark mode" feature, fixed C:\path bug`): old code → `jq: parse error`; new code → valid JSON, summary intact.
- Full node suite **506/506** pass, 0 fail (unchanged baseline). `framework-update` 11/11, `telegram-burst` 24/24, `telegram-session` 5/5.
- The two failing shell suites in my sandbox (`health-check`, `publish-content`) fail **identically on clean `main`** — pre-existing/environmental (sandbox can't reach the test's localhost mock server / fixture setup); they pass in CI.

Version bump 1.5.21 → 1.5.22.

Surfaced by a framework-script audit; a follow-up issue tracks the other (lower-priority) findings.