### PR TITLE
fix: health-check.sh writes under DATA_DIR, not legacy ./logs (#247 F4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-portal",
-  "version": "1.5.23",
+  "version": "1.5.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-portal",
-      "version": "1.5.23",
+      "version": "1.5.24",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.5.23",
+  "version": "1.5.24",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -5,8 +5,9 @@
 #
 # Default mode: reads the `endpoints:` list from <agent-dir>/agent.yaml (a list
 # of {url, type} objects), issues GET requests, measures latency, and writes
-# one canonical JSONL line per endpoint to <agent-dir>/logs/health.jsonl
-# in the schema consumed by the portal Health tab:
+# one canonical JSONL line per endpoint to <agent-dir>/<DATA_DIR>/logs/health.jsonl
+# (DATA_DIR resolves from portal.config.json, default ".") in the schema
+# consumed by the portal Health tab:
 #
 #   {"ts","project","endpoint","status","latency_ms","ok"}
 #
@@ -78,7 +79,19 @@ if [ -n "$THRESHOLD" ] && ! [[ "$THRESHOLD" =~ ^[0-9]+$ ]]; then
   exit 1
 fi
 
-LOG_DIR="$AGENT_DIR/logs"
+# Resolve DATA_DIR from portal.config.json (defaults to ".") so health.jsonl
+# lands where the portal reads it. lib/routes/health.js reads via
+# dataPath(config,'logs','health.jsonl') = <agent-dir>/<DATA_DIR>/logs/...;
+# without this, a dataDir:"data" agent's results would be written to ./logs
+# while the Health tab reads ./data/logs and shows nothing. Same idiom as the
+# sibling path-writing scripts (log-event.sh, log-journal.sh).
+FRAMEWORK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+if [ -z "$DATA_DIR" ] && [ -f "$AGENT_DIR/portal.config.json" ]; then
+  eval "$(bash "$FRAMEWORK_DIR/scripts/read-harness-config.sh" "$AGENT_DIR" 2>/dev/null | grep '^export DATA_DIR=')"
+fi
+DATA_DIR="${DATA_DIR:-.}"
+
+LOG_DIR="$AGENT_DIR/$DATA_DIR/logs"
 LOG="$LOG_DIR/health.jsonl"
 
 if [ ! -d "$LOG_DIR" ]; then

--- a/test/health-check.test.sh
+++ b/test/health-check.test.sh
@@ -420,6 +420,34 @@ ONLY=$(jq -r '.project' "$NO_AGENT/logs/health.jsonl")
 assert_eq "Standalone" "$ONLY" "project name correctly recorded"
 rm -rf "$NO_AGENT"
 
+# --- Test 20: dataDir layout — writes under <agent>/<DATA_DIR>/logs (#247 F4) ---
+# A dataDir:"data" agent reads its Health tab from data/logs/health.jsonl
+# (lib/routes/health.js -> dataPath(config,'logs','health.jsonl')). The script
+# must resolve DATA_DIR from portal.config.json and write to the same place,
+# not to the legacy ./logs. DATA_DIR= prefix keeps the test hermetic regardless
+# of the caller's environment.
+echo "## Test 20: dataDir:\"data\" — health.jsonl lands under data/logs, not ./logs"
+DD_AGENT=$(mktemp -d)
+echo '{"dataDir":"data"}' > "$DD_AGENT/portal.config.json"
+mkdir -p "$DD_AGENT/data/logs"
+cat > "$DD_AGENT/agent.yaml" <<EOF
+name: ddagent
+endpoints:
+  - url: http://127.0.0.1:$PORT/200
+    type: http
+EOF
+EXIT=0
+DATA_DIR= "$HEALTH" "$DD_AGENT" >/dev/null 2>&1 || EXIT=$?
+assert_eq "0" "$EXIT" "exit 0 under dataDir layout"
+if [ -f "$DD_AGENT/data/logs/health.jsonl" ]; then DATA_LOG=yes; else DATA_LOG=no; fi
+assert_eq "yes" "$DATA_LOG" "health.jsonl written under data/logs (DATA_DIR-aware)"
+if [ -f "$DD_AGENT/logs/health.jsonl" ]; then LEGACY_LOG=yes; else LEGACY_LOG=no; fi
+assert_eq "no" "$LEGACY_LOG" "nothing written to legacy ./logs path"
+if [ "$DATA_LOG" = "yes" ]; then
+  assert_eq "ddagent" "$(jq -r '.project' "$DD_AGENT/data/logs/health.jsonl")" "project recorded under dataDir layout"
+fi
+rm -rf "$DD_AGENT"
+
 echo ""
 echo "# Results: $PASS/$TESTS passed, $FAIL failed"
 [ $FAIL -eq 0 ]


### PR DESCRIPTION
## Summary

Fixes **Finding 4** of #247 — the framework-script audit follow-up. F2 shipped in #248; this is the next-highest-ranked remaining item (the issue flags F2 and F4 as "the most worth doing").

`scripts/health-check.sh:81` hardcoded `LOG_DIR="$AGENT_DIR/logs"` — it was the **only path-writing framework script that did not resolve `DATA_DIR`** from `portal.config.json`. The consumer `lib/routes/health.js:10` reads via `dataPath(config,'logs','health.jsonl')` = `<agent-dir>/<DATA_DIR>/logs/...` (DATA_DIR-aware).

So on a `dataDir:"data"` agent with `features.health` enabled, the script writes `./logs/health.jsonl` while the portal reads `./data/logs/health.jsonl` → **Health tab always empty** (and the script may `exit 1` "Log dir not found"). Currently **latent** — no agent has both `dataDir:"data"` and `features.health` (contentbot is `dataDir:"data"` but `health:no`) — but a guaranteed trap for the next one. The hosted-deployment layout in the Data Layout doc is exactly `dataDir:"data"`.

## Fix

Resolve `DATA_DIR` via `read-harness-config.sh` using the **exact idiom from the sibling path-writing scripts** (`log-event.sh`, `log-journal.sh`), then write to `$AGENT_DIR/$DATA_DIR/logs`. Default/legacy layout (no `portal.config.json`, or `dataDir:"."`) is byte-identical to before.

## Verification

- **New Test 20** in `health-check.test.sh` exercises the `dataDir:"data"` case (health.jsonl lands under `data/logs`, **not** `./logs`; project recorded correctly). CI-covered (`npm test` runs `test/*.test.sh`).
- **Bite-verified**: reverting `LOG_DIR` to the old hardcoded path makes Test 20 report 2 FAILs and the suite exit 1.
- **Full health-check suite 62/62** (was 58); **node suite 506/506**; `bash -n` clean.
- **Standalone E2E** (10/10) confirms: `dataDir:"data"` → `data/logs`; no regression for no-config or `dataDir:"."` layouts → `./logs`; old code does **not** write to `data/logs` (bite).
- Sandbox note: Tests 1–19 can't run in this sandbox because the bare `python3` lacks PyYAML (the script's config parser needs it) — this fails identically on clean `main` and is unrelated to the change; verified above with the `memory-venv` python (which has PyYAML), matching the CI environment.

## Scope

F4 only, per the issue's "one PR at a time" intent. **F3** (consolidate-memory.sh awk, same root cause as F2) and **F5** (framework-update.sh rollback) remain tracked on #247.

Refs #247