### PR TITLE
fix(sandcat): gate readiness on a real WireGuard handshake; bound container setup

### DIFF
--- a/sandcat/scripts/wg-client-init.sh
+++ b/sandcat/scripts/wg-client-init.sh
@@ -54,11 +54,16 @@ mitmproxy_ip=$(getent hosts mitmproxy | awk '{print $1}')
 # docker-compose `sysctls` option.
 ip link add wg0 type wireguard
 
+# persistent-keepalive makes WireGuard initiate the handshake itself rather
+# than waiting for the first outbound packet to trigger it. Without it the
+# tunnel is configured but idle, and the readiness signal below would have
+# nothing to wait on.
 wg set wg0 \
     private-key <(echo "$client_private_key") \
     fwmark 51820 \
     peer "$server_public_key" \
         endpoint mitmproxy:51820 \
+        persistent-keepalive 25 \
         allowed-ips 0.0.0.0/0,::/0
 
 ip address add 10.0.0.1/32 dev wg0
@@ -147,6 +152,42 @@ if [ -n "$docker_network_v6" ]; then
     ip6tables -A OUTPUT -o eth0 -d "$docker_network_v6" -j ACCEPT
 fi
 ip6tables -A OUTPUT -o eth0 -j DROP
+
+# ── Wait for the tunnel to actually carry traffic ───────────────────────────
+# The compose healthcheck is `test -f /tmp/wg-ready`, and docker-compose-create.sh
+# begins installing into the agent container the moment that healthcheck passes.
+# Signalling here on configuration alone is a lie: WireGuard's handshake is lazy,
+# so the rules can be in place while the tunnel has never exchanged a packet.
+# Small requests then trigger the handshake and survive a retry, while a large
+# sustained transfer started in that window stalls — which is how a rebuild ends
+# up hanging on the ~28MB node tarball while apt and the nvm installer succeeded.
+#
+# `wg show wg0 latest-handshakes` reports a unix timestamp per peer, 0 until the
+# first successful handshake. That is the exact condition, not a proxy for it —
+# and it needs no tooling beyond wireguard-tools, which is all this image has
+# (no curl, no ping).
+HANDSHAKE_TIMEOUT="${HANDSHAKE_TIMEOUT:-30}"
+echo "Waiting for WireGuard handshake (timeout ${HANDSHAKE_TIMEOUT}s)..."
+handshake_ok=false
+elapsed=0
+while [ "$elapsed" -lt "$HANDSHAKE_TIMEOUT" ]; do
+    # Fields: <peer-public-key>\t<unix-timestamp>. Any non-zero timestamp means
+    # a handshake completed, so the tunnel is passing traffic.
+    if wg show wg0 latest-handshakes 2>/dev/null | awk '{ if ($2 + 0 > 0) found = 1 } END { exit found ? 0 : 1 }'; then
+        handshake_ok=true
+        break
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+done
+
+if [ "$handshake_ok" != true ]; then
+    echo "ERROR: no WireGuard handshake within ${HANDSHAKE_TIMEOUT}s — the tunnel is configured but not passing traffic." >&2
+    echo "  Refusing to signal readiness; a stack started now would stall on the first large transfer." >&2
+    wg show wg0 >&2 || true
+    exit 1
+fi
+echo "  WireGuard handshake confirmed after ${elapsed}s"
 
 # Signal readiness to containers waiting on the healthcheck.
 touch /tmp/wg-ready

--- a/scripts/docker-compose-create.sh
+++ b/scripts/docker-compose-create.sh
@@ -257,30 +257,79 @@ fi
 # ── Run setup inside agent container ──────────────────────────────────────
 COMPOSE="docker compose -f $STACK_DIR/docker-compose.yml"
 
