### PR TITLE
fix: framework-update rollback must not report success on a failed checkout (#247 F5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-portal",
-  "version": "1.5.26",
+  "version": "1.5.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-portal",
-      "version": "1.5.26",
+      "version": "1.5.27",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.5.26",
+  "version": "1.5.27",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/scripts/framework-update.sh
+++ b/scripts/framework-update.sh
@@ -56,21 +56,31 @@ fi
 if [ -f "$CYCLE_FAILED_MARKER" ] && [ -n "$FRAMEWORK_LAST_KNOWN_GOOD" ] && [ "$FRAMEWORK_LAST_KNOWN_GOOD" != "null" ]; then
   if [ "$FRAMEWORK_COMMIT" != "$FRAMEWORK_LAST_KNOWN_GOOD" ]; then
     echo "Previous cycle failed and framework changed — rolling back to $FRAMEWORK_LAST_KNOWN_GOOD" >&2
-    git -C "$FRAMEWORK_DIR" checkout "$FRAMEWORK_LAST_KNOWN_GOOD" >&2 2>&1 || {
-      echo "ERROR: rollback failed" >&2
-      bash "$FRAMEWORK_DIR/scripts/log-event.sh" "$AGENT_DIR" error \
-        "Framework rollback to $FRAMEWORK_LAST_KNOWN_GOOD failed"
-    }
-    FRAMEWORK_COMMIT="$FRAMEWORK_LAST_KNOWN_GOOD"
-    bash "$FRAMEWORK_DIR/scripts/log-event.sh" "$AGENT_DIR" rollback \
-      "Rolled back framework to $FRAMEWORK_LAST_KNOWN_GOOD"
-    # Restart portal again with the rolled-back code
-    if [ -f "$PORTAL_PID_FILE" ]; then
-      PORTAL_PID=$(cat "$PORTAL_PID_FILE" 2>/dev/null)
-      if [ -n "$PORTAL_PID" ] && kill -0 "$PORTAL_PID" 2>/dev/null; then
-        kill "$PORTAL_PID" 2>/dev/null
-        echo "Killed portal after rollback (PID $PORTAL_PID)" >&2
+    if git -C "$FRAMEWORK_DIR" checkout "$FRAMEWORK_LAST_KNOWN_GOOD" >&2 2>&1; then
+      # Checkout succeeded — HEAD is now the last-known-good. Report it as the
+      # current commit and log the rollback as a success.
+      FRAMEWORK_COMMIT="$FRAMEWORK_LAST_KNOWN_GOOD"
+      bash "$FRAMEWORK_DIR/scripts/log-event.sh" "$AGENT_DIR" rollback \
+        "Rolled back framework to $FRAMEWORK_LAST_KNOWN_GOOD"
+      # Restart portal again with the rolled-back code
+      if [ -f "$PORTAL_PID_FILE" ]; then
+        PORTAL_PID=$(cat "$PORTAL_PID_FILE" 2>/dev/null)
+        if [ -n "$PORTAL_PID" ] && kill -0 "$PORTAL_PID" 2>/dev/null; then
+          kill "$PORTAL_PID" 2>/dev/null
+          echo "Killed portal after rollback (PID $PORTAL_PID)" >&2
+        fi
       fi
+    else
+      # Checkout FAILED — HEAD is still on the broken commit. Do NOT overwrite
+      # FRAMEWORK_COMMIT (it must keep reporting the real HEAD) and do NOT log a
+      # success rollback: otherwise wake.sh would record the last-known-good SHA
+      # while actually running the broken commit, poisoning framework-last-known-good.
+      # Exiting non-zero would not help — wake.sh consumes this via `eval "$(...)"`,
+      # which discards the exit status and would just blank FRAMEWORK_COMMIT (risking
+      # a last-known-good wipe). So we continue and report the real HEAD on stdout below.
+      echo "ERROR: rollback failed — HEAD remains on $FRAMEWORK_COMMIT" >&2
+      bash "$FRAMEWORK_DIR/scripts/log-event.sh" "$AGENT_DIR" error \
+        "Framework rollback to $FRAMEWORK_LAST_KNOWN_GOOD failed; HEAD still on $FRAMEWORK_COMMIT"
     fi
   fi
 fi

--- a/test/framework-update.test.sh
+++ b/test/framework-update.test.sh
@@ -97,6 +97,100 @@ SECOND_RESULT=$(cat "$KILL_LOG" 2>/dev/null || true)
 assert_eq "would-restart" "$FIRST_RESULT" "restart on first change"
 assert_eq "" "$SECOND_RESULT" "no restart after stabilizing"
 
+# ============================================================================
+# Rollback behavior — real end-to-end runs of framework-update.sh (#247 F5)
+# ============================================================================
+# Unlike the stale-portal tests above (which exercise an extracted copy of the
+# logic), these run the ACTUAL script against a throwaway git repo and assert
+# its observable effects. The bug (#247 F5): when `git checkout <last-known-good>`
+# fails, the old `|| { ... }` branch logged the error but execution CONTINUED —
+# overwriting FRAMEWORK_COMMIT with the (un-checked-out) target and logging a
+# success `rollback` event unconditionally. So a failed rollback reported the
+# opposite of reality and poisoned framework-last-known-good.
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RB_CLEANUP_DIRS=""
+RB_CLEANUP_FILES=""
+
+# Extend the existing EXIT trap to also clear rollback fixtures.
+cleanup_rollback() {
+  rm -rf $RB_CLEANUP_DIRS
+  rm -f $RB_CLEANUP_FILES
+}
+trap 'cleanup; cleanup_rollback' EXIT
+
+count_events() {  # $1=events.jsonl path, $2=event type
+  [ -f "$1" ] || { echo 0; return; }
+  local n
+  n=$(grep -c "\"type\":\"$2\"" "$1" 2>/dev/null || true)
+  echo "${n:-0}"
+}
+
+# run_rollback <last-known-good-value>
+# Builds a self-contained framework dir (real helper scripts + node_modules,
+# throwaway git history: commit "good" then commit "broken"=HEAD), sets agent.yaml's
+# framework-last-known-good to $1, plants the cycle-failed marker, then runs the
+# real framework-update.sh. Sets globals: RB_STDOUT, RB_EXIT, RB_HEAD,
+# RB_SHA_GOOD, RB_SHA_BROKEN, RB_EVENTS, RB_REPORTED_COMMIT.
+run_rollback() {
+  local lkg="$1"
+  local fw agent name
+  fw=$(mktemp -d); agent=$(mktemp -d)
+  name="fwtest-$$-$RANDOM"
+  RB_CLEANUP_DIRS="$RB_CLEANUP_DIRS $fw $agent"
+  RB_CLEANUP_FILES="$RB_CLEANUP_FILES /tmp/agent-${name}-cycle-failed /tmp/${name}-portal-commit /tmp/${name}-portal.pid /tmp/agent-${name}-wake-prompt.txt /tmp/agent-${name}-respond-prompt.txt"
+
+  # Real helper scripts the script invokes (skip the heavy memory-venv); node_modules for js-yaml.
+  mkdir -p "$fw/scripts"
+  local s
+  for s in framework-update.sh read-config.js log-event.sh read-harness-config.sh; do
+    cp "$REPO_ROOT/scripts/$s" "$fw/scripts/$s"
+  done
+  ln -s "$REPO_ROOT/node_modules" "$fw/node_modules"
+
+  # Throwaway git history. Only `version` is tracked; scripts/ + node_modules stay
+  # untracked so `git checkout <sha>` never touches them.
+  git -C "$fw" init -q
+  git -C "$fw" config user.email "test@example.com"
+  git -C "$fw" config user.name "test"
+  echo good > "$fw/version"; git -C "$fw" add version; git -C "$fw" commit -qm good
+  RB_SHA_GOOD=$(git -C "$fw" rev-parse HEAD)
+  echo broken > "$fw/version"; git -C "$fw" add version; git -C "$fw" commit -qm broken
+  RB_SHA_BROKEN=$(git -C "$fw" rev-parse HEAD)
+
+  # Sentinel @GOOD@ means "use THIS fixture's good SHA" (only known after the commits exist).
+  [ "$lkg" = "@GOOD@" ] && lkg="$RB_SHA_GOOD"
+  printf 'name: %s\nframework-last-known-good: %s\n' "$name" "$lkg" > "$agent/agent.yaml"
+  touch "/tmp/agent-${name}-cycle-failed"
+
+  RB_EXIT=0
+  RB_STDOUT=$(bash "$fw/scripts/framework-update.sh" "$fw" "$agent" 2>/dev/null) || RB_EXIT=$?
+  RB_HEAD=$(git -C "$fw" rev-parse HEAD)
+  RB_EVENTS="$agent/logs/events.jsonl"
+  # Mirror wake.sh:211 — eval the script's stdout to recover the exported commit.
+  FRAMEWORK_COMMIT=""
+  eval "$RB_STDOUT"
+  RB_REPORTED_COMMIT="$FRAMEWORK_COMMIT"
+}
+
+# --- Test 7: Successful rollback moves HEAD, reports the good SHA, logs success ---
+echo "## Test 7: Successful rollback (checkout succeeds)"
+run_rollback "@GOOD@"   # roll back to this fixture's own good SHA
+assert_eq "$RB_SHA_GOOD" "$RB_HEAD" "HEAD is moved to last-known-good"
+assert_eq "$RB_SHA_GOOD" "$RB_REPORTED_COMMIT" "exported FRAMEWORK_COMMIT is the good SHA"
+assert_eq "1" "$(count_events "$RB_EVENTS" rollback)" "one rollback (success) event logged"
+assert_eq "0" "$(count_events "$RB_EVENTS" error)" "no error event on success"
+assert_eq "0" "$RB_EXIT" "script exits 0 on success"
+
+# --- Test 8: FAILED rollback must NOT report success (the #247 F5 bug) ---
+echo "## Test 8: Failed rollback (checkout of a non-existent commit)"
+run_rollback "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"   # not a real object → checkout fails
+assert_eq "$RB_SHA_BROKEN" "$RB_HEAD" "HEAD stays on the broken commit (checkout failed)"
+assert_eq "$RB_SHA_BROKEN" "$RB_REPORTED_COMMIT" "exported FRAMEWORK_COMMIT is the REAL HEAD, not the failed target"
+assert_eq "0" "$(count_events "$RB_EVENTS" rollback)" "NO success rollback event on failure"
+assert_eq "1" "$(count_events "$RB_EVENTS" error)" "an error event is logged on failure"
+assert_eq "0" "$RB_EXIT" "script still exits 0 (wake.sh consumes stdout via eval, not exit code)"
+
 echo ""
 echo "# Results: $PASS/$TESTS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

Fixes **Finding 5** of #247 — the last open item on the framework-script audit, completing the issue.

`scripts/framework-update.sh` rolled back the framework with:

```sh
git -C "$FRAMEWORK_DIR" checkout "$FRAMEWORK_LAST_KNOWN_GOOD" >&2 2>&1 || {
  echo "ERROR: rollback failed" >&2
  bash .../log-event.sh "$AGENT_DIR" error "Framework rollback ... failed"
}
FRAMEWORK_COMMIT="$FRAMEWORK_LAST_KNOWN_GOOD"      # <-- runs even on failure
bash .../log-event.sh "$AGENT_DIR" rollback "Rolled back ..."   # <-- success, unconditional
```

The `|| { ... }` **catches** the checkout failure (so `set -e` never fires) and execution **continues**. On a failed checkout the script then:
1. overwrites `FRAMEWORK_COMMIT` with the rollback *target* (while HEAD is still on the broken commit),
2. logs a **success** `rollback` event unconditionally — so the log shows a contradictory *"rollback failed"* **and** *"Rolled back successfully"*,
3. exports the good SHA on stdout (line 102), which `wake.sh:211` `eval`s and later writes as `framework-last-known-good` (`wake.sh:455`) — **recording the good SHA as last-known-good while the agent is actually running the broken commit.**

This is the failure-handling-of-a-failure path: it fires precisely when an update has already gone wrong, and reports the opposite of reality during exactly the moment an operator is debugging. Recall surfaced a real `Framework rollback ... failed` event in agent-coder's own history (2026-03-31), so rollbacks do happen in practice.

## Fix

Restructure `|| { ... }` into `if git checkout ...; then <success> else <failure> fi`:
- **Success path** (overwrite `FRAMEWORK_COMMIT`, log `rollback` success, restart portal) now runs **only when the checkout actually succeeds**.
- **Failure path** leaves `FRAMEWORK_COMMIT` untouched (so stdout reports the *real* HEAD, the broken commit) and logs only the `error` event.

Deliberately **not** `exit 1`: `wake.sh` consumes this via `eval "$(framework-update.sh ...)"`, which discards the script's exit status and would just blank `FRAMEWORK_COMMIT` — risking a `framework-last-known-good` *wipe* on the next successful cycle. Reporting the truthful HEAD on stdout is the correct contract.

## Tests

`test/framework-update.test.sh` gains a **real end-to-end harness** that runs the actual script against a throwaway git repo (good commit → broken commit = HEAD), with the real `read-config.js`/`log-event.sh` helpers and a planted cycle-failed marker. **11 → 21 assertions:**
- **Test 7 — successful rollback:** HEAD moves to last-known-good; exported `FRAMEWORK_COMMIT` = good SHA; exactly one `rollback` event, zero `error`.
- **Test 8 — failed rollback** (checkout of a non-existent commit): HEAD stays on the broken commit; exported `FRAMEWORK_COMMIT` = the **real HEAD** (not the failed target); **zero** `rollback` (success) events; one `error` event.

**Bite-verified:** reverting `framework-update.sh` to the old code fails exactly the two F5 assertions in Test 8 (reports `deadbeef…` as `FRAMEWORK_COMMIT`; logs a success rollback) while Test 7 stays green. The new tests are **CI-visible** via `npm test`'s `for f in test/*.test.sh` loop (node-tests job).

## Verification
- Full suite green in a PyYAML-equipped env (= CI ubuntu): node `--test` ✓; shell — consolidate-memory 18/18, data-dir-scripts 18/18, **framework-update 21/21**, health-check 62/62. (health-check + publish-content fail only in the bare sandbox — missing PyYAML / no network — and reproduce identically on clean `main`; op-learning #109/#110.)
- `bash -n` clean on both changed scripts.
- Version bumped 1.5.26 → 1.5.27, lockfile synced.

Refs #247