### PR TITLE
fix(requests): sort pending first, status colors, drop duplicate title

### DIFF
--- a/lib/ui/tabs/requests.js
+++ b/lib/ui/tabs/requests.js
@@ -13,24 +13,39 @@ async function loadRequests() {
     var res = await fetch('/api/requests');
     var data = await res.json();
     var items = data.items || [];
+    // Order: pending first (needs Rob), then open/other, parked, resolved/completed last.
+    // Stable within a rank (preserves filed order) via the original-index tiebreak.
+    var STATUS_RANK = { pending: 0, approved: 1, rejected: 1, parked: 2, completed: 3, resolved: 3 };
+    items = items.map(function(r, i) { return { r: r, i: i }; }).sort(function(a, b) {
+      var ra = STATUS_RANK[a.r.status]; if (ra === undefined) ra = 2;
+      var rb = STATUS_RANK[b.r.status]; if (rb === undefined) rb = 2;
+      return (ra - rb) || (a.i - b.i);
+    }).map(function(x) { return x.r; });
     _requestFiles = items.map(function(r) { return r.file; });
     var html = '<div class="status-section"><h2>PM Requests</h2>';
     if (items.length === 0) {
       html += '<div style="color:#999;font-size:14px;padding:8px 0">No requests filed yet.</div>';
     } else {
       items.forEach(function(req, idx) {
-        var statusClass = 'tag-note';
-        if (req.status === 'pending') statusClass = 'tag-question';
-        else if (req.status === 'approved') statusClass = 'tag-output';
-        else if (req.status === 'rejected') statusClass = 'tag-feedback';
-        else if (req.status === 'completed') statusClass = 'tag-outcome';
-        html += '<div class="journal-entry" style="border-left:3px solid #ff9800">'
+        // Status-appropriate colors (badge + left border): amber = needs you,
+        // green = done (resolved/completed/approved), gray = parked/deferred.
+        var statusClass = 'tag-note', borderColor = '#9e9e9e';
+        if (req.status === 'pending') { statusClass = 'tag-question'; borderColor = '#ff9800'; }
+        else if (req.status === 'resolved' || req.status === 'completed' || req.status === 'approved') { statusClass = 'tag-output'; borderColor = '#43a047'; }
+        else if (req.status === 'rejected') { statusClass = 'tag-feedback'; borderColor = '#e65100'; }
+        else if (req.status === 'parked') { statusClass = 'tag-note'; borderColor = '#9e9e9e'; }
+        // Drop the leading H1 from the body — the card header already shows the
+        // title (it is derived from that same H1), so rendering it would duplicate.
+        var _c = req.content || '';
+        var _nl = _c.indexOf('\\n');
+        var _body = (_c.charAt(0) === '#' && _nl !== -1) ? _c.slice(_nl + 1) : _c;
+        html += '<div class="journal-entry" style="border-left:3px solid ' + borderColor + '">'
           + '<div class="journal-entry-header">'
           + '<span style="font-weight:600;font-size:14px">' + escapeHtml(req.title) + '</span>'
           + '<span class="tag-badge ' + statusClass + '">' + escapeHtml(req.status) + '</span>'
           + (req.filed ? '<span class="timestamp">Filed ' + escapeHtml(req.filed) + '</span>' : '')
           + '</div>'
-          + '<div class="journal-entry-body md-content">' + renderMarkdown(req.content) + '</div>';
+          + '<div class="journal-entry-body md-content">' + renderMarkdown(_body) + '</div>';
 
         // Reply form
         html += '<div style="margin-top:12px;padding-top:12px;border-top:1px solid #eee">'


### PR DESCRIPTION
## What
Fixes three issues on the portal **Requests** tab (per Rob's request on the fleethd-research agent):

1. **Pending at top.** Requests were shown in file order; now sorted **pending → open/other → parked → resolved/completed**, stable within each rank (preserves filed order).
2. **Status-appropriate colors** (badge **and** left border), where before every card was the same orange and `resolved`/`parked` both fell through to gray:
   - **pending** → amber (needs you)
   - **resolved/completed/approved** → green (done)
   - **parked** → gray (deferred)
3. **Duplicate title removed.** Each request `.md` starts with `# Request NNNN: …`, which the route uses to derive the card title — so the body re-rendered the same heading. The leading H1 is now dropped from the body.

All changes are in `lib/ui/tabs/requests.js` (client rendering only). No API or data changes.

## Verification
- `node --test` — **166/166 pass** (ui/web-portal/routes/badges suites).
- Ran the portal locally against the real request files and verified via DOM inspection: card order = pending,pending,parked,parked,resolved,resolved; computed border/badge colors match (amber `rgb(255,152,0)`, gray `rgb(158,158,158)`, green `rgb(67,160,71)`); **0 H1s** in any card body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)