### PR TITLE
feat(ui): show agent status in the browser-tab favicon

### DIFF
--- a/lib/ui/client-core.js
+++ b/lib/ui/client-core.js
@@ -124,6 +124,11 @@ async function updateStatusDot() {
   try {
     const res = await fetch('/api/status');
     const data = await res.json();
+
+    // The tab icon rides on this poll rather than one of its own — it is the
+    // same payload, already on a 10s timer.
+    if (typeof setFavicon === 'function') setFavicon(data);
+
     const dot = document.getElementById('status-dot');
     if (dot) {
       if (data.lastWake && data.lastWake.ts) {

--- a/lib/ui/favicon.js
+++ b/lib/ui/favicon.js
@@ -1,0 +1,93 @@
+// favicon.js — the browser-tab icon, driven by whether the agent is running.
+//
+// Four states, because the data supports four and collapsing them would lie:
+//
+//   running    filled green disc     a cycle holds the lock right now
+//   scheduled  clock                 cron is installed AND the daemon is alive,
+//                                    so it WILL fire — just not this second
+//   broken     red ring              cron is installed and the daemon is DEAD.
+//                                    Nothing will fire. This looks identical to
+//                                    "scheduled" in every other part of the UI,
+//                                    which is exactly why it earns its own icon
+//                                    — a clock here would promise a run that is
+//                                    never coming.
+//   idle       grey ring             no cron installed; the agent is off on
+//                                    purpose. Hollow, so "off" reads as absence.
+//
+// Drawn for 16x16, which is the only size that matters — a tab favicon is never
+// shown larger. Everything is sized in a 32-unit viewBox and then halved by the
+// browser, so strokes are deliberately heavy (3 units ≈ 1.5 device px) and the
+// clock's hands sit at 10:10, the angle that stays legible when the glyph is
+// smaller than the text beside it.
+
+const RING = (color) =>
+  `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">` +
+  `<circle cx="16" cy="16" r="12" fill="none" stroke="${color}" stroke-width="4"/></svg>`;
+
+const FAVICONS = {
+  // Filled, with a slightly darker rim so the disc keeps an edge against a
+  // light tab strip and does not dissolve into a green smudge.
+  running:
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">` +
+    `<circle cx="16" cy="16" r="13" fill="#2e7d32"/>` +
+    `<circle cx="16" cy="16" r="13" fill="none" stroke="#1b5e20" stroke-width="2"/></svg>`,
+
+  scheduled:
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">` +
+    `<circle cx="16" cy="17" r="11" fill="none" stroke="#b26a00" stroke-width="3.5"/>` +
+    // Stem and crown, so it reads as a stopwatch rather than a letter O.
+    `<rect x="13" y="1.5" width="6" height="3.5" rx="1.5" fill="#b26a00"/>` +
+    `<rect x="14.75" y="4" width="2.5" height="3" fill="#b26a00"/>` +
+    // Hands at 10:10 — the classic watch-face angle, and the one pair of
+    // directions that never overlaps the stem or each other at this size.
+    `<path d="M16 17 L16 10 M16 17 L21 20" fill="none" stroke="#b26a00" ` +
+    `stroke-width="3" stroke-linecap="round"/></svg>`,
+
+  broken: RING('#c62828'),
+  idle: RING('#9e9e9e'),
+};
+
+/**
+ * Pick the state from an /api/status payload.
+ *
+ * Exported and pure so the branch order is testable without a browser: running
+ * wins over everything (a cycle running with a dead cron daemon is still
+ * running), and a dead daemon beats "scheduled" so the promise is never made.
+ */
+function faviconState(status) {
+  if (!status) return 'idle';
+  if (status.cycleRunning) return 'running';
+  const cron = (status.services && status.services.cron) || {};
+  if (!cron.installed) return 'idle';
+  return cron.daemonRunning ? 'scheduled' : 'broken';
+}
+
+/** Client-side half: the same table, plus the swap on each status poll. */
+function getFaviconJS() {
+  return `
+var FAVICONS = ${JSON.stringify(FAVICONS)};
+
+function faviconState(status) {
+  if (!status) return 'idle';
+  if (status.cycleRunning) return 'running';
+  var cron = (status.services && status.services.cron) || {};
+  if (!cron.installed) return 'idle';
+  return cron.daemonRunning ? 'scheduled' : 'broken';
+}
+
+var _faviconState = null;
+function setFavicon(status) {
+  var state = faviconState(status);
+  // Reassigning href re-decodes the image in some browsers and makes the tab
+  // icon visibly flicker every poll. Only touch the DOM on a real change.
+  if (state === _faviconState) return;
+  var el = document.getElementById('favicon');
+  if (!el) return;
+  el.href = 'data:image/svg+xml,' + encodeURIComponent(FAVICONS[state]);
+  el.title = state;
+  _faviconState = state;
+}
+`;
+}
+
+module.exports = { FAVICONS, faviconState, getFaviconJS };

--- a/lib/ui/shell.js
+++ b/lib/ui/shell.js
@@ -23,6 +23,7 @@ try {
   // Not a git repo or git not available — graceful degradation
 }
 const { getClientCore } = require('./client-core');
+const { FAVICONS, getFaviconJS } = require('./favicon');
 const { getGitHubTabJS } = require('./tabs/github');
 const { getRoadmapTabJS } = require('./tabs/roadmap');
 const { getHealthTabJS } = require('./tabs/health');
@@ -326,6 +327,11 @@ window.addEventListener('popstate', function(e) {
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>${name} — Agent Portal</title>
+<!-- Status favicon. Starts as the neutral ring and is replaced by setFavicon()
+     on the first /api/status poll. An inline default matters: without one the
+     browser requests /favicon.ico, gets the SPA's HTML fallback, and shows its
+     generic icon until the first poll lands. -->
+<link rel="icon" id="favicon" href="data:image/svg+xml,${encodeURIComponent(FAVICONS.idle)}">
 <!-- CDN libs pinned to exact versions so Subresource Integrity can verify them; on bump, update the version AND recompute the integrity hash together. -->
 <script src="https://cdn.jsdelivr.net/npm/marked@15.0.12/marked.min.js" integrity="sha384-948ahk4ZmxYVYOc+rxN1H2gM1EJ2Duhp7uHtZ4WSLkV4Vtx5MUqnV+l7u9B+jFv+" crossorigin="anonymous"><\/script>
 <script src="https://cdn.jsdelivr.net/npm/dompurify@3.4.11/dist/purify.min.js" integrity="sha384-o44XUELLEnv/iSlA1NWxBweqbD4TSR0qgq2VzVsxtkHS989JJjGKSE9vkfo5MN4K" crossorigin="anonymous"><\/script>
@@ -351,6 +357,7 @@ ${sidebarHTML}
 
 <script>
 const PORTAL_CONFIG = ${JSON.stringify(portalConfig)};
+${getFaviconJS()}
 ${getClientCore()}
 ${projectSidebarJS}
 ${tabJS}

--- a/test/favicon.test.js
+++ b/test/favicon.test.js
@@ -1,0 +1,103 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { FAVICONS, faviconState, getFaviconJS } = require('../lib/ui/favicon');
+
+const status = (cycleRunning, cron) => ({
+  cycleRunning,
+  services: cron === undefined ? {} : { cron },
+});
+
+describe('faviconState', () => {
+  it('running wins over cron state', () => {
+    assert.equal(faviconState(status(true, { installed: true, daemonRunning: true })), 'running');
+    assert.equal(faviconState(status(true, { installed: false })), 'running');
+  });
+
+  it('a running cycle with a DEAD daemon is still running', () => {
+    // The lock is the ground truth for "is it working right now". Cron only
+    // says whether another one will start later.
+    assert.equal(faviconState(status(true, { installed: true, daemonRunning: false })), 'running');
+  });
+
+  it('installed and alive, idle right now → scheduled', () => {
+    assert.equal(faviconState(status(false, { installed: true, daemonRunning: true })), 'scheduled');
+  });
+
+  it('installed but the daemon is dead → broken, never scheduled', () => {
+    // The whole reason this state exists: a clock would promise a run that is
+    // not coming. Nothing else in the UI distinguishes these two.
+    assert.equal(faviconState(status(false, { installed: true, daemonRunning: false })), 'broken');
+  });
+
+  it('no cron installed → idle', () => {
+    assert.equal(faviconState(status(false, { installed: false, daemonRunning: false })), 'idle');
+  });
+
+  it('missing or malformed payloads degrade to idle, never throw', () => {
+    assert.equal(faviconState(status(false)), 'idle');       // no cron key
+    assert.equal(faviconState({ cycleRunning: false }), 'idle');  // no services
+    assert.equal(faviconState({}), 'idle');
+    assert.equal(faviconState(null), 'idle');
+    assert.equal(faviconState(undefined), 'idle');
+  });
+});
+
+describe('FAVICONS', () => {
+  it('defines exactly the four states faviconState can return', () => {
+    assert.deepEqual(Object.keys(FAVICONS).sort(), ['broken', 'idle', 'running', 'scheduled']);
+  });
+
+  it('every icon is a well-formed standalone SVG', () => {
+    for (const [name, svg] of Object.entries(FAVICONS)) {
+      assert.match(svg, /^<svg xmlns="http:\/\/www\.w3\.org\/2000\/svg"/, name);
+      assert.match(svg, /<\/svg>$/, name);
+      assert.match(svg, /viewBox="0 0 32 32"/, name);
+    }
+  });
+
+  it('all four are visually distinct', () => {
+    // idle and broken are the same ring shape and differ only by colour, which
+    // makes them the easy pair to break with a careless refactor.
+    assert.equal(new Set(Object.values(FAVICONS)).size, 4);
+    assert.notEqual(FAVICONS.idle, FAVICONS.broken);
+  });
+
+  it('the two ring states carry their intended colours', () => {
+    assert.match(FAVICONS.idle, /stroke="#9e9e9e"/);
+    assert.match(FAVICONS.broken, /stroke="#c62828"/);
+  });
+
+  it('survives URI encoding for a data: href', () => {
+    for (const [name, svg] of Object.entries(FAVICONS)) {
+      const uri = 'data:image/svg+xml,' + encodeURIComponent(svg);
+      assert.equal(decodeURIComponent(uri.slice('data:image/svg+xml,'.length)), svg, name);
+    }
+  });
+});
+
+describe('getFaviconJS', () => {
+  it('emits a client copy of the same table', () => {
+    const js = getFaviconJS();
+    assert.match(js, /function setFavicon\(/);
+    assert.match(js, /function faviconState\(/);
+    // The client gets the icons by serialising the server's object, so the two
+    // halves cannot drift apart.
+    assert.ok(js.includes(JSON.stringify(FAVICONS)));
+  });
+
+  it('the emitted client state machine agrees with the server one', () => {
+    // Evaluate the emitted source and run the same cases through it, so a
+    // divergence between the two copies fails here rather than in a browser.
+    const clientFaviconState = new Function(`${getFaviconJS()}; return faviconState;`)();
+    const cases = [
+      status(true, { installed: false }),
+      status(false, { installed: true, daemonRunning: true }),
+      status(false, { installed: true, daemonRunning: false }),
+      status(false, { installed: false }),
+      {}, null,
+    ];
+    for (const c of cases) {
+      assert.equal(clientFaviconState(c), faviconState(c), JSON.stringify(c));
+    }
+  });
+});


### PR DESCRIPTION
Tells you from the browser tab whether an agent is working, without opening it.

## States

| Icon | State | Meaning |
|---|---|---|
| filled green disc | `running` | a cycle holds the lock right now |
| stopwatch | `scheduled` | cron installed **and** daemon alive — it will fire |
| red ring | `broken` | cron installed and the daemon is **dead** |
| grey ring | `idle` | no cron; off on purpose |

**Four states, not three.** `installed: true, daemonRunning: false` looks identical to a healthy schedule everywhere else in the UI, and it means nothing will ever fire. A clock there would promise a run that isn't coming, so it gets its own colour.

## No new plumbing

`/api/status` already returns `cycleRunning` (via `isCycleLocked`, which covers the `.starting` marker window before `flock` is taken) and `services.cron.{installed,daemonRunning}`. `updateStatusDot()` already polls it every 10s. The favicon rides that — no new endpoint, no new timer.

Icons are inline SVG data URIs: no asset, no build step, no dependency, in a zero-dependency project. Drawn in a 32-unit viewBox for a 16px tab — strokes at 3–4 units, stopwatch hands at 10:10, the one pair of angles that clears both the stem and itself at that size.

Two details that are easy to get wrong:
- The `<link>` carries the idle icon **inline**, so there's no flash of the browser default before the first poll. Without it the browser requests `/favicon.ico`, gets the SPA's HTML fallback, and shows its generic icon.
- `setFavicon` only touches the DOM on a real state change. Reassigning `href` re-decodes the image and visibly flickers the tab otherwise.

Server and client share one table — `getFaviconJS()` serialises the same object into the page, and a test evaluates the emitted source and runs both copies through identical cases, so they can't drift.

## Verified

In a browser against a real portal instance, not just unit tests:

- all four render distinguishably at 16px in a simulated tab strip
- all four hrefs unique — `idle` and `broken` are the same ring shape differing only by colour, so that was the pair worth checking
- five identical polls → **0** DOM writes; one genuine change → **1**
- full suite **573/573** node tests, shell suites clean