+# Every step below installs into the agent container's WRITABLE LAYER — the
+# image is bare ubuntu:24.04. A recreate therefore returns the container to a
+# state with no node, no claude and no npm deps, and this script is the only
+# thing that puts them back. That makes it critical that a step which cannot
+# finish is reported as a failure rather than waited on forever.
+#
+# It hangs rather than fails when egress stalls. `nvm install --lts`
+# (vm-setup.sh) fetches from nodejs.org through the WireGuard/mitmproxy chain;
+# if packets are dropped rather than refused, curl waits indefinitely, this
+# script never reaches the final restart below, and the caller sees a rebuild
+# that runs forever. Flenderson spawns this script with no timeout of its own,
+# so its job stays "running" and its UI never reports an outcome.
+#
+# `timeout` runs INSIDE the container (Ubuntu coreutils) so this works from a
+# macOS host, where `timeout` is not present by default. Exit 124 = timed out.
+SETUP_TIMEOUT="${SETUP_TIMEOUT:-600}"
+
+# Run a setup step in the agent container under a timeout, and fail loudly.
+run_setup_step() {
+    local label="$1"; shift
+    local rc=0
+    $COMPOSE exec -T agent timeout "$SETUP_TIMEOUT" bash -c "$1" || rc=$?
+    if [ "$rc" -eq 124 ]; then
+        echo "ERROR: '$label' exceeded ${SETUP_TIMEOUT}s and was killed." >&2
+        echo "  The step stalled rather than failed — usually egress through the" >&2
+        echo "  mitmproxy/WireGuard chain dropping packets for the host it fetches from." >&2
+        echo "  Check egress:  $COMPOSE exec agent curl -sS -m 10 -o /dev/null -w '%{http_code}\\n' https://nodejs.org/dist/index.json" >&2
+        echo "  Raise the bound with SETUP_TIMEOUT=<seconds> if the step is merely slow." >&2
+        exit 124
+    elif [ "$rc" -ne 0 ]; then
+        echo "ERROR: '$label' failed (exit $rc)." >&2
+        exit "$rc"
+    fi
+}
+
 echo ""
 echo "Installing system packages..."
-$COMPOSE exec -T agent bash -c \
+run_setup_step "Installing system packages" \
     "DEBIAN_FRONTEND=noninteractive apt-get update -qq && \
      DEBIAN_FRONTEND=noninteractive apt-get install -y -qq curl jq git cron ca-certificates > /dev/null 2>&1 && \
      update-ca-certificates 2>/dev/null"
 
 echo "Setting container timezone to $AGENT_TIMEZONE..."
-$COMPOSE exec -T agent bash -c \
+run_setup_step "Setting container timezone" \
     "ln -sf /usr/share/zoneinfo/$AGENT_TIMEZONE /etc/localtime && \
      echo $AGENT_TIMEZONE > /etc/timezone"
 
 echo "Running vm-setup.sh..."
-$COMPOSE exec -T agent bash -c \
+run_setup_step "Running vm-setup.sh" \
     "for f in /etc/profile.d/sandcat-*.sh; do [ -r \"\$f\" ] && source \"\$f\"; done; \
      cd $CONTAINER_AGENT_DIR && \
      bash $CONTAINER_FRAMEWORK_DIR/scripts/vm-setup.sh"
 
 echo "Installing framework dependencies..."
-$COMPOSE exec -T agent bash -c \
+run_setup_step "Installing framework dependencies" \
     "for f in /etc/profile.d/sandcat-*.sh; do [ -r \"\$f\" ] && source \"\$f\"; done; \
      source ~/.nvm/nvm.sh && \
      cd $CONTAINER_FRAMEWORK_DIR && \
      npm install --production"
