### PR TITLE
test: hermetic Layer C wiring coverage + de-flake CI live tests (v1.5.32)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,16 @@ jobs:
         with:
           node-version: "22"
       - run: npm install
+      # SKIP_LIVE_TESTS=1 skips the opt-in tests that hit the live Archive.org
+      # metadata API (content-validator-layer-c.test.js, extractor-archive-org.test.js).
+      # Those make CI depend on archive.org being reachable on every PR and
+      # false-green on their graceful fallbacks when it isn't. The Layer C
+      # integration wiring is covered deterministically by
+      # content-validator-layer-c-hermetic.test.js; run the live tests locally
+      # (npm test without this env var) to verify against the real API.
       - run: npm test
+        env:
+          SKIP_LIVE_TESTS: "1"
 
   python-tests:
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-portal",
-  "version": "1.5.31",
+  "version": "1.5.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-portal",
-      "version": "1.5.31",
+      "version": "1.5.32",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.5.31",
+  "version": "1.5.32",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/test/content-validator-layer-c-hermetic.test.js
+++ b/test/content-validator-layer-c-hermetic.test.js
@@ -1,0 +1,266 @@
+// content-validator-layer-c-hermetic.test.js — Deterministic, NETWORK-FREE
+// tests for Layer C of validateItem (extractor + tenant preference check).
+//
+// WHY THIS FILE EXISTS (separate from content-validator-layer-c.test.js):
+//   The sibling layer-c test file exercises the same wiring against the LIVE
+//   Archive.org metadata API. Those live tests (a) make CI depend on
+//   archive.org being reachable on every PR, and (b) take graceful-fallback
+//   branches that silently pass WITHOUT asserting the wiring when the network
+//   is unavailable — so the Layer C integration glue (extractor facts ->
+//   loadConstraints -> preference-checker -> error/warning merge -> ok flag)
+//   has no DETERMINISTIC regression protection. Layers A+B, by contrast, are
+//   already covered hermetically by content-validator.test.js (a local
+//   http.createServer on 127.0.0.1). This file closes that gap for Layer C.
+//
+// HOW IT STAYS HERMETIC:
+//   - The only network leaf in Layer C is the extractor's own fetch. We mock
+//     `archiveOrg.extract` (via node:test's mock.method) so the REAL
+//     extractors.lookup registry still routes archive.org URLs to the
+//     archive-org module, but the fetch is replaced with canned facts.
+//   - skipFetch:true disables Layer B's liveness fetch (Layer C is gated by
+//     skipExtraction, not skipFetch, so it still runs).
+//   Net: every assertion below runs with zero network I/O.
+
+const { describe, it, afterEach, mock } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const yaml = require('js-yaml');
+const archiveOrg = require('../lib/extractors/archive-org');
+const { validateItem } = require('../lib/content-validator');
+
+const ARCHIVE_URL = 'https://archive.org/details/foo';
+
+function approvedArchiveSource() {
+  return [{ id: 'archive-org', name: 'Archive.org', hosts: ['archive.org'], status: 'approved' }];
+}
+
+function makeItem(overrides = {}) {
+  return {
+    id: 'i1',
+    title: 'Test Item',
+    category: 'comics',
+    source: 'archive-org',
+    source_url: ARCHIVE_URL,
+    status: 'linked',
+    ...overrides,
+  };
+}
+
+// Default "healthy" facts an extractor would return for a freely-downloadable,
+// English, PDF item. Individual tests override fields to drive each branch.
+function facts(overrides = {}) {
+  return {
+    identifier: 'foo',
+    language: 'eng',
+    available_formats: ['pdf'],
+    borrowable_only: false,
+    title: 'Test Item',
+    ...overrides,
+  };
+}
+
+// Create a throwaway dataRoot containing memory/preferences.yaml (or none).
+function dataRootWith(preferences) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'layerc-herm-'));
+  fs.mkdirSync(path.join(dir, 'memory'), { recursive: true });
+  if (preferences != null) {
+    fs.writeFileSync(path.join(dir, 'memory', 'preferences.yaml'), yaml.dump(preferences));
+  }
+  return dir;
+}
+
+// Mock the extractor's network leaf so Layer C runs without I/O. Returns the
+// mock handle so a test can assert call count. Restored in afterEach.
+function stubExtract(impl) {
+  return mock.method(archiveOrg, 'extract', impl);
+}
+
+// Run validateItem against an archive.org item with Layer B disabled. Layer C
+// runs against the (mocked) extractor.
+function validate(item, sources, opts) {
+  return validateItem(item, sources, { skipFetch: true, ...opts });
+}
+
+describe('Layer C wiring — hermetic (no network)', () => {
+  afterEach(() => mock.restoreAll());
+
+  it('passes and reports facts when the item satisfies constraints', async () => {
+    const m = stubExtract(async () => facts());
+    const dataRoot = dataRootWith({
+      preferences: { comics: { constraints: { formats: { accept: ['pdf'] }, languages: { accept: ['en'] } } } },
+    });
+    const r = await validate(makeItem(), approvedArchiveSource(), { dataRoot });
+    assert.equal(r.ok, true, JSON.stringify(r.errors));
+    assert.equal(m.mock.calls.length, 1, 'real lookup routed to (mocked) extract');
+    assert.ok(r.extractor, 'extractor report populated');
+    assert.equal(r.extractor.source, ARCHIVE_URL);
+    assert.equal(r.extractor.facts.language, 'eng', 'facts flowed into the report');
+    assert.deepEqual(r.errors, []);
+  });
+
+  it('rejects on a disallowed format (error merged from preference-checker)', async () => {
+    stubExtract(async () => facts({ available_formats: ['pdf'] }));
+    const dataRoot = dataRootWith({
+      preferences: { comics: { constraints: { formats: { accept: ['cbz', 'cbr'] } } } },
+    });
+    const r = await validate(makeItem(), approvedArchiveSource(), { dataRoot });
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some(e => e.field === 'formats'), JSON.stringify(r.errors));
+  });
+
+  it('rejects on a disallowed language', async () => {
+    stubExtract(async () => facts({ language: 'spa' }));
+    const dataRoot = dataRootWith({
+      preferences: { comics: { constraints: { languages: { accept: ['en'] } } } },
+    });
+    const r = await validate(makeItem(), approvedArchiveSource(), { dataRoot });
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some(e => e.field === 'language'), JSON.stringify(r.errors));
+  });
+
+  it('rejects a borrowable-only item when borrowable_ok=false', async () => {
+    stubExtract(async () => facts({ borrowable_only: true }));
+    const dataRoot = dataRootWith({
+      preferences: { comics: { constraints: { borrowable_ok: false } } },
+    });
+    const r = await validate(makeItem(), approvedArchiveSource(), { dataRoot });
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some(e => e.field === 'borrowable_only'), JSON.stringify(r.errors));
+  });
+
+  it('merges ALL violations from a multi-failure item', async () => {
+    stubExtract(async () => facts({ language: 'spa', available_formats: ['pdf'], borrowable_only: true }));
+    const dataRoot = dataRootWith({
+      preferences: {
+        comics: {
+          constraints: {
+            languages: { accept: ['en'] },
+            formats: { accept: ['cbz', 'cbr'] },
+            borrowable_ok: false,
+          },
+        },
+      },
+    });
+    const r = await validate(makeItem(), approvedArchiveSource(), { dataRoot });
+    assert.equal(r.ok, false);
+    const fields = r.errors.map(e => e.field).sort();
+    assert.deepEqual(fields, ['borrowable_only', 'formats', 'language'],
+      `expected all three violations merged; got ${JSON.stringify(r.errors)}`);
+  });
+
+  it('merges WARNINGS (not errors) for an unknown fact under the default policy', async () => {
+    // available_formats empty => "fact unavailable" => warn (default), not reject.
+    stubExtract(async () => facts({ available_formats: [] }));
+    const dataRoot = dataRootWith({
+      preferences: { comics: { constraints: { formats: { accept: ['pdf'] } } } },
+    });
+    const r = await validate(makeItem(), approvedArchiveSource(), { dataRoot });
+    assert.equal(r.ok, true, JSON.stringify(r.errors));
+    assert.ok(r.warnings.some(w => w.field === 'formats'),
+      `expected a formats warning; got ${JSON.stringify(r.warnings)}`);
+  });
+
+  it('honors unknown_field_policy=reject (warning is promoted to a failing error)', async () => {
+    stubExtract(async () => facts({ available_formats: [] }));
+    const dataRoot = dataRootWith({
+      preferences: {
+        comics: { constraints: { formats: { accept: ['pdf'] }, unknown_field_policy: { formats: 'reject' } } },
+      },
+    });
+    const r = await validate(makeItem(), approvedArchiveSource(), { dataRoot });
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some(e => e.field === 'formats'), JSON.stringify(r.errors));
+  });
+
+  it('treats an extractor _error as a graceful WARNING (no crash, preference check skipped)', async () => {
+    stubExtract(async () => ({ _error: 'simulated metadata fetch failure' }));
+    const dataRoot = dataRootWith({
+      // Constraints that WOULD reject if facts were available — must not apply
+      // because the extractor produced no facts.
+      preferences: { comics: { constraints: { formats: { accept: ['cbz'] } } } },
+    });
+    const r = await validate(makeItem(), approvedArchiveSource(), { dataRoot });
+    assert.equal(r.ok, true, 'extractor failure must not fail the item');
+    assert.ok(r.warnings.some(w => /extractor failed/.test(w.reason)),
+      `expected an extractor-failed warning; got ${JSON.stringify(r.warnings)}`);
+    assert.ok(r.extractor && r.extractor.facts && r.extractor.facts._error,
+      'extractor report should surface the _error');
+  });
+
+  it('treats a null extractor result as a graceful warning (no crash)', async () => {
+    stubExtract(async () => null);
+    const dataRoot = dataRootWith({
+      preferences: { comics: { constraints: { formats: { accept: ['cbz'] } } } },
+    });
+    const r = await validate(makeItem(), approvedArchiveSource(), { dataRoot });
+    assert.equal(r.ok, true);
+    assert.ok(r.warnings.some(w => /extractor failed/.test(w.reason)), JSON.stringify(r.warnings));
+  });
+
+  it('applies no enforcement when the category has no constraints (backward compat)', async () => {
+    // Extractor runs and reports facts, but with no preferences.yaml there is
+    // nothing to enforce — Layers A+B behavior is preserved.
+    const m = stubExtract(async () => facts({ language: 'spa', available_formats: ['pdf'] }));
+    const dataRoot = dataRootWith(null); // no preferences.yaml at all
+    const r = await validate(makeItem(), approvedArchiveSource(), { dataRoot });
+    assert.equal(r.ok, true, JSON.stringify(r.errors));
+    assert.equal(m.mock.calls.length, 1, 'extractor still runs (report is populated)');
+    assert.ok(r.extractor, 'extractor report present even without constraints');
+    assert.deepEqual(r.errors, []);
+  });
+
+  it('uses item.category to select constraints (constraints under a different category do not apply)', async () => {
+    // Item is "comics"; constraints live only under "movies" => not applied.
+    stubExtract(async () => facts({ language: 'spa' }));
+    const dataRoot = dataRootWith({
+      preferences: { movies: { constraints: { languages: { accept: ['en'] } } } },
+    });
+    const r = await validate(makeItem({ category: 'comics' }), approvedArchiveSource(), { dataRoot });
+    assert.equal(r.ok, true, 'a comics item is not subject to movies constraints');
+    assert.deepEqual(r.errors, []);
+  });
+
+  it('skipExtraction=true bypasses Layer C entirely (extractor never called)', async () => {
+    const m = stubExtract(async () => facts({ available_formats: ['pdf'] }));
+    const dataRoot = dataRootWith({
+      preferences: { comics: { constraints: { formats: { accept: ['cbz'] } } } }, // would reject
+    });
+    const r = await validate(makeItem(), approvedArchiveSource(), { dataRoot, skipExtraction: true });
+    assert.equal(r.ok, true, 'skipExtraction disables Layer C');
+    assert.equal(m.mock.calls.length, 0, 'extractor must not be called');
+    assert.equal(r.extractor, undefined, 'no extractor report when skipped');
+  });
+
+  it('skips Layer C for a source whose host has no registered extractor', async () => {
+    const m = stubExtract(async () => facts()); // should never be called for netflix
+    const sources = [{ id: 'netflix', name: 'Netflix', hosts: ['www.netflix.com'], status: 'approved' }];
+    const item = makeItem({
+      source: 'netflix',
+      source_url: 'https://www.netflix.com/title/123',
+      category: 'movies',
+    });
+    const dataRoot = dataRootWith({
+      preferences: { movies: { constraints: { formats: { accept: ['cbz'] } } } },
+    });
+    const r = await validate(item, sources, { dataRoot });
+    assert.equal(r.ok, true, JSON.stringify(r.errors));
+    assert.equal(m.mock.calls.length, 0, 'archive-org extractor not invoked for a netflix URL');
+    assert.equal(r.extractor, undefined, 'no extractor report when no extractor is registered');
+  });
+
+  it('does NOT run Layer C when Layer A produced errors (extractor gated behind a clean A/B)', async () => {
+    const m = stubExtract(async () => facts());
+    // Host not in the approved registry => Layer A error => early return before Layer C.
+    const sources = [{ id: 'other', name: 'Other', hosts: ['example.com'], status: 'approved' }];
+    const item = makeItem({ source: 'other', source_url: 'https://archive.org/details/foo' });
+    const dataRoot = dataRootWith({
+      preferences: { comics: { constraints: { formats: { accept: ['pdf'] } } } },
+    });
+    const r = await validate(item, sources, { dataRoot });
+    assert.equal(r.ok, false);
+    assert.equal(m.mock.calls.length, 0, 'extractor must not run once structural errors exist');
+    assert.equal(r.extractor, undefined);
+  });
+});


