### PR TITLE
fix: filter /api/wins by instant, not lexicographic ISO string

### DIFF
--- a/lib/routes/events.js
+++ b/lib/routes/events.js
@@ -80,8 +80,16 @@ function register(routes, config) {
         }
       }
     } catch {}
-    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
-    const recent = allWins.filter(w => w.ts >= thirtyDaysAgo);
+    // Filter by absolute instant, not by raw ISO string. wins.jsonl timestamps
+    // arrive in mixed representations — shell `date` writes a local numeric
+    // offset (e.g. -07:00, no fraction); Python isoformat writes +00:00 with
+    // microseconds — so a lexicographic `w.ts >= <UTC-"Z" cutoff>` mis-filters
+    // across the offset/format boundary: a win whose instant is within the
+    // window but is logged in local evening sorts before the cutoff string and
+    // is silently dropped. new Date() normalizes every ISO form to an instant,
+    // matching the /api/journal and /api/projects filtering idiom.
+    const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const recent = allWins.filter(w => new Date(w.ts) >= cutoff);
     sendJSON(res, 200, recent);
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-portal",
-  "version": "1.5.27",
+  "version": "1.5.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-portal",
-      "version": "1.5.27",
+      "version": "1.5.28",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.5.27",
+  "version": "1.5.28",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -336,6 +336,68 @@ describe('GET /api/wins', () => {
   });
 });
 
