### PR TITLE
Pin marked/DOMPurify CDN loads + add Subresource Integrity (v1.5.37)

### DIFF
--- a/lib/ui/shell.js
+++ b/lib/ui/shell.js
@@ -326,8 +326,9 @@ window.addEventListener('popstate', function(e) {
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>${name} — Agent Portal</title>
-<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"><\/script>
-<script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"><\/script>
+<!-- CDN libs pinned to exact versions so Subresource Integrity can verify them; on bump, update the version AND recompute the integrity hash together. -->
+<script src="https://cdn.jsdelivr.net/npm/marked@15.0.12/marked.min.js" integrity="sha384-948ahk4ZmxYVYOc+rxN1H2gM1EJ2Duhp7uHtZ4WSLkV4Vtx5MUqnV+l7u9B+jFv+" crossorigin="anonymous"><\/script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3.4.11/dist/purify.min.js" integrity="sha384-o44XUELLEnv/iSlA1NWxBweqbD4TSR0qgq2VzVsxtkHS989JJjGKSE9vkfo5MN4K" crossorigin="anonymous"><\/script>
 <style>
 ${getStyles(authors)}
 </style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-portal",
-  "version": "1.5.36",
+  "version": "1.5.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-portal",
-      "version": "1.5.36",
+      "version": "1.5.37",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portal",
-  "version": "1.5.36",
+  "version": "1.5.37",
   "description": "Shared web portal for autonomous agents",
   "main": "index.js",
   "bin": {

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -56,9 +56,24 @@ describe('buildHTML', () => {
     assert.ok(html.includes('"hasGitHub":false'));
   });
 
-  it('includes marked.js CDN script tag', () => {
+  it('loads marked + DOMPurify from CDN, version-pinned with Subresource Integrity', () => {
     const html = buildHTML(baseConfig);
-    assert.ok(html.includes('cdn.jsdelivr.net/npm/marked/marked.min.js'));
+    // Pinned to exact immutable versions (floating "latest"/major URLs cannot be SRI-verified).
+    assert.ok(html.includes('cdn.jsdelivr.net/npm/marked@15.0.12/marked.min.js'), 'marked must be version-pinned');
+    assert.ok(html.includes('cdn.jsdelivr.net/npm/dompurify@3.4.11/dist/purify.min.js'), 'DOMPurify must be version-pinned');
+    // No floating CDN URL may slip back in — that would silently disable integrity checking.
+    assert.ok(!html.includes('npm/marked/marked.min.js'), 'marked must not be loaded unversioned');
+    assert.ok(!html.includes('npm/dompurify@3/dist'), 'DOMPurify must not be loaded at a floating major');
+    // SRI hash + crossorigin are load-bearing security attributes: without them a compromised
+    // CDN response (e.g. a neutered DOMPurify.sanitize) silently bypasses the XSS fix (#262/#263).
+    assert.ok(html.includes('integrity="sha384-948ahk4ZmxYVYOc+rxN1H2gM1EJ2Duhp7uHtZ4WSLkV4Vtx5MUqnV+l7u9B+jFv+"'), 'marked SRI hash must match the pinned bytes');
+    assert.ok(html.includes('integrity="sha384-o44XUELLEnv/iSlA1NWxBweqbD4TSR0qgq2VzVsxtkHS989JJjGKSE9vkfo5MN4K"'), 'DOMPurify SRI hash must match the pinned bytes');
+    const tags = html.match(/<script src="https:\/\/cdn\.jsdelivr\.net[^>]*><\/script>/g) || [];
+    assert.equal(tags.length, 2, 'expected exactly the two pinned CDN script tags');
+    for (const tag of tags) {
+      assert.ok(tag.includes('integrity="sha384-'), `CDN script tag missing SRI: ${tag}`);
+      assert.ok(tag.includes('crossorigin="anonymous"'), `CDN script tag missing crossorigin (SRI fails without it): ${tag}`);
+    }
   });
 
   it('includes all CSS sections', () => {


### PR DESCRIPTION
## What

Pin the portal's two CDN script loads (`marked`, `DOMPurify`) to exact immutable versions and add **Subresource Integrity (SRI)** + `crossorigin="anonymous"`.

## Why

The #263 XSS fix routes all markdown through a CDN-loaded `DOMPurify`. But both `marked` and `DOMPurify` were loaded with **no integrity check** — so a compromised/MITM'd CDN response could silently neuter the sanitizer (`DOMPurify.sanitize = x => x`) or replace `marked` with arbitrary JS, **re-opening the sink #262/#263 closed** in Rob's authenticated portal session. SRI makes the loads tamper-evident; version pinning is what makes SRI possible (a hash can't verify a floating "latest" target).

`marked` was also loaded fully unversioned — jsdelivr served whatever's newest with a `/marked.min.js` file (currently **v15.0.12**, since v16+ moved the file). Implicit, fragile, non-reproducible.

## Change

`lib/ui/shell.js`:
- `marked@15.0.12/marked.min.js` — the exact version served today, verified **byte-identical** via `cmp` (zero behavior change), `integrity` sha384 + `crossorigin`.
- `dompurify@3.4.11/dist/purify.min.js` — what `@3` resolves to, also byte-identical, `integrity` sha384 + `crossorigin`.

`renderMarkdown` and all 14 sink sites are unchanged. `marked` stays on v15.0.12 (a deliberate v18 upgrade is out of scope — it moves the file path and needs #263's sanitization re-verified). See #264 for residual decisions (self-host option, deliberate-bump operational note).

## Verification

- SRI hashes computed from the exact bytes the browser fetches from the pinned URLs; jsdelivr sends `Access-Control-Allow-Origin: *` (confirmed) so `crossorigin="anonymous"` verifies.
- Pinned-URL bytes **byte-identical** to the live unversioned loads (`cmp` clean, sha256 match) → no rendering change.
- New `test/ui.test.js` assertion locks the invariant (both tags pinned + SRI + crossorigin; no floating URL); **bite-verified** it fails against the unpinned `shell.js`.
- Node suite **560 (555 pass / 0 fail / 5 live-skipped)**.
- **Booted the real server** (`node index.js`) and confirmed the served 200 page carries both pinned tags with the correct `integrity` + `crossorigin`.

Refs #264, #262