### PR DESCRIPTION
## What

The content-publishing validator's **Layer C** (source extractor + tenant preference check — the part of `validateItem` that enforces `preferences.<category>.constraints` against extractor-derived facts) had its integration wiring covered **only by live Archive.org tests**.

Problems with the live-only coverage (all confirmed empirically):
1. **CI depends on archive.org every PR.** `npm test` ran without `SKIP_LIVE_TESTS`, so each PR makes real network calls to `archive.org/metadata/...` (~4–9s observed, flaky/slow, rate-limit-prone). An archive.org outage turns unrelated PRs red.
2. **False-green when the network is down.** The live tests have graceful fallbacks (`if (r._error) return;`) that pass *without asserting the wiring* when archive.org is unreachable.
3. **No deterministic protection for the glue:** extractor facts → `loadConstraints` → `preference-checker.check` → error/warning merge → `ok` flag.

Layers A+B are already covered hermetically (a local `http.createServer` in `content-validator.test.js`). This PR closes the same gap for Layer C.

## Changes

- **`test/content-validator-layer-c-hermetic.test.js`** (new, 14 tests): mocks the extractor's network leaf via `node:test` `mock.method` so the **real** `extractors.lookup` registry still routes archive.org URLs to the archive-org module, and runs with `skipFetch:true` → **zero network I/O**. Covers: pass-when-allowed; format / language / borrowable rejection; multi-violation merge; warning-vs-error merge; `unknown_field_policy=reject`; extractor `_error` and `null` graceful handling (no crash); no-constraints backward-compat; `item.category` routing; `skipExtraction` bypass; no-registered-extractor skip; and the "Layer C gated behind a clean A/B" invariant.
- **`.github/workflows/test.yml`**: set `SKIP_LIVE_TESTS=1` on the node-tests job so PRs no longer depend on archive.org. The live tests stay intact and runnable locally (`npm test` without the var).

**No production code changed** — this is purely test coverage + CI hygiene.

## Verification

- Full node suite **527 tests** (was 513): **522 pass / 5 skipped (live) / 0 fail** under `SKIP_LIVE_TESTS=1` (CI parity), 1.4s (was ~8.7s+ with live network).
- **Bite-verified** across 4 distinct wiring regressions — each breaks exactly the dependent tests, all green after restore:
  - drop the preference-checker **error** merge → 5 rejection tests fail
  - drop the **warning** merge → 1 warning test fails
  - break the `skipExtraction` gate → 1 bypass test fails
  - hardcode the wrong `category` → 6 constraint-dependent tests fail
- Live tests still pass locally without the flag (23/23, hits real archive.org).
- **End-to-end** via the real `publish-content.js` CLI against live archive.org: a comics item (pdf/epub) with `formats.accept: [cbz, cbr]` is correctly rejected by Layer C (`ok: false`, formats error).

Found via the correctness-audit rotation (Layer C was the named un-swept slice after #256 swept Layers A+B). The Layer C *code* audited clean — no reachable bug — so per the clean-audit discipline the productive output is locking the load-bearing invariant with a deterministic test.