### PR TITLE
fix(journal/todos): render entries from hyphen-named agents

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -76,7 +76,7 @@ function parseJournal(content) {
     if (firstNewline === -1) continue;
     const header = part.substring(0, firstNewline).trim();
     const body = part.substring(firstNewline + 1).trim();
-    const headerMatch = header.match(/^(\S+)\s*\|\s*(\w+)\s*\|\s*(\w+)/);
+    const headerMatch = header.match(/^(\S+)\s*\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*$/);
     if (headerMatch) {
       entries.push({
         ts: headerMatch[1],

--- a/lib/routes/todos.js
+++ b/lib/routes/todos.js
@@ -52,7 +52,7 @@ function parseTodos(content) {
         todos[todos.length - 1].text += '\n' + line.trimStart();
       }
     } else if (section === 'notes') {
-      const headerMatch = line.match(/^### (\S+)\s*\|\s*(\w+)\s*\|\s*(\w+)/);
+      const headerMatch = line.match(/^### (\S+)\s*\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*$/);
       if (headerMatch) {
         if (noteBuffer) notes.push(noteBuffer);
         noteBuffer = { ts: headerMatch[1], author: headerMatch[2], tag: headerMatch[3], content: '' };


### PR DESCRIPTION
## Problem
The journal tab showed only human (`rob`) entries; entries authored by `fleethd-research` were missing from the UI **despite being present in the journal file**.

Root cause: the header parser matches author/tag with `(\w+)`, which excludes hyphens:
```js
/^(\S+)\s*\|\s*(\w+)\s*\|\s*(\w+)/
```
`fleethd-research` (hyphen) fails the match → the whole entry is dropped. Affects any hyphen-named agent. Same bug in two places: `lib/helpers.js` (journal) and `lib/routes/todos.js` (todos/notes). `scripts/memory-index.py` uses `\S+` and was already fine.

## Fix
Broaden author + tag to `([^|]+?)` with an end anchor:
```js
/^(\S+)\s*\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*$/
```

## Verification
Patched `parseJournal` returns all 8 entries from a real mixed-author journal; edge cases (hyphen, underscore, extra whitespace) parse for both patterns. No data migration needed — parsing is on read, so existing entries render retroactively once the portal restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)