### PR TITLE
fix(requests): use large markdown H1 as title, drop small header title

### DIFF
--- a/lib/ui/tabs/requests.js
+++ b/lib/ui/tabs/requests.js
@@ -34,18 +34,14 @@ async function loadRequests() {
         else if (req.status === 'resolved' || req.status === 'completed' || req.status === 'approved') { statusClass = 'tag-output'; borderColor = '#43a047'; }
         else if (req.status === 'rejected') { statusClass = 'tag-feedback'; borderColor = '#e65100'; }
         else if (req.status === 'parked') { statusClass = 'tag-note'; borderColor = '#9e9e9e'; }
-        // Drop the leading H1 from the body — the card header already shows the
-        // title (it is derived from that same H1), so rendering it would duplicate.
-        var _c = req.content || '';
-        var _nl = _c.indexOf('\\n');
-        var _body = (_c.charAt(0) === '#' && _nl !== -1) ? _c.slice(_nl + 1) : _c;
+        // Title comes from the body's markdown H1 (renders large). The header row
+        // is just the status badge + filed date — no small duplicate title span.
         html += '<div class="journal-entry" style="border-left:3px solid ' + borderColor + '">'
           + '<div class="journal-entry-header">'
-          + '<span style="font-weight:600;font-size:14px">' + escapeHtml(req.title) + '</span>'
           + '<span class="tag-badge ' + statusClass + '">' + escapeHtml(req.status) + '</span>'
           + (req.filed ? '<span class="timestamp">Filed ' + escapeHtml(req.filed) + '</span>' : '')
           + '</div>'
-          + '<div class="journal-entry-body md-content">' + renderMarkdown(_body) + '</div>';
+          + '<div class="journal-entry-body md-content">' + renderMarkdown(req.content) + '</div>';
 
         // Reply form
         html += '<div style="margin-top:12px;padding-top:12px;border-top:1px solid #eee">'


### PR DESCRIPTION
Follow-up to #269. That PR removed the body H1 and kept a small (14px) header title span; Rob prefers the **large markdown H1** as the title.

- Header row is now just the **status badge + filed date** (no small title span).
- Body renders the full request markdown again, so its `# Request NNNN: …` H1 is the title and renders large (24px).
- Sort order and status colors from #269 are unchanged.

## Verification
- `node --test` — **156/156 pass** (ui/web-portal/routes).
- Rendered locally against the real request files; DOM check confirms: no small-title span in any header, each body H1 present and computed at **24px**, order = pending,pending,parked,parked,resolved,resolved, borders amber/gray/green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)