### PR TITLE
test: cover async-handler rejection in the dispatcher (v1.5.29)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-portal",
-  "version": "1.5.28",
+  "version": "1.5.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-portal",
-      "version": "1.5.28",
+      "version": "1.5.29",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.5.28",
+  "version": "1.5.29",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -143,6 +143,63 @@ describe('createServer', () => {
     const data = await res.json();
     assert.equal(data.error, 'Internal server error');
   });
+
+  // The dispatcher must `await` the handler INSIDE its try/catch. Async handlers
+  // that reject AFTER an await (the shape of every `JSON.parse(await readBody(req))`
+  // body parser) produce a rejected promise, not a synchronous throw — so the
+  // sync-throw test above passes even if the dispatcher drops the `await` and lets
+  // rejections escape. An escaped rejection is an unhandledRejection, which crashes
+  // the portal process on Node 15+ (a single malformed request body = portal-wide
+  // DoS). These two tests lock that invariant in for both dispatch paths. The
+  // AbortController makes a regression (response never sent) fail deterministically
+  // instead of hanging the suite.
+  it('returns 500 when an async route handler rejects after an await (exact match)', async () => {
+    server.close();
+
+    const routes = {
+      'POST /api/async-error': async () => {
+        await new Promise(resolve => setImmediate(resolve));
+        throw new Error('async boom'); // models JSON.parse(await readBody(req)) on a malformed body
+      }
+    };
+
+    const config = { name: 'Test', port: 0 };
+    server = createServer(config, { routes, getHTML: () => '<html></html>' });
+    await new Promise(resolve => server.listen(0, resolve));
+    port = server.address().port;
+
+    const res = await fetch(`http://localhost:${port}/api/async-error`, {
+      method: 'POST',
+      signal: AbortSignal.timeout(3000),
+    });
+    assert.equal(res.status, 500);
+    const data = await res.json();
+    assert.equal(data.error, 'Internal server error');
+  });
+
+  it('returns 500 when an async parameterized route handler rejects after an await', async () => {
+    server.close();
+
+    const routes = {
+      'POST /api/items/:id': async () => {
+        await new Promise(resolve => setImmediate(resolve));
+        throw new Error('async boom');
+      }
+    };
+
+    const config = { name: 'Test', port: 0 };
+    server = createServer(config, { routes, getHTML: () => '<html></html>' });
+    await new Promise(resolve => server.listen(0, resolve));
+    port = server.address().port;
+
+    const res = await fetch(`http://localhost:${port}/api/items/42`, {
+      method: 'POST',
+      signal: AbortSignal.timeout(3000),
+    });
+    assert.equal(res.status, 500);
+    const data = await res.json();
+    assert.equal(data.error, 'Internal server error');
+  });
 });
 
 // --- Tailscale auth middleware ---


### PR DESCRIPTION
## What

Adds two regression tests for the HTTP dispatcher's error handling (`lib/server.js`), covering the **async-handler-rejection** path that the existing test missed.

## Why

The dispatcher wraps every handler invocation as `try { await handler(req, res, url) } catch { sendJSON 500 }`. The `await` is load-bearing: async handlers that reject **after an await** — the exact shape of every `JSON.parse(await readBody(req))` body parser — produce a *rejected promise*, not a synchronous throw. Without the `await` inside the try, that rejection escapes as an `unhandledRejection`, which **crashes the portal process on Node 15+** (Node 24 here). One malformed POST body would take the portal down for all users.

The existing `returns 500 when a route handler throws` test only uses a **synchronous** throw (`() => { throw }`), which is caught even if the dispatcher drops the `await`. So the invariant protecting every mutation route from a malformed-body DoS was untested and could silently regress (e.g. a refactor to `try { handler(...) }` without `await`).

## Verification

- **Bite-verified**: removing `await` from both dispatch blocks (exact-match + parameterized) fails *exactly* these two new tests, while the sync-throw test stays green — proving they cover a gap the old test couldn't.
- Full node suite **511/511** (was 509; +2).
- **Real-portal E2E**: booted the actual portal and POSTed a malformed JSON body to `POST /api/todos` (a real async handler that does *not* wrap its own parse) → dispatcher returned **500**, process stayed **alive**, subsequent `GET /api/status` → 200, valid POST → 200, no `unhandledRejection` logged. Confirms routes like todos rely entirely on the dispatcher `await` to avoid a crash.

No behavior change — test coverage only.

## Context

Surfaced while honestly auditing the two "candidates not yet swept" in `skills/correctness-audit.md` (JSONL-parse robustness and DATA_DIR resolution on the portal routes). Both came back **clean** — file readers skip-and-continue per line, body parsers are caught by the dispatcher, and read-side data paths consistently use `dataPath()`. This PR locks in the dispatcher invariant that *makes* the body-parse class clean, so it can't silently regress. Extends the correctness-audit lineage (#247, #253) to the dispatcher's error-handling guarantee.