+
+# ── Verify the runtime actually landed ────────────────────────────────────
+# vm-setup.sh guards each install with `command -v`, so a step that half-ran
+# can leave the container without node while every exit code is still 0. The
+# agent is useless in that state — no cycles, no portal — so assert it here
+# instead of discovering it hours later in supervisor.log.
+echo "Verifying node, npm and claude are installed..."
+if ! $COMPOSE exec -T agent timeout 60 bash -c \
+    'export NVM_DIR="$HOME/.nvm"; [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"; \
+     node --version && npm --version && claude --version' ; then
+    echo "ERROR: setup reported success but the runtime is not usable in the container." >&2
+    echo "  Inspect with:  $COMPOSE exec agent bash -c 'export NVM_DIR=\$HOME/.nvm; . \$NVM_DIR/nvm.sh; nvm ls'" >&2
+    exit 1
+fi
 
 # ── Restart agent service for clean boot ──────────────────────────────────
 echo ""

--- a/test/sandcat-setup-timeout.test.sh
+++ b/test/sandcat-setup-timeout.test.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# sandcat-setup-timeout.test.sh — Verify docker-compose-create.sh bounds its
+# in-container setup steps and fails loudly instead of hanging.
+#
+# Context: the agent container is bare ubuntu:24.04; node, claude and the npm
+# deps are installed post-boot into its writable layer by that script. When
+# `nvm install --lts` stalls on egress the step never returns, the script never
+# reaches its final restart, and the caller (flenderson spawns it with no
+# timeout of its own) shows a rebuild that runs forever.
+#
+# We cannot run Docker here, so we exercise run_setup_step's exit-code handling
+# by sourcing the helper with $COMPOSE stubbed. That is the whole of the logic
+# this change adds.
+set -e
+
+FRAMEWORK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$FRAMEWORK_DIR/scripts/docker-compose-create.sh"
+
+OK=0
+FAIL=0
+ok()   { echo "  ok - $*"; OK=$((OK+1)); }
+fail() { echo "  not ok - $*"; FAIL=$((FAIL+1)); }
+
+echo "# sandcat-setup-timeout"
+
+# ── 1. the script is syntactically valid ─────────────────────────────────
+if bash -n "$SCRIPT" 2>/dev/null; then
+  ok "docker-compose-create.sh parses"
+else
+  fail "docker-compose-create.sh has a syntax error"
+fi
+
+# ── 2. every in-container setup step is bounded ──────────────────────────
+# A bare `$COMPOSE exec -T agent bash -c` in the setup block is exactly the
+# unbounded form this change exists to remove.
+SETUP_BLOCK=$(sed -n '/── Run setup inside agent container/,/── Restart agent service/p' "$SCRIPT")
+if echo "$SETUP_BLOCK" | grep -q 'exec -T agent bash -c'; then
+  fail "an unbounded 'exec -T agent bash -c' remains in the setup block"
+else
+  ok "no unbounded exec remains in the setup block"
+fi
+
+if echo "$SETUP_BLOCK" | grep -q 'timeout "\$SETUP_TIMEOUT"'; then
+  ok "setup steps run under SETUP_TIMEOUT"
+else
+  fail "setup steps are not run under a timeout"
+fi
+
+# timeout must run inside the container: macOS hosts have no coreutils timeout.
+if echo "$SETUP_BLOCK" | grep -q 'exec -T agent timeout'; then
+  ok "timeout is invoked inside the container, not on the host"
+else
+  fail "timeout is not invoked inside the container (breaks on macOS hosts)"
+fi
+
+# ── 3. run_setup_step exit-code handling ─────────────────────────────────
+# Extract the helper and drive it with a stubbed $COMPOSE.
+HELPER=$(sed -n '/^run_setup_step() {/,/^}/p' "$SCRIPT")
+if [ -z "$HELPER" ]; then
+  fail "run_setup_step not found"
+else
+  ok "run_setup_step is defined"
+
+  run_case() { # <stub-exit-code> -> prints "rc=<exit> out=<stderr first line>"
+    local stub_rc="$1" tmp
+    tmp=$(mktemp -t sandcat-setup-XXXXXX)
+    {
+      echo 'SETUP_TIMEOUT=600'
+      echo "COMPOSE=\"exit $stub_rc; \""
+      # Stub: swallow the real invocation and return the code under test.
+      echo "$HELPER" | sed 's|\$COMPOSE exec -T agent timeout "\$SETUP_TIMEOUT" bash -c "\$1"|( exit '"$stub_rc"' )|'
+      echo 'run_setup_step "stub step" "true"'
+      echo 'echo REACHED_END'
+    } > "$tmp"
+    bash "$tmp" 2>&1
+    echo "rc=$?"
+    rm -f "$tmp"
+  }
+
+  OUT=$(run_case 0)
+  if echo "$OUT" | grep -q REACHED_END; then
+    ok "a successful step continues"
+  else
+    fail "a successful step did not continue: $OUT"
+  fi
+
+  OUT=$(run_case 124)
+  if echo "$OUT" | grep -q "exceeded 600s"; then
+    ok "a timed-out step (124) reports the timeout"
+  else
+    fail "a timed-out step did not report the timeout: $OUT"
+  fi
+  if echo "$OUT" | grep -q REACHED_END; then
+    fail "a timed-out step continued instead of aborting"
+  else
+    ok "a timed-out step aborts"
+  fi
+
+  OUT=$(run_case 7)
+  if echo "$OUT" | grep -q "failed (exit 7)"; then
+    ok "a failing step reports its exit code"
+  else
+    fail "a failing step did not report its exit code: $OUT"
+  fi
+  if echo "$OUT" | grep -q REACHED_END; then
+    fail "a failing step continued instead of aborting"
+  else
+    ok "a failing step aborts"
+  fi
+fi
+
+# ── 4. the runtime is asserted before the script claims success ──────────
+if grep -q 'Verifying node, npm and claude are installed' "$SCRIPT"; then
+  ok "runtime verification step present"
+else
+  fail "no runtime verification before the final restart"
+fi
+
+# The assertion must precede the final restart, or it verifies nothing useful.
+VERIFY_LINE=$(grep -n 'Verifying node, npm and claude' "$SCRIPT" | head -1 | cut -d: -f1)
+RESTART_LINE=$(grep -n '^\$COMPOSE restart agent' "$SCRIPT" | head -1 | cut -d: -f1)
+if [ -n "$VERIFY_LINE" ] && [ -n "$RESTART_LINE" ] && [ "$VERIFY_LINE" -lt "$RESTART_LINE" ]; then
+  ok "verification runs before the final restart"
+else
+  fail "verification does not precede the final restart ($VERIFY_LINE vs $RESTART_LINE)"
+fi
+
+echo ""
+echo "# passed $OK, failed $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/test/sandcat-wg-readiness.test.sh
+++ b/test/sandcat-wg-readiness.test.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# sandcat-wg-readiness.test.sh — Verify wg-client signals readiness only once the
+# WireGuard tunnel has actually completed a handshake.
+#
+# Context: the compose healthcheck is `test -f /tmp/wg-ready`, and
+# docker-compose-create.sh starts installing into the agent container the moment
+# it passes. WireGuard's handshake is lazy, so signalling on configuration alone
+# leaves a window where the rules exist but no packet has crossed the tunnel.
+# Small fetches trigger the handshake and survive a retry; a large sustained
+# transfer begun in that window stalls. That is the shape of the rebuild hang:
+# apt and the 16KB nvm installer succeeded, the 28MB node tarball did not.
+#
+# WireGuard cannot run here, so we test the decision logic (the awk predicate
+# over `wg show wg0 latest-handshakes`) and the script's structure.
+set -e
+
+FRAMEWORK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$FRAMEWORK_DIR/sandcat/scripts/wg-client-init.sh"
+
+OK=0
+FAIL=0
+ok()   { echo "  ok - $*"; OK=$((OK+1)); }
+fail() { echo "  not ok - $*"; FAIL=$((FAIL+1)); }
+
+echo "# sandcat-wg-readiness"
+
+# ── 1. script still parses ───────────────────────────────────────────────
+if bash -n "$SCRIPT" 2>/dev/null; then
+  ok "wg-client-init.sh parses"
+else
+  fail "wg-client-init.sh has a syntax error"
+fi
+
+# ── 2. the peer initiates rather than waiting for traffic ────────────────
+# Without persistent-keepalive the handshake only fires on the first outbound
+# packet, so the wait below would have nothing to observe.
+if grep -q 'persistent-keepalive' "$SCRIPT"; then
+  ok "peer configured with persistent-keepalive"
+else
+  fail "no persistent-keepalive — handshake would not be initiated"
+fi
+
+# ── 3. readiness is gated on a handshake, and the gate precedes the signal ─
+if grep -q 'latest-handshakes' "$SCRIPT"; then
+  ok "readiness checks latest-handshakes"
+else
+  fail "readiness does not check for a handshake"
+fi
+
+WAIT_LINE=$(grep -n 'latest-handshakes' "$SCRIPT" | head -1 | cut -d: -f1)
+TOUCH_LINE=$(grep -n '^touch /tmp/wg-ready' "$SCRIPT" | head -1 | cut -d: -f1)
+if [ -n "$WAIT_LINE" ] && [ -n "$TOUCH_LINE" ] && [ "$WAIT_LINE" -lt "$TOUCH_LINE" ]; then
+  ok "handshake gate precedes touch /tmp/wg-ready"
+else
+  fail "handshake gate does not precede the readiness signal ($WAIT_LINE vs $TOUCH_LINE)"
+fi
+
+# A failed handshake must abort, not fall through to signalling ready.
+if sed -n "${WAIT_LINE},${TOUCH_LINE}p" "$SCRIPT" | grep -q 'exit 1'; then
+  ok "a missing handshake aborts before signalling readiness"
+else
+  fail "a missing handshake does not abort"
+fi
+
+# ── 4. the handshake predicate itself ────────────────────────────────────
+# Extract the exact awk program the script uses so the test tracks the source.
+AWK_PROG=$(grep -F 'latest-handshakes' "$SCRIPT" | grep -o "awk '.*'" | head -1 | sed "s/^awk '//; s/'$//")
+if [ -z "$AWK_PROG" ]; then
+  fail "could not extract the handshake awk predicate"
+else
+  ok "handshake predicate extracted from the script"
+
+  # returns 0 when a handshake has happened, 1 otherwise
+  probe() { printf '%s\n' "$1" | awk "$AWK_PROG"; }
+
+  # `wg show <if> latest-handshakes` prints "<peer-pubkey>\t<unix-ts>", ts 0
+  # until the first handshake completes.
+  if ! probe "$(printf 'abc123=\t0')"; then
+    ok "no handshake (timestamp 0) is not ready"
+  else
+    fail "timestamp 0 was treated as ready"
+  fi
+
+  if probe "$(printf 'abc123=\t1785200000')"; then
+    ok "a completed handshake is ready"
+  else
+    fail "a real handshake timestamp was not treated as ready"
+  fi
+
+  if ! probe ""; then
+    ok "empty output (interface absent) is not ready"
+  else
+    fail "empty output was treated as ready"
+  fi
+
+  # Multiple peers: any one handshake means the tunnel is up.
+  if probe "$(printf 'aaa=\t0\nbbb=\t1785200000')"; then
+    ok "one handshaked peer among several is ready"
+  else
+    fail "a handshaked peer was missed when another peer had none"
+  fi
+
+  # Guard against a string-compare regression: "0" is falsy numerically but
+  # truthy as a non-empty string, which is why the script forces $2 + 0.
+  if ! probe "$(printf 'aaa=\t0\nbbb=\t0')"; then
+    ok "all-zero timestamps are not ready"
+  else
+    fail "all-zero timestamps were treated as ready"
+  fi
+fi
+
+# ── 5. the wait is bounded ───────────────────────────────────────────────
+if grep -q 'HANDSHAKE_TIMEOUT' "$SCRIPT"; then
+  ok "handshake wait is bounded by HANDSHAKE_TIMEOUT"
+else
+  fail "handshake wait is unbounded"
+fi
+
+echo ""
+echo "# passed $OK, failed $FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## What broke

