### PR TITLE
respond.sh: release lock on exit + close lock fd for children

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-portal",
-  "version": "1.5.29",
+  "version": "1.5.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-portal",
-      "version": "1.5.29",
+      "version": "1.5.30",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.5.29",
+  "version": "1.5.30",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/scripts/respond.sh
+++ b/scripts/respond.sh
@@ -35,6 +35,13 @@ fi
 # Remove starting marker now that real flock is held
 rm -f "${AGENT_LOCK_FILE}.starting"
 
+# Release the lock on any exit (normal, error, signal). Without this, a child
+# that inherits the lock fd (200) — the harness, or a detached helper it spawns —
+# keeps the lock's open file description locked after this script exits, blocking
+# subsequent cycles until wake.sh's stale-lock timeout. Mirrors wake.sh's
+# lock-reliability handling (added to wake.sh in PR #66, never propagated here).
+trap 'flock -u 200 2>/dev/null; exec 200>&- 2>/dev/null' EXIT
+
 CYCLE_TS="$(date +%Y%m%d-%H%M)"
 CYCLE_LOG="$DATA_DIR/logs/cycles/${CYCLE_TS}-respond.log"
 mkdir -p "$DATA_DIR/logs/cycles"
@@ -51,17 +58,17 @@ if [ "$WORKSPACES_COUNT" -gt 0 ] 2>/dev/null; then
     ws_repo="${!repo_var}"; ws_path="${!path_var}"; ws_npm="${!npm_var}"
 
     if [ -d "$ws_path/.git" ]; then
-      git -C "$ws_path" pull --ff-only 2>/dev/null || echo "Warning: pull failed for $ws_repo"
+      git -C "$ws_path" pull --ff-only 200>&- 2>/dev/null || echo "Warning: pull failed for $ws_repo"
     else
       mkdir -p "$(dirname "$ws_path")"
