### PR TITLE
feat: optional bind mounts and an adb client, for device-backed agents

### DIFF
--- a/scripts/docker-compose-create.sh
+++ b/scripts/docker-compose-create.sh
@@ -110,6 +110,23 @@ mkdir -p "$STACK_DIR"
 # makes Docker invent a root-owned directory, which then fails the login write.
 mkdir -p "$HOME/.claude" "$HOME/.codex"
 
+# ── Optional extra bind mounts ────────────────────────────────────────────
+# portal.config.json may declare `mounts: { "<host path>": "<container path>" }`.
+# fleethd-coder uses this for the fleethd-app checkout: that repo cannot be
+# built in the container (no aarch64-Linux Android NDK), so Gradle and Metro run
+# on the host against the SAME directory the agent edits. The shared checkout is
+# the whole mechanism — a private clone would have the host building code the
+# agent never wrote.
+EXTRA_MOUNTS=""
+if [ -f "$AGENT_DIR/portal.config.json" ] && command -v node >/dev/null 2>&1; then
+    EXTRA_MOUNTS=$(node -e '
+      const c = JSON.parse(require("fs").readFileSync(process.argv[1], "utf-8"));
+      for (const [h, g] of Object.entries(c.mounts || {})) {
+        console.log("      - " + h.replace(/^~/, process.env.HOME) + ":" + g);
+      }' "$AGENT_DIR/portal.config.json")
+    [ -n "$EXTRA_MOUNTS" ] && echo "  Extra mounts:" && echo "$EXTRA_MOUNTS"
+fi
+
 # ── Generate compose .env ─────────────────────────────────────────────────
 # Docker Compose reads .env automatically for variable substitution in yml.
 # Preserve existing web password if already generated.
@@ -191,6 +208,7 @@ services:
       - $FRAMEWORK_DIR:$CONTAINER_FRAMEWORK_DIR
       - ${HOME}/.claude:/root/.claude
       - ${HOME}/.codex:/root/.codex
+$EXTRA_MOUNTS
       - sandcat-certs:/sandcat-certs:ro
     entrypoint: ["bash", "$CONTAINER_FRAMEWORK_DIR/sandcat/scripts/app-init.sh", "$CONTAINER_AGENT_DIR"]
     environment:
@@ -201,6 +219,10 @@ services:
       # trust store. Without this it cannot complete a TLS handshake through
       # mitmproxy — every request, including the device-auth login, fails.
       - CODEX_CA_CERTIFICATE=/sandcat-certs/mitmproxy-ca-cert.pem
+      # adb speaks to the HOST's adb server; the client here is only a
+      # client. Set unconditionally — harmless where adb is not installed.
+      - ANDROID_ADB_SERVER_ADDRESS=host.docker.internal
+      - ANDROID_ADB_SERVER_PORT=5037
     restart: unless-stopped
     depends_on:
       wg-client:

--- a/scripts/vm-setup.sh
+++ b/scripts/vm-setup.sh
@@ -123,6 +123,26 @@ if grep -q '"type"[[:space:]]*:[[:space:]]*"codex"' portal.config.json 2>/dev/nu
   fi
 fi
 
+# Step 2c: adb — only for agents that declare a device mount.
+#
+# The container never runs an Android build; it has no NDK and could not. What
+# it needs is the adb CLIENT, which talks to the adb SERVER on the host via
+# ANDROID_ADB_SERVER_ADDRESS. That is enough to install, drive and screenshot an
+# emulator running on the Mac. Gated on `mounts` being declared so no other
+# agent carries an Android toolchain it never invokes.
+if grep -q '"mounts"' portal.config.json 2>/dev/null; then
+  if ! command -v adb &>/dev/null; then
+    echo "--- Installing adb (client only; the server runs on the host) ---"
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq android-sdk-platform-tools-common adb \
+      >/dev/null 2>&1 || apt-get install -y -qq adb >/dev/null 2>&1 || \
+      echo "WARNING: adb install failed — mobile work will be blocked"
+    command -v adb >/dev/null && echo "  $(adb --version 2>/dev/null | head -1)"
+    echo ""
+  else
+    echo "--- adb already installed: $(adb --version 2>/dev/null | head -1) ---"
+  fi
+fi
+
 # Step 3: GitHub CLI
 if ! command -v gh &>/dev/null; then
   echo "--- Installing GitHub CLI ---"


### PR DESCRIPTION
fleethd-coder needs to work on `fleethd-app`, which **cannot be built in a container** — no aarch64-Linux Android NDK, so Gradle and Metro run on the Mac.

## Mounts

`portal.config.json` may now declare `"mounts": { "<host>": "<container>" }`, emitted as bind mounts. The mobile loop needs the host and the agent editing the **same checkout** — a private clone would have the host building code the agent never wrote. Agents without the key are unaffected.

## adb

Installs the adb **client** when an agent declares mounts, and sets `ANDROID_ADB_SERVER_ADDRESS=host.docker.internal` unconditionally. The container never builds; it installs, drives and screenshots an emulator whose adb server is on the host.

**The open question was whether Sandcat's kill switch would block this.** It does not — verified from inside the agent container:

```
status: OKAY
devices: 'emulator-5554\tdevice'
```

Gated on `mounts` so no other agent carries an Android toolchain it never invokes, mirroring the codex gating on `harness.type`.

`npm test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)