### PR TITLE
Sanitize markdown render output to close the marked→innerHTML XSS sink (v1.5.36)

### DIFF
--- a/lib/ui/client-core.js
+++ b/lib/ui/client-core.js
@@ -48,6 +48,20 @@ function escapeHtml(s) {
   return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
 }
 
+// Render agent/user-authored markdown for innerHTML insertion. Current marked does
+// NOT sanitize raw HTML in markdown (the sanitize option was removed in v0.7+), so the
+// parsed output is passed through DOMPurify to strip <script>, on*= handlers, and
+// javascript: URLs before it reaches innerHTML — closing the stored-XSS sink for any
+// field that can carry externally-derived content. Fail-safe: if DOMPurify did not load,
+// fall back to the raw marked output (prior behavior) so rendering never breaks; the
+// change can only add protection, never regress display.
+function renderMarkdown(s) {
+  var html = marked.parse(s == null ? '' : String(s));
+  return (typeof DOMPurify !== 'undefined' && DOMPurify && typeof DOMPurify.sanitize === 'function')
+    ? DOMPurify.sanitize(html)
+    : html;
+}
+
 function formatTimestamp(isoStr) {
   const d = new Date(isoStr);
   if (isNaN(d.getTime())) return isoStr;
@@ -473,7 +487,7 @@ function renderJournalEntry(e, idx) {
     + '<span class="timestamp">' + dateStr + '</span>'
     + editBtn
     + '</div>'
-    + '<div class="journal-entry-body md-content">' + marked.parse(e.content) + '</div>'
+    + '<div class="journal-entry-body md-content">' + renderMarkdown(e.content) + '</div>'
     + '</div>';
 }
 
@@ -906,7 +920,7 @@ async function loadStatus() {
     // Today.md
     html += '<div class="status-section">'
       + '<h2>Today</h2>'
-      + '<div class="status-card"><div class="md-content">' + marked.parse(today.content || '*No today.md*') + '</div></div>'
+      + '<div class="status-card"><div class="md-content">' + renderMarkdown(today.content || '*No today.md*') + '</div></div>'
       + '</div>';
 
     // Recent events (last 20)

--- a/lib/ui/shell.js
+++ b/lib/ui/shell.js
@@ -327,6 +327,7 @@ window.addEventListener('popstate', function(e) {
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>${name} — Agent Portal</title>
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"><\/script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"><\/script>
 <style>
 ${getStyles(authors)}
 </style>

--- a/lib/ui/sidebar-projects.js
+++ b/lib/ui/sidebar-projects.js
@@ -82,7 +82,7 @@ async function selectBobboLog() {
           + '<span class="timestamp">' + dateStr + '</span>'
           + editBtn
           + '</div>'
-          + '<div class="journal-entry-body md-content">' + marked.parse(e.content) + '</div>'
+          + '<div class="journal-entry-body md-content">' + renderMarkdown(e.content) + '</div>'
           + '</div>';
       });
     }
@@ -163,7 +163,7 @@ async function loadProjectJournal() {
           + '<span class="timestamp">' + dateStr + '</span>'
           + editBtn
           + '</div>'
-          + '<div class="journal-entry-body md-content">' + marked.parse(e.content) + '</div>'
+          + '<div class="journal-entry-body md-content">' + renderMarkdown(e.content) + '</div>'
           + '</div>';
       });
     }