-      git clone "https://${GH_TOKEN}@github.com/${ws_repo}.git" "$ws_path" 2>/dev/null || {
+      git clone "https://${GH_TOKEN}@github.com/${ws_repo}.git" "$ws_path" 200>&- 2>/dev/null || {
         echo "Warning: clone failed for $ws_repo"
         continue
       }
     fi
 
     if [ "$ws_npm" = "true" ] && [ -f "$ws_path/package.json" ]; then
-      (cd "$ws_path" && npm install --production 2>&1) || echo "Warning: npm install failed for $ws_repo"
+      (cd "$ws_path" && npm install --production 200>&- 2>&1) || echo "Warning: npm install failed for $ws_repo"
     fi
   done
 fi
@@ -98,9 +105,11 @@ while [ "$HARNESS_EXIT" -ne 0 ] && [ "$RETRY" -lt "$MAX_RETRIES" ]; do
     sleep 30
   fi
 
+  # Close the lock fd (200) for the harness pipeline so it (and any detached
+  # child it spawns) cannot inherit and hold the lock. Mirrors wake.sh.
   set +e
-  cat "$PROMPT_FILE" | $HARNESS_CMD $HARNESS_EXTRA_FLAGS \
-    2>&1 | tee "$CYCLE_LOG"
+  cat "$PROMPT_FILE" 200>&- | $HARNESS_CMD $HARNESS_EXTRA_FLAGS \
+    200>&- 2>&1 | tee 200>&- "$CYCLE_LOG"
   HARNESS_EXIT=${PIPESTATUS[1]}
   set -e
 

--- a/test/respond-lock.test.sh
+++ b/test/respond-lock.test.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# test/respond-lock.test.sh — respond.sh must release its lock on exit even when
+# a child process inherits the lock fd (200).
+#
+# Regression test for the lock-fd-leak fixed by mirroring wake.sh's PR #66
+# lock-reliability handling into respond.sh (release trap + 200>&- on children).
+# Before the fix, a detached child spawned by the harness inherited the locked
+# fd 200 and kept the lock's open file description locked after respond.sh
+# exited, blocking every subsequent cycle until wake.sh's stale-lock timeout
+# (~90 min). flock locks live on the open file description, so an inherited,
+# never-released fd holds the lock for the lifetime of the child.
+#
+# Run directly or via `npm test` (the test/*.test.sh loop). CI-covered.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+RESPOND="$SCRIPT_DIR/scripts/respond.sh"
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); echo "  ok - $1"; }
+bad() { FAIL=$((FAIL + 1)); echo "  FAIL - $1"; }
+
+echo "# respond.sh lock-release tests"
+
+# respond.sh's lock handling is flock-based (Linux). Skip cleanly elsewhere.
+if ! command -v flock >/dev/null 2>&1; then
+  echo "  SKIP - flock not available (non-Linux host); respond.sh lock handling is Linux-only"
+  exit 0
+fi
+
+TMP=$(mktemp -d)
+LINGER_PID_FILE="$TMP/linger.pid"
+cleanup() {
+  [ -f "$LINGER_PID_FILE" ] && kill "$(cat "$LINGER_PID_FILE" 2>/dev/null)" 2>/dev/null
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+LOCK_FILE="$TMP/agent.lock"
+
+# Minimal agent: no workspaces (skips the git-pull block), a respond-prompt, a
+# lock file. read-config.js maps name->AGENT_NAME, lock-file->AGENT_LOCK_FILE,
+# respond-prompt->RESPOND_PROMPT_FILE.
+cat > "$TMP/agent.yaml" <<YAML
+name: respondlocktest
+repo: example/none
+lock-file: $LOCK_FILE
+respond-prompt: |
+  test respond prompt
+YAML
+
+# Point the harness at our mock. type != claude-code so read-harness-config.sh
+# injects no default flags; dataDir "." keeps state under the temp agent dir.
+cat > "$TMP/portal.config.json" <<JSON
+{ "harness": { "type": "mock", "command": "bash $TMP/mock-harness.sh", "extraFlags": "" }, "dataDir": "." }
+JSON
+
+# Mock harness: drain the piped prompt, then spawn a lingering DETACHED child.
+# The child inherits the harness's open fds (including fd 200 if respond.sh
+# leaks it) but its stdout/stderr go to /dev/null so it does NOT hold the
+# pipeline open (otherwise tee/respond.sh would block until it exits).
+cat > "$TMP/mock-harness.sh" <<MOCK
+#!/bin/bash
+cat >/dev/null
+nohup sleep 30 >/dev/null 2>&1 &
+echo "\$!" > "$LINGER_PID_FILE"
+exit 0
+MOCK
+chmod +x "$TMP/mock-harness.sh"
+
+# Temp git repo so commit.sh (respond.sh's final step) succeeds locally.
+git -C "$TMP" init -q
+git -C "$TMP" config user.email test@example.com
+git -C "$TMP" config user.name test
+git -C "$TMP" add -A
+git -C "$TMP" commit -qm init
+mkdir -p "$TMP/logs"
+
+# Run a full respond cycle. GH_TOKEN unset => commit.sh skips push (offline).
+( cd "$TMP" && env -u GH_TOKEN bash "$RESPOND" "$TMP" ) >"$TMP/respond.out" 2>&1
+RESPOND_RC=$?
+
+# Sanity: the lingering child must still be alive when we check the lock — else
+# a "lock free" result would be meaningless (the leak window already closed).
+LINGER_PID=$(cat "$LINGER_PID_FILE" 2>/dev/null || echo "")
+if [ -n "$LINGER_PID" ] && kill -0 "$LINGER_PID" 2>/dev/null; then
+  ok "lingering child alive at lock-check time (valid test window)"
+else
+  bad "lingering child not alive at check time — invalid window (respond rc=$RESPOND_RC); see $TMP/respond.out"
+fi
+
+# THE KEY ASSERTION: with the lingering child still running, the lock must be
+# acquirable from a fresh open file description — respond.sh released it on exit.
+# Without the fix the child holds the locked fd 200 and this flock -n is denied.
+exec 9>"$LOCK_FILE"
+if flock -n 9; then
+  ok "lock is free after respond.sh exit (no fd-200 leak into child)"
+  flock -u 9
+else
+  bad "lock still HELD after respond.sh exit (fd-200 leaked into lingering child)"
+fi
+exec 9>&-
+
+echo ""
+echo "respond.sh lock-release: $PASS passed, $FAIL failed"
+RC=0
+[ "$FAIL" -ne 0 ] && RC=1
+exit "$RC"


### PR DESCRIPTION
## Problem

`respond.sh` (the lightweight journal-respond cycle, run for every respond cycle) acquires the agent mutex via `flock` on fd 200, but **never releases it explicitly and never closes fd 200 for the children it spawns** (the harness, `git`, `npm`).

`flock` locks live on the **open file description**, not the fd number or process. So if a child inherits fd 200 and outlives `respond.sh` — the harness, or a detached helper it spawns — that child keeps the lock's open file description **locked after `respond.sh` exits**. Every subsequent wake/respond cycle then sees the lock held and skips, until wake.sh's stale-lock detection kills the (wrong) holder after ~90 min.

`wake.sh` received this exact hardening in **PR #66** ("Lock reliability: trap cleanup, stale detection, dirty-branch recovery") — a release trap plus `200>&-` on every child spawn. It was **never propagated to `respond.sh`**, even though both use the same lock file and spawn the same kinds of children.

| | `200>&-` closes | release trap | `flock -u` |
|---|---|---|---|
| wake.sh (before this PR) | 9 | ✓ | ✓ |
| respond.sh (before this PR) | **0** | **✗** | **✗** |

## Fix

Mirror wake.sh's proven pattern (no new behavior invented):
- Add an `EXIT` trap that runs `flock -u 200` on every exit path (normal, error, signal).
- Close fd 200 (`200>&-`) for the harness pipeline (`cat`/harness/`tee`) and the `git`/`npm` workspace children.

Either mechanism alone fixes the leak; together they match wake.sh (defense in depth). Default/legacy behavior is otherwise unchanged.

## Verification

- New **CI-covered** `test/respond-lock.test.sh` runs a *full* respond cycle (real `respond.sh` → mock harness → `commit.sh`, fully offline) where the mock harness spawns a lingering detached child that inherits fd 200, then asserts the lock is acquirable from a fresh open file description after `respond.sh` exits. A sanity check confirms the child is still alive at check time (valid test window).
- **Bite-verified**: reverting `respond.sh` to the pre-fix version fails the lock assertion (`lock still HELD … fd-200 leaked into lingering child`) while the sanity check stays green — the test covers a real, reproduced bug.
- Full suite green (CI parity): node 511/511; shell tests all pass (consolidate-memory 18/18, data-dir-scripts 18/18, framework-update 21/21, health-check 62/62, respond-lock 2/2, telegram 24/24 + 5/5).
- `bash -n scripts/respond.sh` clean.

Version bumped 1.5.29 → 1.5.30 (lockfile synced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)