### PR TITLE
fix: sanitize memory-search FTS5 query so keyword matching stops silently failing (#247 F6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-portal",
-  "version": "1.5.24",
+  "version": "1.5.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-portal",
-      "version": "1.5.24",
+      "version": "1.5.25",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.5.24",
+  "version": "1.5.25",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/scripts/memory-search-fts-test.py
+++ b/scripts/memory-search-fts-test.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Regression tests for FTS5 query sanitization in memory-search.py.
+
+These cover Finding 6 of agent-portal#247: memory-search.py passed the raw user
+query straight into an FTS5 ``MATCH``. FTS5's query syntax treats ":", "-", "(",
+")", "*", "^", double-quotes and bare AND/OR/NOT as operators, so any such
+character raised sqlite3.OperationalError — which the surrounding ``except
+Exception: pass`` silently swallowed, dropping the keyword half of the hybrid
+score. Since most of this agent's recall queries name hyphenated repos/scripts
+(agent-portal, memory-index, log-event, health-check), keyword matching was
+silently disabled on the majority of wake-up searches.
+
+build_fts_query reduces the query to space-joined quoted literal terms so it
+always parses, preserving the previous implicit-AND matching semantics for
+queries that already worked.
+
+Run locally (the memory scripts are not in CI — the python-tests job installs
+only pytest+mitmproxy):
+
+    scripts/memory-venv/bin/python scripts/memory-search-fts-test.py
+
+The build_fts_query tests are pure stdlib; the executes-against-fts5 tests build
+an in-memory FTS5 table. No embedding model is loaded — fastembed is imported
+lazily inside main(), so importing the module is instant.
+"""
+
+import importlib.util
+import re
+import sqlite3
+import sys
+from pathlib import Path
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "memory_search", Path(__file__).parent / "memory-search.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# The realistic wake-up queries that motivated the fix. All but the first two
+# contain an FTS5 operator character and raise on a raw MATCH.
+REALISTIC_QUERIES = [
+    "cost reporting fidelity",      # plain — already worked
+    "security audit npm",           # plain — already worked
+    "framework-update rollback",    # hyphen
+    "memory-index timestamp",       # hyphen
+    "cost: fidelity",               # ":" column-filter syntax
+    "health-check DATA_DIR",        # hyphen + underscore
+    "security audit (npm)",         # parens
+    "log-event.sh JSON",            # hyphen + dot
+    "agent-portal vs contentbot",   # hyphen
+    "what did I ship?",             # "?"
+    "NOT shipping",                 # bare NOT operator
+]
+
+
+def test_lazy_import(mod):
+    """Importing the module must not pull in fastembed, so the pure helper below
+    is testable without loading the embedding model."""
+    assert "fastembed" not in sys.modules, \
+        "fastembed must be imported lazily inside main(), not at module top"
+    print("✓ module imports without loading fastembed")
+
+
+def test_quotes_each_token(mod):
+    assert mod.build_fts_query("framework-update rollback") == '"framework" "update" "rollback"'
+    assert mod.build_fts_query("cost reporting fidelity") == '"cost" "reporting" "fidelity"'
+    # Underscores are word characters and stay within a single token (matching how
+    # the unicode61 tokenizer indexes DATA_DIR).
+    assert mod.build_fts_query("health-check DATA_DIR") == '"health" "check" "DATA_DIR"'
+    print("✓ build_fts_query wraps each word token in double quotes")
+
+
+def test_strips_operator_characters(mod):
+    """No FTS5 operator/special character may survive into the output except the
+    wrapping quotes — that is what makes the MATCH parse-safe."""
+    for q in REALISTIC_QUERIES:
+        out = mod.build_fts_query(q)
+        assert out is not None, f"unexpected None for {q!r}"
+        # Strip the wrapping quotes and the joining spaces; what remains must be
+        # word characters only — no ":", "-", "(", ")", "*", "?", "." leaked.
+        bare = out.replace('"', "").replace(" ", "")
+        assert re.fullmatch(r"\w*", bare), f"operator characters leaked from {q!r}: {out!r}"
+        for ch in ':-().?*^':
+            assert ch not in out, f"operator {ch!r} leaked from {q!r}: {out!r}"
+    print("✓ build_fts_query strips every FTS5 operator character")
+
+
+def test_empty_and_punctuation_only(mod):
+    assert mod.build_fts_query("") is None
+    assert mod.build_fts_query("   ") is None
+    assert mod.build_fts_query("???") is None
+    assert mod.build_fts_query("-- () : *") is None
+    print("✓ build_fts_query returns None when there is nothing to match on")
+
+
+def test_quote_in_query_is_neutralized(mod):
+    """A double-quote in the query must not break out of the quoting — the word
+    tokenizer drops it, so it can never reach FTS5 unescaped."""
+    out = mod.build_fts_query('say "hello" now')
+    assert out == '"say" "hello" "now"', out
+    assert out.count('"') == 6, f"stray quotes would break MATCH: {out!r}"
+    print("✓ build_fts_query neutralizes embedded double-quotes")
+
+
+def _make_fts():
+    conn = sqlite3.connect(":memory:")
+    # Default tokenizer (unicode61) — same as the real entries_fts table.
+    conn.execute("CREATE VIRTUAL TABLE fts USING fts5(content)")
+    conn.executemany("INSERT INTO fts(content) VALUES (?)", [
+        ("the framework-update rollback path and its checkout logic",),
+        ("memory-index timestamp comparison across a DST boundary",),
+        ("health-check DATA_DIR resolution for the hosted layout",),
+        ("security audit of npm advisories in the portal",),
+        ("log-event.sh JSON escaping prevents corruption",),
+        ("agent-portal and contentbot cycle notes about shipping",),
+    ])
+    return conn
+
+
+def test_raw_query_throws_but_sanitized_executes(mod):
+    """The bite + the fix, hermetically: the raw operator queries raise
+    OperationalError (the bug), while the sanitized form always executes."""
+    conn = _make_fts()
+    sql = "SELECT rowid FROM fts WHERE fts MATCH ? ORDER BY rank LIMIT 20"
+
+    raw_threw = 0
+    for q in REALISTIC_QUERIES:
+        # Sanitized form must never raise.
+        mq = mod.build_fts_query(q)
+        assert mq is not None
+        conn.execute(sql, (mq,)).fetchall()  # raises if the fix is wrong
+        # Track which raw queries throw (pins that the bug is real for these).
+        try:
+            conn.execute(sql, (q,)).fetchall()
+        except sqlite3.OperationalError:
+            raw_threw += 1
+    assert raw_threw >= 8, \
+        f"expected the raw operator queries to throw (the bug); only {raw_threw} did"
+    conn.close()
+    print(f"✓ sanitized queries all execute; {raw_threw}/{len(REALISTIC_QUERIES)} raw queries throw (the bug)")
+
+
+def test_sanitized_query_actually_matches(mod):
+    """Sanitizing must not just avoid errors — it must still find the content."""
+    conn = _make_fts()
+    sql = "SELECT rowid FROM fts WHERE fts MATCH ? ORDER BY rank LIMIT 20"
+    # A hyphenated query that previously threw now matches its indexed row.
+    hits = conn.execute(sql, (mod.build_fts_query("framework-update rollback"),)).fetchall()
+    assert len(hits) == 1, f"expected the rollback row, got {hits}"
+    hits = conn.execute(sql, (mod.build_fts_query("agent-portal contentbot"),)).fetchall()
+    assert len(hits) == 1, f"expected the agent-portal/contentbot row, got {hits}"
+    conn.close()
+    print("✓ sanitized hyphenated queries match the indexed content")
+
+
+def test_behavior_preserved_for_plain_queries(mod):
+    """For a query that already parsed, the sanitized form returns the same rows
+    (implicit-AND semantics preserved)."""
+    conn = _make_fts()
+    sql = "SELECT rowid FROM fts WHERE fts MATCH ? ORDER BY rank LIMIT 20"
+    for q in ("security audit npm", "cost reporting fidelity", "shipping"):
+        raw = conn.execute(sql, (q,)).fetchall()
+        san = conn.execute(sql, (mod.build_fts_query(q),)).fetchall()
+        assert raw == san, f"sanitizing changed results for plain query {q!r}: {raw} != {san}"
+    conn.close()
+    print("✓ plain queries return identical rows after sanitizing (behavior preserved)")
+
+
+def main():
+    mod = load_module()
+    test_lazy_import(mod)
+    test_quotes_each_token(mod)
+    test_strips_operator_characters(mod)
+    test_empty_and_punctuation_only(mod)
+    test_quote_in_query_is_neutralized(mod)
+    test_raw_query_throws_but_sanitized_executes(mod)
+    test_sanitized_query_actually_matches(mod)
+    test_behavior_preserved_for_plain_queries(mod)
+    print("\n✅ All FTS sanitization tests passed!")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/memory-search.py
+++ b/scripts/memory-search.py
@@ -10,6 +10,7 @@ snippet, and relevance score.
 
 import math
 import os
+import re
 import sqlite3
 import struct
 import sys
@@ -24,7 +25,11 @@ if "SSL_CERT_FILE" not in os.environ and os.path.exists("/etc/ssl/certs/ca-certi
     os.environ["SSL_CERT_FILE"] = "/etc/ssl/certs/ca-certificates.crt"
 
 import numpy as np
-from fastembed import TextEmbedding
+
+# fastembed (the embedding model) is imported lazily inside main() so this module
+# can be imported to unit-test the pure helpers (build_fts_query) without loading
+# the heavy model. numpy stays top-level — it is light and is used by the
+# module-level vector helpers (serialize_vec / deserialize_vec).
 
 EMBED_DIM = 384
 MODEL_NAME = "BAAI/bge-small-en-v1.5"
@@ -55,7 +60,32 @@ def recency_score(timestamp_str: str) -> float:
         return 0.0
 
 
-def search(db_path: str, query: str, model: TextEmbedding) -> list[dict]:
+def build_fts_query(query: str) -> str | None:
+    """Turn a free-text query into a safe FTS5 MATCH expression.
+
+    FTS5's MATCH syntax is not plain text: ``:`` introduces a column filter and
+    ``-``, ``(``, ``)``, ``*``, ``^``, double-quotes and the bare words AND/OR/NOT
+    are operators. Passing a raw query (e.g. ``"agent-portal"`` or ``"what did I
+    ship?"``) therefore raises ``sqlite3.OperationalError`` — which the caller's
+    except-clause silently swallows, disabling keyword matching for that query.
+    Most of this agent's queries name hyphenated repos/scripts (agent-portal,
+    memory-index, log-event), so the keyword half of the hybrid search was being
+    dropped on the majority of searches.
+
+    We extract word tokens and wrap each in double quotes so every term is a
+    literal string. FTS5 still tokenizes the quoted text with the table's own
+    tokenizer, so matching against indexed content is unchanged; tokens are
+    space-joined (FTS5 implicit AND), preserving the matching semantics for
+    queries that already parsed. Returns None when the query has no word
+    characters (nothing to match on).
+    """
+    tokens = re.findall(r"\w+", query)
+    if not tokens:
+        return None
+    return " ".join(f'"{t}"' for t in tokens)
+
+
+def search(db_path: str, query: str, model) -> list[dict]:
     """Perform hybrid search combining vector, keyword, and recency."""
     conn = sqlite3.connect(db_path)
 
@@ -75,19 +105,25 @@ def search(db_path: str, query: str, model: TextEmbedding) -> list[dict]:
         sorted_vec = sorted(vec_results.items(), key=lambda x: x[1], reverse=True)[:20]
         vec_results = dict(sorted_vec)
 
-    # FTS keyword search
+    # FTS keyword search. Sanitize the raw query into quoted literal terms first
+    # (see build_fts_query) — otherwise any FTS5 operator character in the query
+    # (a hyphen, ":", parens, "?", a bare NOT, ...) raises OperationalError that
+    # the except below would silently swallow, dropping the keyword half of the
+    # hybrid score. The except remains only as a last-resort guard.
     fts_results = {}
-    try:
-        fts_rows = conn.execute(
-            "SELECT rowid, rank FROM entries_fts WHERE entries_fts MATCH ? ORDER BY rank LIMIT 20",
-            (query,)
-        ).fetchall()
-        if fts_rows:
-            max_rank = max(abs(r[1]) for r in fts_rows)
-            for row_id, rank in fts_rows:
-                fts_results[row_id] = abs(rank) / max_rank if max_rank > 0 else 0
-    except Exception:
-        pass
+    match_query = build_fts_query(query)
+    if match_query:
+        try:
+            fts_rows = conn.execute(
+                "SELECT rowid, rank FROM entries_fts WHERE entries_fts MATCH ? ORDER BY rank LIMIT 20",
+                (match_query,)
+            ).fetchall()
+            if fts_rows:
+                max_rank = max(abs(r[1]) for r in fts_rows)
+                for row_id, rank in fts_rows:
+                    fts_results[row_id] = abs(rank) / max_rank if max_rank > 0 else 0
+        except Exception:
+            pass
 
     # Combine candidates
     all_ids = set(vec_results.keys()) | set(fts_results.keys())
@@ -178,6 +214,7 @@ def main():
         sys.exit(1)
 
     print(f"Loading embedding model ({MODEL_NAME})...", file=sys.stderr)
+    from fastembed import TextEmbedding
     model = TextEmbedding(model_name=MODEL_NAME)
 
     results = search(str(db_path), query, model)


### PR DESCRIPTION
## Finding 6 (new, from this cycle's continued framework-script audit) — `memory-search.py` silently drops keyword matching on most wake queries

`memory-search.py` is the recall **read** path every agent runs at wake (the `memory-search` step). F2 (#248) fixed the **index/write** side (`memory-index.py`); this is the never-audited read counterpart.

### The bug
`search()` passes the **raw user query** straight into an FTS5 `MATCH`:

```python
fts_rows = conn.execute(
    "SELECT rowid, rank FROM entries_fts WHERE entries_fts MATCH ? ORDER BY rank LIMIT 20",
    (query,)          # <-- raw query
).fetchall()
```

FTS5's query grammar is **not** plain text — `:` is a column filter and `-`, `(`, `)`, `*`, `^`, double-quotes and bare `AND`/`OR`/`NOT` are operators. So any such character raises `sqlite3.OperationalError`, which the surrounding `except Exception: pass` **silently swallows** — dropping the keyword half of the hybrid score (`FTS_WEIGHT = 0.25` **and** the entire FTS candidate set), falling back to vector-only with no signal that anything failed.

Because almost every recall query names a hyphenated repo/script (`agent-portal`, `memory-index`, `log-event`, `health-check`, `framework-update`, `dev-agent`, `starter-agent`, …), keyword matching was silently disabled on the **majority** of searches. Reproduced against the live `memory.db` — **8 of 10** realistic wake queries threw:

| query | raw MATCH |
|---|---|
| `cost reporting fidelity` | ✅ 2 hits |
| `framework-update rollback` | ❌ `no such column: update` |
| `memory-index timestamp` | ❌ `no such column: index` |
| `cost: fidelity` | ❌ `no such column: cost` |
| `health-check DATA_DIR` | ❌ `no such column: check` |
| `security audit (npm)` | ❌ `syntax error near "audit"` |
| `log-event.sh JSON` | ❌ `syntax error near "."` |
| `agent-portal vs contentbot` | ❌ `no such column: portal` |
| `what did I ship?` | ❌ `syntax error near "?"` |
| `NOT shipping` | ❌ `syntax error near "NOT"` |

This is "recall loss now" (same category as F2) — degrading every hyphenated/punctuated wake search, not just across a DST boundary.

### The fix
`build_fts_query()` reduces the query to space-joined quoted literal terms:

```python
tokens = re.findall(r"\w+", query)
return " ".join(f'"{t}"' for t in tokens) if tokens else None
```

- The `\w+` extraction inherently strips **every** FTS5 operator character (including the double-quote itself), so nothing can leak into `MATCH`.
- Each token is double-quoted → FTS5 treats it as a literal string but still tokenizes it with the table's own `unicode61` tokenizer, so matching against indexed content is unchanged.
- Tokens are space-joined → FTS5 **implicit AND**, preserving the matching semantics for queries that already parsed.
- Returns `None` (skip FTS) when the query has no word characters.

`fastembed` is now lazy-imported inside `main()` (mirrors the F2 change) so the pure helper is unit-testable without loading the embedding model.

### Verification
- **`scripts/memory-search-fts-test.py`** — 8 test groups (quoting, operator-stripping, empty/punctuation-only → `None`, embedded-quote neutralization, and a hermetic in-memory FTS5 table proving the raw operator queries throw while the sanitized form executes **and** matches). **Bite-verified**: reverting `build_fts_query` to the raw passthrough makes 6 of the groups fail. Memory scripts aren't in CI (the `python-tests` job installs only pytest+mitmproxy), so the test runs locally, matching the `memory-index-tz-test.py` posture.
- **Real E2E** against the live `memory.db` through the actual `search()`:
  - `framework-update rollback` → 5 results, **3 with `fts_score>0`** (was impossible — the query threw); the keyword boost ranks the rollback/framework entries to the top.
  - `health-check DATA_DIR` → ranks the cycle-137 health-check PR #1 (`fts=0.922` + recency).
  - `cost reporting fidelity` (already worked) → identical hit set; behavior preserved.
- `node --test` **506/506**; `data-dir-scripts` 18/18; `framework-update` 11/11; `health-check` 62/62 (run with a PyYAML-capable python — the bare-sandbox failures are the unrelated #247-F4-era env issue, op-learning #110).
- Version 1.5.24 → 1.5.25, lockfile synced.

Refs #247