+describe('GET /api/wins — instant-based 30-day filtering (mixed ts formats)', () => {
+  // Regression guard: wins.jsonl timestamps arrive in mixed ISO representations
+  // (shell `date` -> local numeric offset like -07:00; Python isoformat ->
+  // +00:00 with microseconds). The cutoff must be compared by absolute INSTANT,
+  // not by raw string >=, or a within-window win logged in local evening sorts
+  // lexicographically before a UTC-"Z" cutoff and is silently dropped.
+  let server, port, tmpDir;
+
+  // Express an instant as an ISO string in UTC-07:00 (shell `date` style: no fraction).
+  function fmtLocalMinus7(instantMs) {
+    return new Date(instantMs - 7 * 3600 * 1000).toISOString().slice(0, 19) + '-07:00';
+  }
+
+  before(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'portal-wins-'));
+    fs.mkdirSync(path.join(tmpDir, 'logs'));
+    const now = Date.now();
+    const cutoffMs = now - 30 * 24 * 3600 * 1000;
+    const wins = [
+      // Boundary win: instant 6h INSIDE the window, but written in -07:00 form so
+      // its local wall-clock string sorts before the UTC-"Z" cutoff. The old
+      // lexicographic filter drops this; the instant filter keeps it.
+      `{"ts":"${fmtLocalMinus7(cutoffMs + 6 * 3600 * 1000)}","description":"BOUNDARY_LOCAL_OFFSET","project":"agent-portal"}`,
+      // Clearly recent (5 days ago), plain UTC "Z" — must stay included.
+      `{"ts":"${new Date(now - 5 * 24 * 3600 * 1000).toISOString()}","description":"RECENT_UTC_Z","project":"agent-portal"}`,
+      // Recent (3 days ago) in Python isoformat +00:00 with microseconds — must parse and stay included.
+      `{"ts":"${new Date(now - 3 * 24 * 3600 * 1000).toISOString().replace('Z', '000+00:00')}","description":"RECENT_PY_MICROS","project":"agent-portal"}`,
+      // Clearly old (40 days ago) — must be excluded.
+      `{"ts":"${new Date(now - 40 * 24 * 3600 * 1000).toISOString()}","description":"OLD_FORTY_DAYS","project":"agent-portal"}`,
+    ];
+    fs.writeFileSync(path.join(tmpDir, 'logs', 'wins.jsonl'), wins.join('\n') + '\n');
+
+    const result = createTestServer({ agentDir: tmpDir });
+    server = result.server;
+    await new Promise(resolve => server.listen(0, resolve));
+    port = server.address().port;
+  });
+
+  after(() => { server.close(); fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('keeps a within-window win written in a local numeric offset (the bug)', async () => {
+    const { status, data } = await fetchJSON(port, '/api/wins');
+    assert.equal(status, 200);
+    const descs = data.map(w => w.description);
+    assert.ok(descs.includes('BOUNDARY_LOCAL_OFFSET'),
+      'within-window -07:00 win was dropped by lexicographic comparison');
+  });
+
+  it('keeps recent wins in UTC-Z and Python-microsecond formats', async () => {
+    const { data } = await fetchJSON(port, '/api/wins');
+    const descs = data.map(w => w.description);
+    assert.ok(descs.includes('RECENT_UTC_Z'));
+    assert.ok(descs.includes('RECENT_PY_MICROS'));
+  });
+
+  it('excludes wins older than 30 days', async () => {
+    const { data } = await fetchJSON(port, '/api/wins');
+    const descs = data.map(w => w.description);
+    assert.ok(!descs.includes('OLD_FORTY_DAYS'), 'a 40-day-old win leaked into the 30-day view');
+  });
+});
+
 describe('GET /api/github/* (no repos configured)', () => {
   let server, port;
 


### PR DESCRIPTION
GET `/api/wins` filtered the last-30-days window with a raw **string** comparison:

```js
const thirtyDaysAgo = new Date(Date.now() - 30*24*60*60*1000).toISOString(); // UTC "Z", with ms
const recent = allWins.filter(w => w.ts >= thirtyDaysAgo);                    // lexicographic
```

`wins.jsonl` timestamps arrive in **mixed ISO representations** — shell `date` writes a local numeric offset (`2026-06-16T18:25:00-07:00`, no fraction); Python `isoformat()` writes `2026-06-17T03:21:39.848510+00:00` (offset + microseconds) — while the cutoff is always UTC `Z` with milliseconds. Comparing these different forms **lexicographically** mis-filters across the offset/format boundary: a win whose instant is *within* the window but is logged in the local evening (negative offset) sorts before the cutoff string and is **silently dropped** from the portal’s wins view.

This is the read/display-side analog of the #247 F2/F3 framework-script findings (`memory-index.py` / `consolidate-memory.sh` compared ISO timestamps lexicographically and silently dropped entries across the UTC/DST offset boundary) — same bug class, now on the server route.

## Fix
Compare by absolute **instant** via `new Date()`, matching the idiom the other read routes already use (`/api/journal`, `/api/projects`):

```js
const cutoff = new Date(Date.now() - 30*24*60*60*1000);
const recent = allWins.filter(w => new Date(w.ts) >= cutoff);
```

Audited the whole `lib/` surface for the same class: `/api/wins` was the **only** site comparing timestamps from two *different* sources (framework-written `ts` vs a portal-computed cutoff). `github.js` (GitHub’s uniform UTC-`Z` `createdAt`) and `rated-items.js` (`created_at` always written via `toISOString()`) sort within a single uniform-format source and are correct; `library.js` sorts by title. Clean one-off.

## Verification
- **New CI-covered regression block** in `test/routes.test.js` (now-relative fixtures, real mixed formats): a `-07:00` win 6h inside the window (**BITE** — dropped by the old code, kept by the fix), a UTC-`Z` win, a `+00:00`-microsecond win (all must be kept), and a 40-day-old win (must be excluded).
- **Bite-verified:** reverting the filter to the old lexicographic line fails *exactly* the boundary assertion (`within-window -07:00 win was dropped`) while the non-boundary cases stay green.
- **Full node suite: 509/509** (was 506).
- **Real HTTP E2E** against agent-coder’s live `wins.jsonl`: `200`, 15 wins returned across all three real formats (4× `-07:00`, 9× `+00:00`-micros, 2× `Z`), all within 30 days; behavior-preserving vs the old logic on todays non-boundary data.

Impact is intermittent by nature (only wins logged within a few hours of the moving 30-day edge in a local-offset format flip), but it is a real recurring silent drop in the same data-integrity class as the shipped #247 fixes, and the change also future-proofs and matches the codebase idiom.

`v1.5.27 → v1.5.28`.