@@ -223,7 +223,7 @@ async function loadProjectFile() {
     const res = await fetch('/api/projects/' + encodeURIComponent(currentSlug) + '/file');
     const data = await res.json();
     contentEl.innerHTML = '<div class="status-section"><div class="status-card"><div class="md-content">'
-      + marked.parse(data.content || '*No project file found.*')
+      + renderMarkdown(data.content || '*No project file found.*')
       + '</div></div></div>';
     contentEl.querySelectorAll('.md-content a').forEach(function(a) { a.target = '_blank'; a.rel = 'noopener'; });
     contentEl.scrollTop = 0;

--- a/lib/ui/tabs/outputs.js
+++ b/lib/ui/tabs/outputs.js
@@ -257,7 +257,7 @@ async function viewOutput(filename) {
     html += '<button class="refresh-btn" onclick="copyRawOutput()" id="copy-raw-btn" style="font-size:12px;padding:4px 10px">Copy Raw</button>';
     html += '</div>';
     html += '</div>';
-    html += '<div class="status-card"><div class="md-content">' + marked.parse(data.content) + '</div></div>';
+    html += '<div class="status-card"><div class="md-content">' + renderMarkdown(data.content) + '</div></div>';
 
     // Feedback panel
     html += '<div id="feedback-panel" style="margin-top:16px;padding:16px;background:#fff;border-radius:8px;border:1px solid #e8e8e8">';

--- a/lib/ui/tabs/requests.js
+++ b/lib/ui/tabs/requests.js
@@ -30,7 +30,7 @@ async function loadRequests() {
           + '<span class="tag-badge ' + statusClass + '">' + escapeHtml(req.status) + '</span>'
           + (req.filed ? '<span class="timestamp">Filed ' + escapeHtml(req.filed) + '</span>' : '')
           + '</div>'
-          + '<div class="journal-entry-body md-content">' + marked.parse(req.content) + '</div>';
+          + '<div class="journal-entry-body md-content">' + renderMarkdown(req.content) + '</div>';
 
         // Reply form
         html += '<div style="margin-top:12px;padding-top:12px;border-top:1px solid #eee">'

--- a/lib/ui/tabs/roadmap.js
+++ b/lib/ui/tabs/roadmap.js
@@ -10,7 +10,7 @@ async function loadRoadmap() {
   try {
     const res = await fetch('/api/roadmap');
     const data = await res.json();
-    contentEl.innerHTML = '<div class="status-section"><div class="status-card"><div class="md-content">' + marked.parse(data.content || '*No roadmap.md*') + '</div></div></div>';
+    contentEl.innerHTML = '<div class="status-section"><div class="status-card"><div class="md-content">' + renderMarkdown(data.content || '*No roadmap.md*') + '</div></div></div>';
     contentEl.querySelectorAll('.md-content a').forEach(function(a) { a.target = '_blank'; a.rel = 'noopener'; });
     contentEl.scrollTop = 0;
   } catch (err) {

--- a/lib/ui/tabs/todos.js
+++ b/lib/ui/tabs/todos.js
@@ -30,7 +30,7 @@ async function loadTodos() {
         html += '<div class="todo-item">'
           + '<input type="checkbox" class="todo-cb" onchange="toggleTodo(' + idx + ', this.checked)">'
           + '<div class="todo-body" ' + (hasDetails ? 'onclick="toggleDetails(' + idx + ')"' : '') + '>'
-          + '<span class="todo-text md-content">' + marked.parse(t.text).trim() + '</span>'
+          + '<span class="todo-text md-content">' + renderMarkdown(t.text).trim() + '</span>'
           + (hasDetails ? ' <span class="todo-info-badge" title="Has additional info">i</span>' : '')
           + '</div>'
           + '<button class="todo-edit" onclick="editTodoDetails(' + idx + ')" title="Edit details">\\u270e</button>'
@@ -38,7 +38,7 @@ async function loadTodos() {
           + '</div>';
         if (hasDetails) {
           html += '<div class="todo-details md-content" id="todo-details-' + idx + '" style="display:none">'
-            + marked.parse(t.details) + '</div>';
+            + renderMarkdown(t.details) + '</div>';
         }
       });
 
@@ -58,14 +58,14 @@ async function loadTodos() {
           html += '<div class="todo-item todo-completed">'
             + '<input type="checkbox" class="todo-cb" checked onchange="toggleTodo(' + idx + ', this.checked)">'
             + '<div class="todo-body" ' + (hasDetails ? 'onclick="toggleDetails(' + idx + ')"' : '') + '>'
-            + '<span class="todo-text md-content">' + marked.parse(t.text).trim() + '</span>'
+            + '<span class="todo-text md-content">' + renderMarkdown(t.text).trim() + '</span>'
             + (hasDetails ? ' <span class="todo-info-badge" title="Has additional info">i</span>' : '')
             + '</div>'
             + '<button class="todo-delete" onclick="deleteTodo(' + idx + ')" title="Delete">\\u00d7</button>'
             + '</div>';
           if (hasDetails) {
             html += '<div class="todo-details md-content" id="todo-details-' + idx + '" style="display:none">'
-              + marked.parse(t.details) + '</div>';
+              + renderMarkdown(t.details) + '</div>';
           }
         });
         html += '</div></div>';
@@ -98,7 +98,7 @@ async function loadTodos() {
           + '<span class="tag-badge tag-' + escapeHtml(n.tag) + '">' + escapeHtml(n.tag) + '</span>'
           + '<span class="timestamp">' + formatTimestamp(n.ts) + '</span>'
           + '</div>'
-          + '<div class="journal-entry-body md-content">' + marked.parse(n.content) + '</div>'
+          + '<div class="journal-entry-body md-content">' + renderMarkdown(n.content) + '</div>'
           + '</div>';
       }
       if (reversedNotes.length > 5) {
@@ -143,7 +143,7 @@ async function loadTodos() {
             + '<span class="tag-badge tag-' + escapeHtml(n.tag) + '">' + escapeHtml(n.tag) + '</span>'
             + '<span class="timestamp">' + formatTimestamp(n.ts) + '</span>'
             + '</div>'
-            + '<div class="journal-entry-body md-content">' + marked.parse(n.content) + '</div>'
+            + '<div class="journal-entry-body md-content">' + renderMarkdown(n.content) + '</div>'
             + '</div>';
         });
         sentinel.insertAdjacentHTML('beforebegin', frag);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-portal",
-  "version": "1.5.35",
+  "version": "1.5.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-portal",
-      "version": "1.5.35",
+      "version": "1.5.36",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.5.35",
+  "version": "1.5.36",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/test/ui-render-markdown.test.js
+++ b/test/ui-render-markdown.test.js
@@ -1,0 +1,136 @@
+// ui-render-markdown.test.js — Behavior + wiring tests for renderMarkdown, the
+// client-side markdown→HTML render helper that feeds innerHTML at 14 sites.
+//
+// THE BUG (issue #262): every journal / today.md / roadmap / output / todo / request
+// field was rendered with marked.parse(...) straight into innerHTML. Current marked does
+// NOT sanitize raw HTML in markdown (the sanitize option was removed in v0.7+), and the
+// portal sets no Content-Security-Policy, so any field carrying externally-derived content
+// was a stored-XSS sink. THE FIX: renderMarkdown pipes marked output through DOMPurify
+// before it reaches innerHTML, with a fail-safe fallback to raw marked output if DOMPurify
+// did not load (so rendering can never regress).
+//
+// These tests evaluate the emitted client JS string in an isolated node:vm context with
+// injectable marked / DOMPurify stubs (no DOM library / new dependency — the established
+// dep-free client-behavior pattern from ui-client-helpers.test.js), and assert the
+// load-bearing property: marked output is routed THROUGH DOMPurify.sanitize. Removing the
+// DOMPurify wrap makes the wiring + sink-closed tests fail (bite-verified).
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const vm = require('node:vm');
+
+const { getClientCore } = require('../lib/ui/client-core');
+const { buildHTML } = require('../lib/ui/shell');
+
+// Evaluate the emitted client-JS string in a sandbox with caller-supplied marked /
+// DOMPurify stubs and pull out renderMarkdown. Omitting DOMPurify from `extra` leaves
+// `typeof DOMPurify === 'undefined'` in the sandbox — the fail-safe path.
+function loadRenderMarkdown(extra) {
+  const noop = () => {};
+  const fakeEl = { style: {}, classList: { add: noop, remove: noop, toggle: noop, contains: () => false }, addEventListener: noop };
+  const sandbox = Object.assign({
+    window: { fetch: noop },
+    document: {
+      getElementById: () => null,
+      querySelector: () => null,
+      querySelectorAll: () => [],
+      addEventListener: noop,
+      createElement: () => fakeEl,
+      body: fakeEl,
+    },
+    performance: { now: () => 0, getEntriesByType: () => [] },
+    localStorage: { getItem: () => null, setItem: noop },
+    PORTAL_CONFIG: { tabs: ['journal'], harnessLabel: 'Claude' },
+    setInterval: () => 0,
+    clearInterval: noop,
+    setTimeout: () => 0,
+    console,
+  }, extra);
+  sandbox.globalThis = sandbox;
+  vm.runInNewContext(`var __helpers = {};\n${getClientCore()}\nglobalThis.__helpers.renderMarkdown = renderMarkdown;`, sandbox, { timeout: 5000 });
+  return sandbox.__helpers.renderMarkdown;
+}
+
+// A marked stub that mimics real marked's non-sanitizing behavior: raw HTML in the
+// markdown passes straight through (this is precisely why the sink existed).
+const passthroughMarked = { parse: (s) => '<p>' + s + '</p>' };
+
+describe('renderMarkdown — wiring (closes the marked→innerHTML XSS sink, #262)', () => {
+  it('routes marked output THROUGH DOMPurify.sanitize before returning', () => {
+    const calls = [];
+    const renderMarkdown = loadRenderMarkdown({
+      marked: { parse: (s) => 'MARKED(' + s + ')' },
+      DOMPurify: { sanitize: (h) => { calls.push(h); return 'PURIFIED(' + h + ')'; } },
+    });
+    const out = renderMarkdown('hello');
+    // DOMPurify must receive exactly marked's output (correct pipe order)...
+    assert.deepEqual(calls, ['MARKED(hello)']);
+    // ...and renderMarkdown must return the sanitized result, not the raw marked output.
+    assert.equal(out, 'PURIFIED(MARKED(hello))');
+  });
+
+  it('neutralizes a script payload that marked would pass straight to innerHTML', () => {
+    // Stub DOMPurify with a representative sanitizer (strip <script> + on*= handlers);
+    // the real DOMPurify is stronger. The point: a payload that reaches innerHTML raw
+    // pre-fix is stripped post-fix.
+    const sanitize = (h) => h.replace(/<script[\s\S]*?<\/script>/gi, '').replace(/ on\w+=("[^"]*"|'[^']*'|[^\s>]+)/gi, '');
+    const renderMarkdown = loadRenderMarkdown({ marked: passthroughMarked, DOMPurify: { sanitize } });
+
+    const scriptOut = renderMarkdown('<script>alert(1)</script>');
+    assert.ok(!/<script/i.test(scriptOut), 'script tag must be stripped');
+
+    const handlerOut = renderMarkdown('<img src=x onerror=alert(1)>');
+    assert.ok(!/onerror/i.test(handlerOut), 'event handler must be stripped');
+  });
+
+  it('passes ordinary markdown HTML through unharmed (no display regression)', () => {
+    // Real DOMPurify preserves benign tags; emulate by returning input unchanged.
+    const renderMarkdown = loadRenderMarkdown({ marked: passthroughMarked, DOMPurify: { sanitize: (h) => h } });
+    assert.equal(renderMarkdown('**bold** and a [link](https://x.test)'), '<p>**bold** and a [link](https://x.test)</p>');
+  });
+});
+
+describe('renderMarkdown — input safety', () => {
+  const renderMarkdown = loadRenderMarkdown({ marked: passthroughMarked, DOMPurify: { sanitize: (h) => h } });
+
+  it('renders null/undefined as empty (no throw) instead of "null"/"undefined"', () => {
+    assert.equal(renderMarkdown(null), '<p></p>');
+    assert.equal(renderMarkdown(undefined), '<p></p>');
+  });
+
+  it('coerces non-string input to a string', () => {
+    assert.equal(renderMarkdown(123), '<p>123</p>');
+  });
+});
+
+describe('renderMarkdown — fail-safe (DOMPurify absent ⇒ no rendering regression)', () => {
+  it('falls back to raw marked output when DOMPurify did not load', () => {
+    // No DOMPurify in the sandbox ⇒ typeof DOMPurify === 'undefined'.
+    const renderMarkdown = loadRenderMarkdown({ marked: { parse: (s) => 'MARKED(' + s + ')' } });
+    assert.equal(renderMarkdown('hi'), 'MARKED(hi)');
+  });
+
+  it('does not throw when DOMPurify is present but malformed', () => {
+    const renderMarkdown = loadRenderMarkdown({ marked: passthroughMarked, DOMPurify: {} });
+    assert.equal(renderMarkdown('x'), '<p>x</p>');
+  });
+});
+
+describe('shell.js — serves the DOMPurify sanitizer alongside marked', () => {
+  const html = buildHTML({ name: 'Test', authors: {}, features: { tabs: ['journal'] }, harness: { type: 'claude-code' } });
+
+  it('loads the DOMPurify CDN script so the global exists in the browser', () => {
+    assert.ok(/cdn\.jsdelivr\.net\/npm\/dompurify@\d/.test(html), 'DOMPurify CDN tag must be present');
+  });
+
+  it('still loads marked (the render pipeline is intact)', () => {
+    assert.ok(/cdn\.jsdelivr\.net\/npm\/marked/.test(html), 'marked CDN tag must remain');
+  });
+
+  it('emits renderMarkdown into the client bundle (no bare marked.parse at render sites)', () => {
+    assert.ok(html.includes('function renderMarkdown('), 'renderMarkdown helper must be emitted');
+    // The only marked.parse left is inside renderMarkdown itself.
+    const occurrences = (html.match(/marked\.parse\(/g) || []).length;
+    assert.equal(occurrences, 1, 'marked.parse must appear only inside renderMarkdown');
+  });
+});


### PR DESCRIPTION
## What & why

Closes the stored-XSS sink documented in #262. The portal rendered agent/Rob-authored markdown with `marked.parse(...)` directly into `innerHTML` at **14 sites**, with **no HTML sanitization and no CSP**. Current `marked` does not sanitize raw HTML in markdown (the `sanitize` option was removed in v0.7+), so any field that can carry externally-derived content was a stored-XSS vector — e.g. an output file summarizing a scraped page, or a journal entry quoting external text. The payload would execute in Rob's authenticated portal session (full API surface).

## Fix

A single client-side helper routes all markdown rendering through DOMPurify:

```js
function renderMarkdown(s) {
  var html = marked.parse(s == null ? '' : String(s));
  return (typeof DOMPurify !== 'undefined' && DOMPurify && typeof DOMPurify.sanitize === 'function')
    ? DOMPurify.sanitize(html) : html;
}
```

- All 14 `marked.parse(...)` call sites → `renderMarkdown(...)` (the only remaining `marked.parse` is inside the helper).
- DOMPurify@3 loaded from the same CDN as marked (verified reachable: v3.4.11, exposes the `DOMPurify` global).
- **Fail-safe by design**: if DOMPurify fails to load, `renderMarkdown` returns raw marked output (prior behavior). The change can only *add* protection — it cannot break rendering.

Why not CSP: a strict `script-src` is not viable without a large refactor (the app relies on inline `onclick` handlers, which force `unsafe-inline`, defeating the protection). DOMPurify is the standard, surgical fix.

## Verification

- `test/ui-render-markdown.test.js` (10 tests): node:vm wiring (marked → DOMPurify order), sink-closing on a `<script>`/`onerror` payload, null/undefined/coercion safety, the fail-safe fallback, and a served-HTML integration check.
- **Bite-verified**: dropping the DOMPurify wrap fails exactly the 2 sink-closing tests.
- Full node suite **560 / 0 fail** (was 550), 5 live-skipped.
- **Booted the real HTTP server** and confirmed the served page (200) carries the marked + DOMPurify loads + `renderMarkdown`, with exactly one bare `marked.parse` (the helper).

## Residual risk / dependency note

Adds one external CDN dependency (DOMPurify), matching the existing marked load. If you'd prefer to self-host/bundle it rather than add a CDN dependency to a private tool, say so and I'll switch — flagging for visibility (also noted on #262). The live browser sanitization can't be exercised in the framework's harness (no DOM test harness; portal is Tailscale-private), so verification covers the wiring + the served page + the fail-safe fallback.

Refs #262