`fleethd-research` stopped running cycles after `2026-07-28T07:23:41-07:00`. A rebuild recreated its container from bare `ubuntu:24.04`, and the reinstall hung — the script never reached its final restart, so the agent came back with no node, no claude, and no portal. Flenderson spawns the create script with no timeout of its own, so the job stayed "running" indefinitely.

No code change caused it. Nothing in this path had been touched since 2026-07-16. The install path only runs on a **rebuild** — restarts preserve the writable layer — so it simply hadn't been exercised since the stack was built.

## Cause

`wg-client-init.sh` touched `/tmp/wg-ready` as soon as the iptables rules landed, and that file is the compose healthcheck the entire stack gates on. WireGuard's handshake is lazy: `wg set` configures the peer, but nothing crosses the tunnel until traffic arrives. So the healthcheck asserted *configured*, not *passing traffic*, and `docker-compose-create.sh` began installing inside that window.

Small requests trigger the handshake and survive a retry; a large sustained transfer started in that window stalls. That matches the observed failure exactly — apt and the 16KB nvm installer succeeded, the 28MB node tarball did not.

Ruled out along the way: code change, architecture (`aarch64`, native, no source-build fallback), DNS, direct egress (200s sub-second), proxy variables (none set), and nvm itself (4.7s when run directly).

