### PR TITLE
fix(wake.sh): stop leaking GH_TOKEN into wake-steps.log

### DIFF
--- a/scripts/wake.sh
+++ b/scripts/wake.sh
@@ -35,7 +35,7 @@ done
 # Source .env if present (pre-Sandcat containers use .env for secrets)
 if [ -f "$AGENT_DIR/.env" ]; then
   set -a; . "$AGENT_DIR/.env"; set +a
-  step ".env sourced (GH_TOKEN=${GH_TOKEN:+set}${GH_TOKEN:-MISSING})"
+  step ".env sourced (GH_TOKEN=$( [ -n "${GH_TOKEN:-}" ] && echo set || echo MISSING ))"
 else
   step ".env not found at $AGENT_DIR/.env (skipping — using container environment)"
 fi


### PR DESCRIPTION
## Problem
`scripts/wake.sh` logs the real `GH_TOKEN` in plaintext into `logs/cycles/wake-steps.log` on every wake of a single-container (non-Sandcat) agent.

The offending line:
```sh
step ".env sourced (GH_TOKEN=\${GH_TOKEN:+set}\${GH_TOKEN:-MISSING})"
```
`${GH_TOKEN:+set}` → `set` when set, but `${GH_TOKEN:-MISSING}` → the **token value** when set (only `MISSING` when unset), so they concatenate to `set<actual-token>`.

Verified: the logged value equals the live token (found on fleethd-research cycle 1).

## Fix
Emit only `set` / `MISSING`, never the value:
```sh
step ".env sourced (GH_TOKEN=\$( [ -n \"\${GH_TOKEN:-}\" ] && echo set || echo MISSING ))"
```
Tested: set→`set`, unset/empty→`MISSING`, value never printed; `bash -n` clean.

## Impact / scope
- Affects all single-container agents (bobbo/pm/coder/contentbot). Sandcat agents were unaffected (placeholder only).
- The leaked file is local-only & gitignored (never pushed), so no remote exposure — but it is plaintext-at-rest per wake.
- **Follow-up (not in this PR):** line ~233 embeds `${GH_TOKEN}` in a clone URL whose stderr is captured on failure. git usually redacts credentials in URLs, but worth a defensive pass later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)