### PR TITLE
content-validator: guard redirect Location parse against uncaughtException crash (v1.5.31)

### DIFF
--- a/lib/content-validator.js
+++ b/lib/content-validator.js
@@ -91,9 +91,18 @@ function singleRequest(targetUrl, method, options, redirectsRemaining) {
       const status = res.statusCode;
       res.resume();
 
-      // Follow redirects
+      // Follow redirects. The Location header is server-controlled and may be
+      // unparseable even relative to a valid base (e.g. an absolute URL with a
+      // broken authority); guard the parse like every other new URL() in this
+      // file so a malformed redirect fails the URL gracefully rather than
+      // throwing out of this async response callback as an uncaughtException.
       if (status >= 300 && status < 400 && res.headers.location && redirectsRemaining > 0) {
-        const nextUrl = new URL(res.headers.location, parsed).href;
+        let nextUrl;
+        try {
+          nextUrl = new URL(res.headers.location, parsed).href;
+        } catch {
+          return resolve({ ok: false, status: null, reason: `invalid redirect Location '${res.headers.location}'`, recoverable: false });
+        }
         return resolve(singleRequest(nextUrl, method, options, redirectsRemaining - 1));
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-portal",
-  "version": "1.5.30",
+  "version": "1.5.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-portal",
-      "version": "1.5.30",
+      "version": "1.5.31",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.5.30",
+  "version": "1.5.31",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/test/content-validator.test.js
+++ b/test/content-validator.test.js
@@ -22,6 +22,9 @@ function startTestServer() {
       }
       if (p === '/redirect') { res.writeHead(302, { Location: '/200' }); res.end(); return; }
       if (p === '/redirect-loop') { res.writeHead(302, { Location: '/redirect-loop' }); res.end(); return; }
+      // 3xx whose Location is unparseable even against a valid base (absolute
+      // URL with a broken authority). Must fail the URL gracefully, not crash.
+      if (p === '/redirect-bad-location') { res.writeHead(302, { Location: 'http://[bad' }); res.end(); return; }
       if (p === '/slow') { /* never respond */ return; }
       res.writeHead(200); res.end('default');
     });
@@ -189,6 +192,16 @@ describe('validateItem — live fetch (skipFetch=false)', () => {
     assert.equal(r.ok, true, JSON.stringify(r.errors));
   });
 
+  it('rejects (not crashes) on a 3xx with an unparseable Location', async () => {
+    const r = await validateItem(
+      makeItem({ source_url: `${base}/redirect-bad-location`, sources: [{ name: 'Test', url: `${base}/redirect-bad-location`, type: 'downloadable' }] }),
+      makeSources(),
+      { fetchTimeoutMs: 2000, fetchRetries: 0 }
+    );
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some(e => /invalid redirect Location/.test(e.reason)), JSON.stringify(r.errors));
+  });
+
   it('rejects on timeout (short timeout against /slow)', async () => {
     const r = await validateItem(
       makeItem({ source_url: `${base}/slow`, sources: [{ name: 'Test', url: `${base}/slow`, type: 'downloadable' }] }),
@@ -344,5 +357,16 @@ describe('fetchUrl', () => {
     const r = await fetchUrl('file:///etc/passwd', { fetchTimeoutMs: 1000 });
     assert.equal(r.ok, false);
     assert.match(r.reason, /unsupported protocol/);
+  });
+
+  it('fails gracefully on a 3xx with an unparseable Location (no crash)', async () => {
+    // Regression: the redirect-target parse was the one new URL() in the file
+    // not wrapped in try/catch, so a malformed server-sent Location threw out
+    // of the async response callback as an uncaughtException, crashing the
+    // process instead of resolving. Must return ok=false, not throw.
+    const r = await fetchUrl(`${base}/redirect-bad-location`, { fetchTimeoutMs: 2000, fetchRetries: 0 });
+    assert.equal(r.ok, false);
+    assert.equal(r.status, null);
+    assert.match(r.reason, /invalid redirect Location/);
   });
 });


### PR DESCRIPTION
## Summary

Correctness/robustness fix for the content-publishing validation gate (`lib/content-validator.js`), found while pressure-testing the \"all framework surfaces correctness-swept\" claim — `publish-content.js` / `content-validator.js` (the gate every `features.library` agent runs to prove a recommendation links to an approved, live URL) had never been correctness-audited.

`singleRequest()` follows 3xx redirects with an **unguarded** parse:

```js
const nextUrl = new URL(res.headers.location, parsed).href;
```

This is the **only** `new URL()` in the file not wrapped in try/catch — and the only one parsing **untrusted, server-controlled input** (the `Location` header). Every other parse (lines 60, 75, 264, 273) guards the agent's own URLs. A malformed `Location` throws `TypeError: Invalid URL` out of the async HTTP response callback as an **uncaughtException**, crashing the validator instead of failing the URL. The top-level `main().catch` cannot reach a throw inside an event callback, so the graceful quarantine path (writing the `_validation` block) never runs — the publish step dies ungracefully on a misbehaving redirect.

Same bug class as #254 (an unhandled async throw that crashes the process), on a different, never-audited surface.

## Reproduced (bites)

A 3xx with `Location: http://[bad` (an absolute URL with a broken authority — unparseable even against a valid base) crashes the process via uncaughtException, where every other malformed-URL path resolves `{ok:false}`. The first parse in the same function is already guarded; this one was missed.

This does **not** compromise the security property — Layer A (host allowlist) is sound and does not false-pass unapproved hosts. The bug is robustness: an untrusted input crashes the gate rather than failing the URL gracefully.

## Fix

Wrap the redirect-target parse exactly like the sibling guards in the file. A malformed `Location` resolves to `{ok:false, reason:'invalid redirect Location ...', recoverable:false}`, so the URL fails liveness and the item is quarantined with a `_validation` block as intended.

## Tests (bite-verified)

Two regression tests, both of which **fail with `TypeError` at the unguarded line** when run against the pre-fix code:
- `fetchUrl`: a 3xx with an unparseable Location returns `ok=false` (no crash)
- `validateItem`: the same vector surfaces as a graceful validation error

Full node suite **513/513** (was 511 + these 2). `publish-content.test.sh` failure count is identical to `main` (pre-existing sandbox-only ENOENT in the quarantine-write path; passes in CI). Standalone repro confirms graceful `{ok:false}` return post-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)