Stated plainly: this is consistent with the evidence but not proven. The failing run's state was never captured and is no longer reproducible now that the tunnel has been up for hours.

## Changes

**1. Gate readiness on a real handshake** (`sandcat/scripts/wg-client-init.sh`)

- `persistent-keepalive 25` on the peer so WireGuard initiates rather than waiting for traffic
- Poll `wg show wg0 latest-handshakes` — a per-peer unix timestamp, `0` until the first handshake — before touching `/tmp/wg-ready`
- Bounded by `HANDSHAKE_TIMEOUT` (30s); a tunnel that never handshakes fails loudly instead of green-lighting a stack that will stall

`wireguard-tools` is already in the image, and there's no curl or ping in it — which is why the handshake timestamp is the right primitive rather than a test fetch.

**2. Bound the setup steps and verify the runtime** (`scripts/docker-compose-create.sh`)

- Each in-container step runs under `timeout`, failing with the step name and exit code. `timeout` runs *inside* the container because macOS hosts have no coreutils `timeout`. Exit 124 prints the egress check to run next.
- Asserts `node`, `npm` and `claude` actually resolve before the final restart. `vm-setup.sh` guards each install with `command -v`, so a half-completed run can leave the container without node while every exit code is still 0 — the exact state this agent was found in.

This second change is insurance, not the fix. A stall can arise another way, and an unbounded rebuild is never the right response to one.

## Testing

Two new suites, `npm test` green:

- `test/sandcat-wg-readiness.test.sh` — 12 assertions. Extracts the awk predicate from the script so the test tracks the source, then drives it with realistic `wg show latest-handshakes` output: timestamp 0, a real timestamp, empty output, mixed peers, and an all-zero guard against a string-compare regression. Plus structural checks that the gate precedes the signal and aborts rather than falling through.
- `test/sandcat-setup-timeout.test.sh` — 12 assertions. Drives `run_setup_step` with stubbed exit codes 0 / 124 / 7 and asserts it continues, reports the timeout, reports the exit code, and aborts. Plus structural checks that no unbounded exec remains and that verification precedes the final restart. This suite caught a real gap during development: my own verification step was initially unbounded.

WireGuard and Docker can't run in this environment, so neither the handshake nor a real rebuild was exercised end to end. The first real test is the next rebuild.

## Not included

Baking node/claude/gh into an image so rebuilds stop depending on the network entirely. That removes the whole failure class — no tunnel, no `--lts` drift, no `:latest` tags — and is the thing that makes UI restart trustworthy. Separate piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)