### PR TITLE
fix: compare memory-index timestamps chronologically, not lexicographically (#247 F2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-portal",
-  "version": "1.5.22",
+  "version": "1.5.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-portal",
-      "version": "1.5.22",
+      "version": "1.5.23",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.5.22",
+  "version": "1.5.23",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/scripts/memory-index-tz-test.py
+++ b/scripts/memory-index-tz-test.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Regression tests for chronological timestamp handling in memory-index.py.
+
+These cover the fix for Finding 2 of agent-portal#247: the incremental indexer
+compared ISO-8601 timestamps lexicographically, which silently dropped entries
+across a UTC-offset / DST change — a chronologically-later entry can sort
+lexicographically-earlier (e.g. "...T07:00:00-07:00" = 14:00Z is later than
+"...T13:00:00+00:00" = 13:00Z, yet "07..." < "13..." as strings), so the
+incremental filter treated it as already-indexed and never embedded it.
+
+Run locally (the memory scripts are not in CI — the python-tests job installs
+only pytest+mitmproxy):
+
+    scripts/memory-venv/bin/python scripts/memory-index-tz-test.py
+
+No embedding model is loaded: memory-index imports without fastembed (that import
+is lazy, inside main()), so these exercise the pure helpers and run instantly.
+"""
+
+import importlib.util
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "memory_index", Path(__file__).parent / "memory-index.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_lazy_import(mod):
+    """Importing the module must not pull in fastembed, so the helpers below are
+    testable without loading the embedding model."""
+    assert "fastembed" not in sys.modules, \
+        "fastembed must be imported lazily inside main(), not at module top"
+    print("✓ module imports without loading fastembed")
+
+
+def test_parse_ts_cross_offset(mod):
+    """The documented failure: 07:00-07:00 (14:00Z) is chronologically later than
+    13:00+00:00 (13:00Z), but sorts earlier as a string."""
+    later = "2026-06-15T07:00:00-07:00"    # 14:00Z
+    earlier = "2026-06-15T13:00:00+00:00"  # 13:00Z
+    assert mod.parse_ts(later) > mod.parse_ts(earlier), "parse_ts ordered these wrong"
+    assert not (later > earlier), "string comparison should be the opposite — that's the bug"
+    print("✓ parse_ts orders entries across a UTC-offset change chronologically")
+
+
+def test_parse_ts_dst(mod):
+    """Guaranteed recurrence at the Nov 2026 PDT->PST fall-back (-07:00 -> -08:00)."""
+    later = "2026-11-02T01:00:00-08:00"    # 09:00Z
+    earlier = "2026-11-02T01:30:00-07:00"  # 08:30Z
+    assert mod.parse_ts(later) > mod.parse_ts(earlier), "parse_ts ordered the DST pair wrong"
+    assert not (later > earlier), "string comparison should be the opposite — that's the bug"
+    print("✓ parse_ts handles the Nov DST fall-back boundary")
+
+
+def test_parse_ts_equivalence_and_naive(mod):
+    assert mod.parse_ts("2026-01-01T00:00:00Z") == mod.parse_ts("2026-01-01T00:00:00+00:00")
+    # A naive (offset-less) timestamp is treated as UTC.
+    assert mod.parse_ts("2026-01-01T00:00:00") == mod.parse_ts("2026-01-01T00:00:00+00:00")
+    print("✓ parse_ts treats 'Z' as +00:00 and naive timestamps as UTC")
+
+
+def test_parse_ts_failsafe(mod):
+    floor = datetime.min.replace(tzinfo=timezone.utc)
+    assert mod.parse_ts("") == floor
+    assert mod.parse_ts("not-a-timestamp") == floor
+    assert mod.parse_ts(None) == floor
+    # Fail-safe entries sort oldest, so they are treated as new (re-indexed),
+    # never silently dropped.
+    assert mod.parse_ts("garbage") < mod.parse_ts("2026-01-01T00:00:00+00:00")
+    print("✓ parse_ts is fail-safe (empty/garbage/None -> oldest, never dropped)")
+
+
+def test_select_new_entries_watermark_trap(mod):
+    """End-to-end trap: a +00:00 watermark must not hide chronologically-later
+    -07:00 entries. This is the assertion that BITES if the filter reverts to
+    lexicographic comparison."""
+    entries = [
+        {"timestamp": "2026-06-15T12:00:00+00:00"},  # 12:00Z — before watermark
+        {"timestamp": "2026-06-15T13:00:00+00:00"},  # 13:00Z — equals watermark
+        {"timestamp": "2026-06-15T07:00:00-07:00"},  # 14:00Z — later, sorts earlier
+        {"timestamp": "2026-06-15T08:00:00-07:00"},  # 15:00Z — later, sorts earlier
+    ]
+    watermark = "2026-06-15T13:00:00+00:00"
+    new, next_wm = mod.select_new_entries(entries, watermark)
+    new_ts = [e["timestamp"] for e in new]
+    assert new_ts == ["2026-06-15T07:00:00-07:00", "2026-06-15T08:00:00-07:00"], \
+        f"cross-offset entries were dropped: {new_ts}"
+    assert next_wm == "2026-06-15T08:00:00-07:00", f"watermark advanced wrong: {next_wm}"
+
+    # Pin the bug being fixed: the OLD lexicographic filter dropped both entries.
+    old_lex = [e["timestamp"] for e in entries if e["timestamp"] > watermark]
+    assert old_lex == [], f"sanity: old lexicographic filter should drop all, got {old_lex}"
+    print("✓ select_new_entries keeps cross-offset entries the old code silently dropped")
+
+
+def test_select_new_entries_first_run_and_empty(mod):
+    entries = [
+        {"timestamp": "2026-06-15T13:00:00+00:00"},  # 13:00Z
+        {"timestamp": "2026-06-15T07:00:00-07:00"},  # 14:00Z = chronological max
+    ]
+    # First run (empty watermark): everything is new; watermark = chronological max.
+    new, wm = mod.select_new_entries(entries, "")
+    assert len(new) == 2, f"first run should index all, got {len(new)}"
+    assert wm == "2026-06-15T07:00:00-07:00", f"first-run watermark wrong: {wm}"
+    # Re-run at that watermark: nothing newer, watermark unchanged.
+    new2, wm2 = mod.select_new_entries(entries, wm)
+    assert new2 == [], f"re-run should find nothing new, got {new2}"
+    assert wm2 == wm, f"watermark should not move, got {wm2}"
+    print("✓ select_new_entries handles the first run and the no-new-entries case")
+
+
+def main():
+    mod = load_module()
+    test_lazy_import(mod)
+    test_parse_ts_cross_offset(mod)
+    test_parse_ts_dst(mod)
+    test_parse_ts_equivalence_and_naive(mod)
+    test_parse_ts_failsafe(mod)
+    test_select_new_entries_watermark_trap(mod)
+    test_select_new_entries_first_run_and_empty(mod)
+    print("\n✅ All tz regression tests passed!")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/memory-index.py
+++ b/scripts/memory-index.py
@@ -1,17 +1,23 @@
 #!/usr/bin/env python3
 """Index journal entries and events into SQLite for semantic search.
 
-Usage: memory-venv/bin/python scripts/memory-index.py /path/to/agent-dir [--data-dir DATA_DIR]
+Usage: memory-venv/bin/python scripts/memory-index.py /path/to/agent-dir [--data-dir DATA_DIR] [--reindex]
 
 Parses journal markdown files and events.jsonl, generates embeddings via
 fastembed (nomic-embed-text-v1.5), and stores in SQLite with FTS5 for
 keyword search and numpy-based vector similarity. Incremental: only
-indexes new entries since last run.
+indexes new entries since last run (timestamps are compared chronologically,
+parsed to UTC — see parse_ts).
 
 --data-dir defaults to "." (legacy layout — journals/, logs/, memory/ at
 agent-dir root). Set to "data" for the dataDir layout where they live
 under <agent-dir>/data/. The DATA_DIR environment variable is honored
 when --data-dir is absent (matches what read-harness-config.sh exports).
+
+--reindex clears the incremental watermarks so every entry is re-examined.
+Already-indexed entries are skipped by the is_duplicate check; this is the
+recovery path for entries that an earlier lexicographic-comparison bug
+silently dropped. It re-embeds all source entries, so use it deliberately.
 """
 
 import json
@@ -20,6 +26,7 @@ import re
 import sqlite3
 import struct
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 # Prefer the OS CA bundle when present so HTTPS works inside TLS-intercepting
@@ -30,12 +37,62 @@ if "SSL_CERT_FILE" not in os.environ and os.path.exists("/etc/ssl/certs/ca-certi
     os.environ["SSL_CERT_FILE"] = "/etc/ssl/certs/ca-certificates.crt"
 
 import numpy as np
-from fastembed import TextEmbedding
+
+# fastembed (the embedding model) is imported lazily inside main() so this module
+# can be imported to unit-test the pure helpers (parse_ts, select_new_entries)
+# without loading the heavy model. numpy stays top-level — it is light and is used
+# by module-level helpers (is_duplicate / deserialize_vec).
 
 EMBED_DIM = 384
 SIMILARITY_THRESHOLD = 0.92
 MODEL_NAME = "BAAI/bge-small-en-v1.5"
 EMBED_BATCH_SIZE = 50
+
+
+def parse_ts(s: str) -> datetime:
+    """Parse an ISO-8601 timestamp into a tz-aware UTC datetime for *chronological*
+    comparison.
+
+    Comparing ISO-8601 strings lexicographically (the previous behaviour) is wrong
+    whenever the UTC offset changes — e.g. a container switching from UTC to
+    America/Los_Angeles, or any DST transition. A chronologically-later entry can
+    then sort lexicographically *earlier*: "2026-06-15T07:00:00-07:00" (14:00Z) is
+    later than "2026-06-15T13:00:00+00:00" (13:00Z), yet "07..." < "13..." as
+    strings. The incremental filter would treat the later entry as already-indexed
+    and silently drop it — it is never embedded and never surfaces in memory-search.
+
+    Fail-safe: empty or unparseable timestamps return datetime.min (UTC) so they
+    sort oldest and get (re-)indexed rather than silently dropped; the is_duplicate
+    check prevents re-embedding genuine duplicates.
+    """
+    if not s:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    try:
+        dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return datetime.min.replace(tzinfo=timezone.utc)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def select_new_entries(entries: list[dict], last_ts: str) -> tuple[list[dict], str]:
+    """Select entries newer than the watermark and compute the next watermark.
+
+    Returns (new_entries, new_watermark). "Newer" is decided chronologically via
+    parse_ts, never by string comparison (see parse_ts for why). The watermark is
+    the original ISO string of the chronologically-latest new entry, or last_ts
+    unchanged when nothing is newer.
+    """
+    last_dt = parse_ts(last_ts)
+    new = [e for e in entries if parse_ts(e["timestamp"]) > last_dt]
+
+    watermark, watermark_dt = last_ts, last_dt
+    for e in new:
+        e_dt = parse_ts(e["timestamp"])
+        if e_dt > watermark_dt:
+            watermark, watermark_dt = e["timestamp"], e_dt
+    return new, watermark
 
 
 def init_db(db_path: str) -> sqlite3.Connection:
@@ -178,10 +235,11 @@ def set_last_indexed(conn: sqlite3.Connection, key: str, value: str):
 
 def main():
     if len(sys.argv) < 2:
-        print("Usage: memory-index.py /path/to/agent-dir [--data-dir DATA_DIR]", file=sys.stderr)
+        print("Usage: memory-index.py /path/to/agent-dir [--data-dir DATA_DIR] [--reindex]", file=sys.stderr)
         sys.exit(1)
 
     agent_dir = Path(sys.argv[1])
+    reindex = "--reindex" in sys.argv
 
     # Resolve data-dir (CLI flag wins; else $DATA_DIR; else ".")
     data_dir = "."
@@ -201,6 +259,19 @@ def main():
 
     conn = init_db(str(db_path))
 
+    if reindex:
+        # Recovery path: clear the incremental watermarks so every entry is
+        # re-examined. Entries already indexed are caught by the is_duplicate
+        # check below and skipped; entries previously dropped by the
+        # lexicographic-comparison bug get indexed this run.
+        conn.execute("DELETE FROM index_state WHERE key IN ('journal_last_ts', 'event_last_ts')")
+        conn.commit()
+        print("Reindex: cleared incremental watermarks (full re-scan; duplicates skipped).")
+
+    # Imported here (not at module top) so this module can be imported to unit-test
+    # the pure helpers without loading the embedding model.
+    from fastembed import TextEmbedding
+
     print(f"Loading embedding model ({MODEL_NAME})...")
     model = TextEmbedding(model_name=MODEL_NAME)
 
@@ -208,12 +279,14 @@ def main():
     journal_entries = parse_journal_entries(journal_dir) if journal_dir.exists() else []
     event_entries = parse_events(events_path)
 
-    # Filter to only new entries (incremental)
+    # Filter to only new entries (incremental). select_new_entries compares
+    # timestamps chronologically (parsed to UTC), never lexicographically — see
+    # parse_ts. It also returns the next watermark (latest new entry's ISO string).
     last_journal_ts = get_last_indexed(conn, "journal_last_ts")
     last_event_ts = get_last_indexed(conn, "event_last_ts")
 
-    new_journal = [e for e in journal_entries if e["timestamp"] > last_journal_ts]
-    new_events = [e for e in event_entries if e["timestamp"] > last_event_ts]
+    new_journal, new_journal_ts = select_new_entries(journal_entries, last_journal_ts)
+    new_events, new_event_ts = select_new_entries(event_entries, last_event_ts)
 
     all_new = new_journal + new_events
     if not all_new:
@@ -233,8 +306,6 @@ def main():
 
     indexed = 0
     skipped = 0
-    max_journal_ts = last_journal_ts
-    max_event_ts = last_event_ts
 
     for entry, emb in zip(all_new, embeddings):
         emb_np = np.array(emb, dtype=np.float32)
@@ -244,25 +315,22 @@ def main():
         if is_duplicate(conn, emb_np):
             skipped += 1
         else:
-            cursor = conn.execute(
+            conn.execute(
                 "INSERT INTO entries (source, timestamp, author, tag, content, embedding) VALUES (?, ?, ?, ?, ?, ?)",
                 (entry["source"], entry["timestamp"], entry.get("author"),
                  entry.get("tag"), entry["content"], emb_bytes)
             )
             indexed += 1
 
-        # Track max timestamps regardless
-        if entry["source"] == "journal" and entry["timestamp"] > max_journal_ts:
-            max_journal_ts = entry["timestamp"]
-        elif entry["source"] == "event" and entry["timestamp"] > max_event_ts:
-            max_event_ts = entry["timestamp"]
-
     conn.commit()
 
-    if max_journal_ts > last_journal_ts:
-        set_last_indexed(conn, "journal_last_ts", max_journal_ts)
-    if max_event_ts > last_event_ts:
-        set_last_indexed(conn, "event_last_ts", max_event_ts)
+    # Advance each watermark to the chronologically-latest entry seen this run
+    # (stored as its original ISO string). Done whenever new entries existed,
+    # regardless of dedup skips — matching the prior behaviour.
+    if new_journal:
+        set_last_indexed(conn, "journal_last_ts", new_journal_ts)
+    if new_events:
+        set_last_indexed(conn, "event_last_ts", new_event_ts)
 
     print(f"Done. Indexed: {indexed}, Skipped (duplicates): {skipped}")
     conn.close()


### PR DESCRIPTION
## Summary

Fixes **Finding 2** of #246/#247: `scripts/memory-index.py` compared ISO-8601 timestamps **as strings** in three places (the incremental filter, the max-tracking, and the watermark store). Across a UTC-offset or DST change a chronologically-later entry sorts lexicographically *earlier*, so the incremental filter treats it as already-indexed and **silently drops it** — the entry is never embedded and never surfaces in `memory-search.py` (the wake-up recall step). A high `+00:00` watermark also permanently traps subsequent lower-wall-clock `-07:00` entries.

`agent-coder`'s real data has mixed offsets (the container switched UTC → America/Los_Angeles): 923 events at `+00:00`, 1805 at `-07:00`. This already cost recall, and is **guaranteed to recur at the Nov 2026 DST transition** (`-07:00` → `-08:00`).

## The fix

- **`parse_ts(s)`** — parses ISO-8601 → tz-aware UTC `datetime`. Fail-safe: empty/unparseable → `datetime.min` (UTC), so such entries sort *oldest* and get (re-)indexed rather than silently dropped (the `is_duplicate` check prevents re-embedding genuine dupes).
- **`select_new_entries(entries, last_ts)`** — a pure, unit-testable filter + watermark computed via `parse_ts`. Replaces the inline lexicographic filter **and** the redundant in-loop max-tracking.
- **Lazy `fastembed` import** inside `main()` — so the module can be imported to unit-test the helpers without loading the embedding model.
- **`--reindex` flag** — clears the watermarks for a full re-scan. The forward fix prevents *future* drops but cannot reach entries already dropped *behind* the current watermark (e.g. March entries when the watermark is now June); `--reindex` recovers them. Idempotent via `is_duplicate`.

## Verification (memory scripts are not in CI — verified locally with `memory-venv`)

- **New `scripts/memory-index-tz-test.py`** — 7 checks (cross-offset ordering, Nov-DST boundary, `Z`/naive handling, fail-safe, the watermark-trap, first-run/empty). **Verified to bite**: each relevant assertion fails when `parse_ts`/`select_new_entries` is reverted to lexicographic comparison.
- **Real-data proof**: replaying agent-coder's corpus (file order is perfectly chronological) — the old lexicographic logic would drop **42 journal entries and ~14 events** that the chronological logic keeps.
- **Phased real-data E2E through the real CLI + model**: seed a `+00:00` watermark at the Mar-2026 UTC→PDT switch; the 3 following `-07:00` events (chronologically ~2h later) are trapped by the old code and correctly indexed by the new; watermark advances past the switch.
- **`--reindex` E2E**: entries behind the watermark are unreachable without it and fully recovered with it; a second run is idempotent (dupes skipped).
- **No regression**: existing `memory-test.py` E2E passes; node suite **506/506**.

## Scope

Addresses **F2 only**. F3 (`consolidate-memory.sh` awk, same root cause), F4 (`health-check.sh` DATA_DIR), F5 (`framework-update.sh` rollback) remain tracked in #247.

Refs #247
