### PR TITLE
fix: compare consolidate-memory timestamps chronologically (#247 F3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-portal",
-  "version": "1.5.25",
+  "version": "1.5.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-portal",
-      "version": "1.5.25",
+      "version": "1.5.26",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.5.25",
+  "version": "1.5.26",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/scripts/consolidate-filter.py
+++ b/scripts/consolidate-filter.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Chronological timestamp filtering for consolidate-memory.sh (agent-portal#247 F3).
+
+consolidate-memory.sh selected the journal entries and events "since the last
+consolidation" by comparing ISO-8601 timestamps *lexicographically* in awk
+(`entry_ts > ts`, `a[1] > last`, `$1 <= ts`). That is wrong across a UTC-offset
+or DST change: a chronologically-later entry can sort lexicographically *earlier*
+("...T07:00:00-07:00" = 14:00Z is later than "...T13:00:00+00:00" = 13:00Z, yet
+"07" < "13" as strings), so recent journal/event entries get wrongly excluded
+from the consolidation input fed to the LLM. Same root cause as Finding 2
+(memory-index.py), but awk has no datetime parsing — so the comparison moves
+into this stdlib-only helper that consolidate-memory.sh shells out to.
+
+Reference timestamp is argv[2]; data is read from stdin; results are written one
+line at a time to stdout. Modes:
+
+  count-after <ref>     events JSONL in  -> count of lines whose "ts" > ref
+  after <ref>           events JSONL in  -> the lines whose "ts" > ref
+  journal-after <ref>   journal md in    -> lines of entries whose `### <ts>` > ref
+
+"After" is always strict (`> ref`), matching the original awk semantics: the
+"since last consolidation" window excludes an entry stamped exactly at the last
+consolidation time.
+"""
+
+import re
+import sys
+from datetime import datetime, timezone
+
+# First "ts":"..." on a line is the event timestamp (it is always the first
+# field; .search returns the first match, so a summary that happens to contain
+# the substring cannot shadow it). Mirrors the old awk -F'"ts":"' field split.
+_TS_RE = re.compile(r'"ts"\s*:\s*"([^"]*)"')
+# Journal header: `### <iso-ts> | <author> | <tag>`. The ts is the first
+# non-space token after the marker and always starts with a digit (year).
+_HEADER_RE = re.compile(r'^###\s+([0-9]\S*)')
+
+
+def parse_ts(s):
+    """ISO-8601 -> tz-aware UTC datetime for *chronological* comparison.
+
+    Fail-safe: empty / unparseable timestamps return datetime.min (UTC) so they
+    sort oldest — an entry with a junk timestamp is treated as old and excluded
+    from the "since" window rather than crashing the consolidation. Mirrors
+    parse_ts in memory-index.py (Finding 2)."""
+    if not s:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    try:
+        dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return datetime.min.replace(tzinfo=timezone.utc)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _event_ts(line):
+    m = _TS_RE.search(line)
+    return m.group(1) if m else ""
+
+
+def events_after(lines, ref):
+    """Event JSONL lines whose "ts" field is chronologically after ref."""
+    ref_dt = parse_ts(ref)
+    return [ln for ln in lines if ln.strip() and parse_ts(_event_ts(ln)) > ref_dt]
+
+
+def journal_after(lines, ref):
+    """Journal markdown lines belonging to entries whose `### <ts> | ...` header
+    is chronologically after ref.
+
+    Replicates the awk state machine: a header line sets whether the following
+    lines (up to the next header) are emitted; lines before the first header are
+    not emitted."""
+    ref_dt = parse_ts(ref)
+    out, printing = [], False
+    for ln in lines:
+        m = _HEADER_RE.match(ln)
+        if m:
+            printing = parse_ts(m.group(1)) > ref_dt
+        if printing:
+            out.append(ln)
+    return out
+
+
+def main(argv):
+    if len(argv) < 3:
+        sys.stderr.write(
+            "usage: consolidate-filter.py {count-after|after|journal-after} <ref-ts>\n")
+        return 2
+    mode, ref = argv[1], argv[2]
+    lines = sys.stdin.read().splitlines()
+    if mode == "count-after":
+        print(len(events_after(lines, ref)))
+    elif mode == "after":
+        sys.stdout.write("".join(ln + "\n" for ln in events_after(lines, ref)))
+    elif mode == "journal-after":
+        sys.stdout.write("".join(ln + "\n" for ln in journal_after(lines, ref)))
+    else:
+        sys.stderr.write(f"unknown mode: {mode}\n")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/consolidate-memory.sh
+++ b/scripts/consolidate-memory.sh
@@ -53,11 +53,12 @@ if [ -f "$INSIGHTS_FILE" ]; then
   LAST_CONSOLIDATION_TS=$(grep -E '^\s*last_consolidated:' "$INSIGHTS_FILE" 2>/dev/null | head -1 | sed 's/^[^:]*: *//' | tr -d '"' | tr -d "'" | tr -d ' ')
 fi
 
-# Count cycles since last consolidation
+# Count cycle_start events since last consolidation. Timestamps are compared
+# chronologically (consolidate-filter.py) — a lexicographic ISO compare miscounts
+# across a UTC-offset / DST change, the same root cause as #247 F2 (memory-index.py).
 if [ -n "$LAST_CONSOLIDATION_TS" ]; then
-  CYCLES_SINCE=$(grep -c '"type":"cycle_start"' "$EVENTS_FILE" 2>/dev/null || echo 0)
-  CYCLES_BEFORE=$(grep '"type":"cycle_start"' "$EVENTS_FILE" 2>/dev/null | awk -F'"ts":"' '{print $2}' | awk -F'"' '{print $1}' | awk -v ts="$LAST_CONSOLIDATION_TS" '$1 <= ts' | wc -l)
-  CYCLES_SINCE=$((CYCLES_SINCE - CYCLES_BEFORE))
+  CYCLES_SINCE=$(grep '"type":"cycle_start"' "$EVENTS_FILE" 2>/dev/null | \
+    python3 "$FRAMEWORK_DIR/scripts/consolidate-filter.py" count-after "$LAST_CONSOLIDATION_TS")
 else
   CYCLES_SINCE=$(grep -c '"type":"cycle_start"' "$EVENTS_FILE" 2>/dev/null || echo 0)
 fi
@@ -76,16 +77,9 @@ JOURNAL_CONTENT=""
 for md_file in "$JOURNALS_DIR"/*.md; do
   [ -f "$md_file" ] || continue
   if [ -n "$LAST_CONSOLIDATION_TS" ]; then
-    # Extract entries newer than last consolidation timestamp
+    # Extract entries newer than last consolidation (chronological compare, #247 F3)
     JOURNAL_CONTENT="$JOURNAL_CONTENT
-$(awk -v ts="$LAST_CONSOLIDATION_TS" '
-  /^### [0-9]/ {
-    split($2, a, " ")
-    entry_ts = a[1]
-    if (entry_ts > ts) { printing=1 } else { printing=0 }
-  }
-  printing { print }
-' "$md_file")"
+$(python3 "$FRAMEWORK_DIR/scripts/consolidate-filter.py" journal-after "$LAST_CONSOLIDATION_TS" < "$md_file")"
   else
     JOURNAL_CONTENT="$JOURNAL_CONTENT
 $(cat "$md_file")"
@@ -95,8 +89,9 @@ done
 # Collect work events since last consolidation
 EVENTS_CONTENT=""
 if [ -n "$LAST_CONSOLIDATION_TS" ]; then
+  # Events newer than last consolidation (chronological compare, #247 F3)
   EVENTS_CONTENT=$(grep -E '"type":"(work|error|dissonance)"' "$EVENTS_FILE" 2>/dev/null | \
-    awk -F'"ts":"' '{split($2,a,"\""); if(a[1] > "'"$LAST_CONSOLIDATION_TS"'") print}' || true)
+    python3 "$FRAMEWORK_DIR/scripts/consolidate-filter.py" after "$LAST_CONSOLIDATION_TS" || true)
 else
   EVENTS_CONTENT=$(grep -E '"type":"(work|error|dissonance)"' "$EVENTS_FILE" 2>/dev/null || true)
 fi

--- a/test/consolidate-memory.test.sh
+++ b/test/consolidate-memory.test.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# consolidate-memory.test.sh — Regression tests for chronological timestamp
+# filtering in consolidate-memory.sh (agent-portal#247 Finding 3).
+#
+# The script picked the journal entries and events "since the last consolidation"
+# with lexicographic ISO-8601 comparisons in awk. Across a UTC-offset / DST change
+# a chronologically-later entry sorts lexicographically earlier
+# ("...T07:00:00-07:00" = 14:00Z is later than "...T13:00:00+00:00" = 13:00Z, yet
+# "07" < "13" as strings), so recent entries were wrongly excluded from the LLM
+# consolidation input. The comparison now lives in scripts/consolidate-filter.py
+# (stdlib python3, available on the CI runner), which these tests exercise.
+#
+# Each "after" assertion is a BITE point: the lexicographic logic gives the
+# opposite answer on the cross-offset fixtures.
+set -e
+
+FRAMEWORK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+FILTER="$FRAMEWORK_DIR/scripts/consolidate-filter.py"
+
+OK=0
+FAIL=0
+ok()   { echo "  ok - $*"; OK=$((OK+1)); }
+fail() { echo "  not ok - $*"; FAIL=$((FAIL+1)); }
+
+# The canonical cross-offset pair, reference = 13:00Z.
+# A = 14:00Z written as 07:00-07:00 (chronologically AFTER 13:00Z, lexically before)
+# B = 12:00Z written as +00:00       (chronologically BEFORE 13:00Z)
+REF="2026-06-15T13:00:00+00:00"
+A_EV='{"ts":"2026-06-15T07:00:00-07:00","type":"cycle_start","summary":"A 14:00Z"}'
+B_EV='{"ts":"2026-06-15T12:00:00+00:00","type":"cycle_start","summary":"B 12:00Z"}'
+
+echo "# consolidate-filter.py count-after — cross-offset"
+N=$(printf '%s\n%s\n' "$A_EV" "$B_EV" | python3 "$FILTER" count-after "$REF")
+[ "$N" = "1" ] && ok "counts the 14:00Z entry as after 13:00Z (got $N)" \
+                || fail "expected 1 cycle after ref, got $N (lexicographic bug returns 0)"
+
+echo "## both entries after a very old ref → counts 2"
+N=$(printf '%s\n%s\n' "$A_EV" "$B_EV" | python3 "$FILTER" count-after "2000-01-01T00:00:00+00:00")
+[ "$N" = "2" ] && ok "counts both after epoch-old ref" || fail "expected 2, got $N"
+
+echo "## both entries before a future ref → counts 0"
+N=$(printf '%s\n%s\n' "$A_EV" "$B_EV" | python3 "$FILTER" count-after "2030-01-01T00:00:00+00:00")
+[ "$N" = "0" ] && ok "counts 0 when ref is in the future" || fail "expected 0, got $N"
+
+echo "## empty input → counts 0 (no crash under set -e pipeline)"
+N=$(printf '' | python3 "$FILTER" count-after "$REF")
+[ "$N" = "0" ] && ok "empty stdin yields 0" || fail "expected 0 on empty input, got $N"
+
+echo ""
+echo "# consolidate-filter.py after — cross-offset"
+A_WORK='{"ts":"2026-06-15T07:00:00-07:00","type":"work","summary":"A 14:00Z"}'
+B_WORK='{"ts":"2026-06-15T12:00:00+00:00","type":"work","summary":"B 12:00Z"}'
+OUT=$(printf '%s\n%s\n' "$A_WORK" "$B_WORK" | python3 "$FILTER" after "$REF")
+echo "$OUT" | grep -q "A 14:00Z" && ok "emits the 14:00Z event (after ref)" \
+                                 || fail "14:00Z event wrongly dropped (lexicographic bug)"
+echo "$OUT" | grep -q "B 12:00Z" && fail "12:00Z event should be excluded" \
+                                 || ok "excludes the 12:00Z event (before ref)"
+
+echo "## ref exactly equal to an entry ts → strict after excludes it"
+OUT=$(printf '%s\n' "$B_WORK" | python3 "$FILTER" after "2026-06-15T12:00:00+00:00")
+[ -z "$OUT" ] && ok "entry stamped exactly at ref is excluded (strict >)" \
+              || fail "entry at ref should be excluded, got: $OUT"
+
+echo "## same offset across ref → ordinary case still correct"
+E1='{"ts":"2026-06-15T10:00:00+00:00","type":"work","summary":"E1 before"}'
+E2='{"ts":"2026-06-15T16:00:00+00:00","type":"work","summary":"E2 after"}'
+OUT=$(printf '%s\n%s\n' "$E1" "$E2" | python3 "$FILTER" after "$REF")
+echo "$OUT" | grep -q "E2 after" && ok "keeps the later same-offset entry" || fail "E2 wrongly dropped"
+echo "$OUT" | grep -q "E1 before" && fail "E1 should be excluded" || ok "drops the earlier same-offset entry"
+
+echo "## malformed line (no ts) is treated as old and excluded (fail-safe)"
+OUT=$(printf '%s\n%s\n' "$A_WORK" 'garbage with no ts field' | python3 "$FILTER" after "$REF")
+echo "$OUT" | grep -q "garbage" && fail "no-ts line should be excluded from the since-window" \
+                                || ok "no-ts line excluded (parse_ts fail-safe → datetime.min)"
+
+echo ""
+echo "# consolidate-filter.py journal-after — stateful + cross-offset"
+JOURNAL=$(cat <<'EOF'
+### 2026-06-15T07:00:00-07:00 | coder | cycle
+body line one of A (14:00Z, after ref)
+body line two of A
+### 2026-06-15T12:00:00+00:00 | coder | cycle
+body of B (12:00Z, before ref)
+EOF
+)
+OUT=$(printf '%s\n' "$JOURNAL" | python3 "$FILTER" journal-after "$REF")
+echo "$OUT" | grep -q "body line one of A" && ok "keeps the 14:00Z entry header+body" \
+                                           || fail "14:00Z journal entry wrongly dropped (lexicographic bug)"
+echo "$OUT" | grep -q "body line two of A" && ok "keeps ALL body lines until the next header" \
+                                           || fail "multi-line body not fully emitted"
+echo "$OUT" | grep -q "body of B" && fail "12:00Z entry should be excluded" \
+                                  || ok "excludes the 12:00Z entry"
+
+echo "## leading content before the first header is not emitted"
+LEAD=$(cat <<'EOF'
+# Journal preamble — no header yet
+### 2026-06-15T07:00:00-07:00 | coder | cycle
+kept body
+EOF
+)
+OUT=$(printf '%s\n' "$LEAD" | python3 "$FILTER" journal-after "$REF")
+echo "$OUT" | grep -q "preamble" && fail "pre-header lines should not be emitted" \
+                                 || ok "pre-header lines excluded (matches awk state machine)"
+echo "$OUT" | grep -q "kept body" && ok "post-header body still emitted" || fail "kept body missing"
+
+echo "## Z-suffixed header timestamp parses (not only ±hh:mm offsets)"
+ZJOURNAL=$(cat <<'EOF'
+### 2026-06-15T16:00:00Z | system | output
+kept Z entry
+EOF
+)
+OUT=$(printf '%s\n' "$ZJOURNAL" | python3 "$FILTER" journal-after "$REF")
+echo "$OUT" | grep -q "kept Z entry" && ok "Z-suffixed header (16:00Z > 13:00Z) kept" || fail "Z header dropped"
+
+echo ""
+echo "# integration — consolidate-memory.sh actually routes through the helper"
+grep -q 'consolidate-filter.py' "$FRAMEWORK_DIR/scripts/consolidate-memory.sh" \
+  && ok "consolidate-memory.sh shells out to consolidate-filter.py" \
+  || fail "consolidate-memory.sh no longer calls consolidate-filter.py (integration lost)"
+# The old buggy awk timestamp comparisons must be gone.
+grep -q 'entry_ts > ts' "$FRAMEWORK_DIR/scripts/consolidate-memory.sh" \
+  && fail "lexicographic awk journal compare still present" \
+  || ok "lexicographic awk journal compare removed"
+
+echo ""
+echo "# Results: $((OK+FAIL)) tests, $OK passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Finding 3 of #247 — `consolidate-memory.sh` lexicographic timestamp comparison

`consolidate-memory.sh` selected the journal entries and events "since the last consolidation" by comparing ISO-8601 timestamps **lexicographically** in awk (`entry_ts > ts` line 85, `a[1] > last` line 99, `$1 <= ts` line 59). Across a UTC-offset / DST change a chronologically-later entry sorts lexicographically *earlier* — `…T07:00:00-07:00` (14:00Z) is later than `…T13:00:00+00:00` (13:00Z), yet `"07" < "13"` as strings — so recent entries are wrongly **excluded** from, or stale already-consolidated entries wrongly **included** in, the consolidation input fed to the LLM.

Same root cause as **Finding 2** (`memory-index.py`, #248) and the FTS read-path **Finding 6** (#250). This **completes the memory-subsystem correctness audit**: write (index, F2) → read (search, F6) → **consolidate (F3)**.

### Fix
awk has no datetime parsing, so the comparison moves to a **stdlib-only** python helper `scripts/consolidate-filter.py` that the script shells out to at all three sites; the shell keeps its `grep` type-filtering (which was correct). Modes `count-after` / `after` / `journal-after` are all chronological via a `parse_ts` mirroring the one in `memory-index.py` (ISO → tz-aware UTC, fail-safe to `datetime.min`). Net `-5` lines in the shell script.

### Verification
- **Real corpus, real transitions** (agent-coder's `events.jsonl`, ~2700 lines spanning the Mar-2026 `+00:00`↔`-07:00` switches): at ref `2026-03-19T13:00:01-07:00` the old logic wrongly **includes 12** already-consolidated events; at ref `2026-03-21T16:43:25+00:00` it wrongly **drops 18** recent events (the dangerous "lose recent learnings" direction).
- **New `test/consolidate-memory.test.sh`** — 18 checks, **CI-visible** via `npm test`'s shell-test loop (the helper is stdlib python3, present on the runner; F2/F6's python tests are local-only). **Bite-verified**: reverting the helper to lexicographic fails exactly the 5 cross-offset assertions + exits 1.
- **Full real-script E2E** with a stubbed `claude` on a boundary-spanning fixture: the prompt actually fed to consolidation includes the `-07:00` entries after a `+00:00` ref and excludes the before-ref entries (old logic would drop the former).
- `npm run test:node` → **506/506**. `bash -n` clean. Version `1.5.25 → 1.5.26`, lockfile synced.

### No recovery step (unlike F2)
Consolidation is additive — `journals/` and `events.jsonl` are never deleted (script header line 15). Only past *summaries* were built on slightly-wrong input; the raw data is intact, so there is nothing to re-index/recover. The forward fix prevents future mis-selection (next: Nov-2026 DST, or any container offset change).

### Remaining on #247
**F5** (`framework-update.sh` rollback logs success on a failed checkout — narrow). 

`Refs #247`