### PR TITLE
feat(sandcat): pass MongoDB Atlas TLS through mitmproxy

### DIFF
--- a/sandcat/compose-proxy.yml
+++ b/sandcat/compose-proxy.yml
@@ -27,6 +27,7 @@ services:
     command: >-
       mitmweb --mode wireguard --web-host 0.0.0.0
       --set web_password=${MITMPROXY_WEB_PASSWORD}
+      --ignore-hosts '(^|\.)mongodb\.net(:[0-9]+)?$$'
       -s /scripts/mitmproxy_addon.py
     ports:
       - "8081" # mitmweb UI; host port assigned dynamically to avoid conflicts

--- a/scripts/docker-compose-create.sh
+++ b/scripts/docker-compose-create.sh
@@ -139,6 +139,7 @@ services:
     command: >-
       mitmweb --mode wireguard --web-host 0.0.0.0
       --set web_password=$MITMPROXY_WEB_PASSWORD
+      --ignore-hosts '(^|\.)mongodb\.net(:[0-9]+)?\$\$'
       -s /scripts/mitmproxy_addon.py
     ports:
       - "8081"


### PR DESCRIPTION
## Problem
Sandcat agents can't reach MongoDB Atlas — mitmproxy intercepts/re-signs the TLS to `*.mongodb.net`, breaking **X.509** (client cert never reaches Atlas) and **SCRAM** (pymongo rejects the `CN=mitmproxy` server cert). Diagnosed on fleethd-research cycle 5.

## Fix
Add `--ignore-hosts '(^|\.)mongodb\.net(:[0-9]+)?$'` to the mitmweb command (generator + template).

- **Port-tolerant** is essential: mitmproxy matches `ignore_hosts` against `host:port`, so a plain trailing-`$` anchor never matches `…mongodb.net:27017` and silently keeps intercepting. **Verified this failure**, then verified the port-tolerant form works.
- **End-anchored** → rejects look-alikes like `mongodb.net.evil.com`.
- `$$` / `\$\$` escaping verified to yield the exact regex as the final mitmweb arg through Compose interpolation + the generator heredoc.

## Verification (mitmproxy 12.2.3, regular mode, real Atlas)
- live00 (SCRAM): passthrough → server cert issued by **Google Trust Services**, not mitmproxy.
- dev + X.509 client PEM: **mutual-TLS handshake completes**, client cert survives the tunnel.
- Without the flag: intercepted (mitmproxy issuer) = broken state reproduced.

## Residual (only the real stack can confirm)
Validated in **regular** mode; the stack runs **WireGuard** mode, where `ignore_hosts` may match on IP/SNI rather than the CONNECT host. Modern mitmproxy peeks SNI so hostname matching likely holds; if not, fall back to Atlas IP ranges or a host-run proxy.

## Deploy
Re-run `docker-compose-create.sh` to regenerate the stack, then connect to Atlas from inside the agent container to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)