### PR TITLE
fix: stop .env redefining the shell, and stop the timeout message guessing

### DIFF
--- a/scripts/commit.sh
+++ b/scripts/commit.sh
@@ -17,7 +17,7 @@ done
 
 # Source .env if GH_TOKEN still not set (pre-Sandcat fallback)
 if [ -z "$GH_TOKEN" ] && [ -f "$AGENT_DIR/.env" ]; then
-  set -a; . "$AGENT_DIR/.env"; set +a
+  . "$FRAMEWORK_DIR/scripts/load-env.sh"; load_agent_env "$AGENT_DIR/.env"
 fi
 
 # Read agent config

--- a/scripts/docker-compose-create.sh
+++ b/scripts/docker-compose-create.sh
@@ -313,10 +313,32 @@ run_setup_step() {
     $COMPOSE exec -T agent timeout "$SETUP_TIMEOUT" bash -c "$1" || rc=$?
     if [ "$rc" -eq 124 ]; then
         echo "ERROR: '$label' exceeded ${SETUP_TIMEOUT}s and was killed." >&2
-        echo "  The step stalled rather than failed — usually egress through the" >&2
-        echo "  mitmproxy/WireGuard chain dropping packets for the host it fetches from." >&2
-        echo "  Check egress:  $COMPOSE exec agent curl -sS -m 10 -o /dev/null -w '%{http_code}\\n' https://nodejs.org/dist/index.json" >&2
-        echo "  Raise the bound with SETUP_TIMEOUT=<seconds> if the step is merely slow." >&2
+        echo "" >&2
+        # This message used to assert egress as the cause and print an egress
+        # probe. The one time it mattered, egress was perfect (30MB at 13MB/s)
+        # and the real cause was a `PWD=` line in the agent's .env sending nvm's
+        # .nvmrc search into an infinite loop. Naming a likely cause reads as a
+        # diagnosis, and two people chased the network for an afternoon on the
+        # strength of it. A bound that cannot say WHICH command stalled should
+        # not guess — it should say how to find out.
+        echo "  The step stalled rather than failed, so the cause is whatever it was" >&2
+        echo "  running when the clock ran out. Get that first — do not assume:" >&2
+        echo "" >&2
+        echo "    $COMPOSE exec -T agent timeout 120 bash -c 'cd $CONTAINER_AGENT_DIR && bash -x <the script> 2>&1'" >&2
+        echo "" >&2
+        echo "  The last '+' line it prints is the command that hung. Common causes," >&2
+        echo "  in the order they have actually occurred:" >&2
+        echo "    - .env assigns a shell-reserved name (PWD, HOME, PATH). Sourcing it" >&2
+        echo "      corrupts the shell itself and hangs something unrelated later." >&2
+        echo "      scripts/load-env.sh now warns and ignores these; check the output." >&2
+        echo "    - egress genuinely stalling through the mitmproxy/WireGuard chain." >&2
+        echo "      Test with a LARGE body, not a small one — a fast index.json says" >&2
+        echo "      nothing about a 30MB tarball:" >&2
+        echo "      $COMPOSE exec -T agent curl -sS -m 120 -o /dev/null -w '%{speed_download}B/s\\n' https://nodejs.org/dist/index.tab" >&2
+        echo "    - a step waiting on stdin it will never receive." >&2
+        echo "" >&2
+        echo "  Raise the bound with SETUP_TIMEOUT=<seconds> only once you know it is" >&2
+        echo "  genuinely slow rather than stuck." >&2
         exit 124
     elif [ "$rc" -ne 0 ]; then
         echo "ERROR: '$label' failed (exit $rc)." >&2

--- a/scripts/load-env.sh
+++ b/scripts/load-env.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# scripts/load-env.sh — source an agent's .env WITHOUT letting it redefine the
+# shell's own variables.
+#
+# Why this exists, in full, because the symptom pointed nowhere near the cause:
+#
+# An agent's .env contained `PWD=<a password>`. `set -a; . .env; set +a` duly
+# set PWD — the shell's current-working-directory variable — to a string with no
+# '/' in it. Everything kept working until vm-setup.sh sourced nvm.sh, whose
+# nvm_find_up walks up the tree looking for .nvmrc:
+#
+#     path_="${PWD}"
+#     while [ "$path_" != "" ] && [ "$path_" != '.' ] && [ ! -f "$path_/.nvmrc" ]; do
+#       path_=${path_%/*}
+#     done
+#
+# With no '/' in PWD, `${path_%/*}` strips nothing, the loop never advances, and
+# it spins forever. No error, no output, no CPU spike — a container create that
+# hangs until something kills it. Two agents were down for an afternoon, and the
+# investigation went to the network, the proxy and the download timeout first,
+# because a hang inside nvm looks like a problem with nvm.
+#
+# The lesson is not "do not name a variable PWD". It is that a config file must
+# not be able to redefine the interpreter's own state, because the resulting
+# failure surfaces arbitrarily far from the file that caused it.
+#
+# Approach: snapshot, source normally, compare, restore what the file changed
+# and say so loudly. Restoring rather than pre-filtering keeps the real shell
+# parser in charge, so quoting, multi-line values and `export` prefixes behave
+# exactly as they always did — a grep-based filter cannot promise that. Nothing
+# executes between the source and the restore, so the window in which a value is
+# wrong contains no code that could observe it.
+#
+# Usage:
+#   . "$FRAMEWORK_DIR/scripts/load-env.sh"
+#   load_agent_env "$AGENT_DIR/.env"     # no-op when the file is absent
+
+# Names whose meaning belongs to the shell AND which a .env could plausibly set.
+#
+# Deliberately excludes UID/EUID/PPID/BASHOPTS/SHELLOPTS (readonly — bash already
+# refuses the assignment) and LINENO/RANDOM/SECONDS/FUNCNAME (dynamic — they
+# change between the snapshot and the comparison, so guarding them reports a
+# clobber on every single load). Guarding a name bash already protects buys
+# nothing and costs a false alarm on every cycle.
+LOAD_ENV_RESERVED="PWD OLDPWD HOME PATH IFS SHELL BASH_ENV ENV CDPATH"
+
+load_agent_env() {
+  local envfile="${1:?load_agent_env: no .env path given}"
+  [ -f "$envfile" ] || return 0
+
+  # Snapshot. Set-vs-unset is tracked separately from the value: a name the file
+  # INTRODUCES must end up unset again, not set to empty string.
+  local _n
+  for _n in $LOAD_ENV_RESERVED; do
+    if [ -n "${!_n+x}" ]; then
+      eval "_LE_HAD_${_n}=1; _LE_VAL_${_n}=\${${_n}}"
+    else
+      eval "_LE_HAD_${_n}=0; _LE_VAL_${_n}="
+    fi
+  done
+
+  set -a
+  # shellcheck disable=SC1090
+  . "$envfile"
+  set +a
+
+  local _clobbered="" _had _val _now
+  for _n in $LOAD_ENV_RESERVED; do
+    eval "_had=\${_LE_HAD_${_n}}; _val=\${_LE_VAL_${_n}}"
+    if [ -n "${!_n+x}" ]; then _now="1:${!_n}"; else _now="0:"; fi
+    if [ "$_now" != "${_had}:${_val}" ]; then
+      _clobbered="$_clobbered $_n"
+      # Plain assignment, NOT `declare` — inside a function `declare` creates a
+      # local and the global stays clobbered, which is exactly how the first
+      # version of this guard failed its own test.
+      if [ "$_had" = "1" ]; then eval "${_n}=\${_LE_VAL_${_n}}"; else unset "$_n"; fi
+    fi
+    unset "_LE_HAD_${_n}" "_LE_VAL_${_n}"
+  done
+
+  if [ -n "$_clobbered" ]; then
+    echo "WARNING: $envfile assigns shell-reserved variable(s):$_clobbered" >&2
+    echo "  Those names belong to the shell. Reassigning them breaks things far" >&2
+    echo "  from this file — a PWD with no '/' in it makes nvm's .nvmrc search" >&2
+    echo "  loop forever, which stalls a container build with no error at all." >&2
+    echo "  The assignment(s) were IGNORED. Rename them in $envfile." >&2
+  fi
+
+  return 0
+}

--- a/scripts/respond.sh
+++ b/scripts/respond.sh
@@ -16,7 +16,7 @@ export NVM_DIR="$HOME/.nvm"
 
 # Source .env
 if [ -f "$AGENT_DIR/.env" ]; then
-  set -a; . "$AGENT_DIR/.env"; set +a
+  . "$FRAMEWORK_DIR/scripts/load-env.sh"; load_agent_env "$AGENT_DIR/.env"
 fi
 
 # Read agent config

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -13,7 +13,7 @@ export NVM_DIR="$HOME/.nvm"
 
 # Source .env
 if [ -f "$AGENT_DIR/.env" ]; then
-  set -a; . "$AGENT_DIR/.env"; set +a
+  . "$FRAMEWORK_DIR/scripts/load-env.sh"; load_agent_env "$AGENT_DIR/.env"
 fi
 
 # Read agent config

--- a/scripts/telegram-respond.sh
+++ b/scripts/telegram-respond.sh
@@ -22,7 +22,7 @@ done
 
 # Source .env if present (pre-Sandcat containers use .env for secrets)
 if [ -f "$AGENT_DIR/.env" ]; then
-  set -a; . "$AGENT_DIR/.env"; set +a
+  . "$FRAMEWORK_DIR/scripts/load-env.sh"; load_agent_env "$AGENT_DIR/.env"
 fi
 
 # Read agent config

--- a/scripts/telegram_poll.sh
+++ b/scripts/telegram_poll.sh
@@ -86,7 +86,7 @@ main() {
 
   # Source .env for credentials if not already in environment
   if [ -z "$TELEGRAM_TOKEN" ] && [ -f "$AGENT_DIR/.env" ]; then
-    set -a; . "$AGENT_DIR/.env"; set +a
+    . "$FRAMEWORK_DIR/scripts/load-env.sh"; load_agent_env "$AGENT_DIR/.env"
   fi
 
   if [ -z "$TELEGRAM_TOKEN" ] || [ -z "$TELEGRAM_CHAT_ID" ]; then

--- a/scripts/vm-setup.sh
+++ b/scripts/vm-setup.sh
@@ -24,7 +24,7 @@ cd "$AGENT_DIR"
 
 # Source .env for GH_TOKEN and git identity
 if [ -f "$AGENT_DIR/.env" ]; then
-  set -a; . "$AGENT_DIR/.env"; set +a
+  . "$FRAMEWORK_DIR/scripts/load-env.sh"; load_agent_env "$AGENT_DIR/.env"
 fi
 
 # Read agent config if agent.yaml exists

--- a/scripts/wake.sh
+++ b/scripts/wake.sh
@@ -34,7 +34,7 @@ done
 
 # Source .env if present (pre-Sandcat containers use .env for secrets)
 if [ -f "$AGENT_DIR/.env" ]; then
-  set -a; . "$AGENT_DIR/.env"; set +a
+  . "$FRAMEWORK_DIR/scripts/load-env.sh"; load_agent_env "$AGENT_DIR/.env"
   step ".env sourced (GH_TOKEN=$( [ -n "${GH_TOKEN:-}" ] && echo set || echo MISSING ))"
 else
   step ".env not found at $AGENT_DIR/.env (skipping — using container environment)"

--- a/test/load-env.test.sh
+++ b/test/load-env.test.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# test/load-env.test.sh — the .env guard that keeps a config file from
+# redefining the shell's own variables.
+#
+# The case that motivated it: an agent's .env carried `PWD=<a password>`, and
+# sourcing it sent nvm's .nvmrc search into an infinite loop, stalling container
+# builds with no error output at all.
+
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FRAMEWORK_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0; fail=0
+ok()   { echo "  ok - $1"; pass=$((pass+1)); }
+notok() { echo "  not ok - $1"; fail=$((fail+1)); }
+check() { [ "$2" = "$3" ] && ok "$1" || notok "$1 (got '$2', want '$3')"; }
+
+# shellcheck disable=SC1090
+. "$FRAMEWORK_DIR/scripts/load-env.sh"
+
+echo "# load_agent_env"
+
+# Test-only variable names. Never GH_TOKEN or anything else that carries a real
+# secret in a developer's environment: a failing assertion prints the value it
+# got, and the first draft of this file printed a live GitHub token to the
+# terminal for exactly that reason.
+unset LOAD_ENV_TEST_VAR LOAD_ENV_TEST_NAME CDPATH
+
+printf 'PWD=EoVFt*9!Dmj1eop#\nLOAD_ENV_TEST_VAR=abc123\n' > "$TMP/bad.env"
+printf 'LOAD_ENV_TEST_NAME=Rob\n'                          > "$TMP/good.env"
+printf 'HOME=/nowhere\nPATH=/bin\n'                        > "$TMP/worse.env"
+
+# Capture stderr through a FILE, never `$(...)`: command substitution runs the
+# function in a subshell, so every variable it sets is discarded and the
+# assertions below silently test the parent's environment instead.
+run_load() { load_agent_env "$1" 2>"$TMP/err"; }
+
+## Test 1: a PWD assignment is ignored, and the rest of the file still loads
+BEFORE_PWD="$PWD"
+run_load "$TMP/bad.env"
+check "PWD survives a .env that assigns it" "$PWD" "$BEFORE_PWD"
+check "non-reserved vars still import"      "${LOAD_ENV_TEST_VAR:-}" "abc123"
+if grep -q "shell-reserved" "$TMP/err" && grep -q "PWD" "$TMP/err"; then
+  ok "warns, naming PWD"
+else
+  notok "warns, naming PWD"
+fi
+
+## Test 2: the actual hang — nvm_find_up's walk must terminate
+p="$PWD"; n=0
+while [ "$p" != "" ] && [ "$p" != '.' ] && [ ! -f "$p/.nvmrc" ] && [ "$n" -lt 200 ]; do
+  p=${p%/*}; n=$((n+1))
+done
+[ "$n" -lt 200 ] && ok "nvm_find_up-style walk terminates ($n steps)" \
+                 || notok "nvm_find_up-style walk still loops forever"
+
+## Test 3: a clean .env is silent and exports normally
+run_load "$TMP/good.env"
+check "clean .env produces no warning" "$(cat "$TMP/err")" ""
+check "clean .env imports"             "${LOAD_ENV_TEST_NAME:-}" "Rob"
+check "set -a export is preserved"     "$(env | grep -c '^LOAD_ENV_TEST_NAME=')" "1"
+
+## Test 4: HOME and PATH are protected too
+H="$HOME"; P="$PATH"
+run_load "$TMP/worse.env"
+check "HOME survives" "$HOME" "$H"
+check "PATH survives" "$PATH" "$P"
+
+## Test 5: a reserved name the file INTRODUCES ends up unset, not empty
+unset CDPATH
+printf 'CDPATH=/tmp\n' > "$TMP/intro.env"
+run_load "$TMP/intro.env"
+[ -z "${CDPATH+x}" ] && ok "an introduced reserved name is unset, not empty" \
+                     || notok "CDPATH leaked as '${CDPATH:-}'"
+
+## Test 6: dynamic and readonly names must not produce false warnings.
+## LINENO/RANDOM change on their own and UID/PPID are readonly; guarding them
+## would fire on every single load and train everyone to ignore the warning.
+run_load "$TMP/good.env"
+check "no false warning from dynamic/readonly names" "$(cat "$TMP/err")" ""
+
+## Test 7: a missing .env is a silent no-op
+load_agent_env "$TMP/nonexistent.env"; rc=$?
+check "missing .env returns 0" "$rc" "0"
+
+echo ""
+echo "# Results: $pass/$((pass+fail)) passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Two agents were down for an afternoon and every container create stalled with no error, no output and no CPU spike.

## The cause

An agent's `.env` contained `PWD=<a password>`. `set -a; . .env; set +a` set `PWD` — the shell's own working-directory variable — to a string with no `/` in it. Nothing broke until `vm-setup.sh` sourced `nvm.sh`, whose `nvm_find_up` walks up the tree:

```sh
path_="${PWD}"
while [ "$path_" != "" ] && [ "$path_" != '.' ] && [ ! -f "$path_/.nvmrc" ]; do
  path_=${path_%/*}
done
```

With no `/` in `PWD`, `${path_%/*}` strips nothing, the loop never advances, and it spins forever.

Three-way confirmation: the two agents that hung both had a `.env` whose only variable was `PWD`; the one that restarted fine had no `.env` at all.

## Fix 1 — `scripts/load-env.sh`

Replaces the byte-identical three-line source block in all **seven** scripts that read `.env`. Snapshot the shell-reserved names, source normally, restore anything the file changed, warn loudly.

Restoring beats pre-filtering: the real shell parser stays in charge, so quoting, multi-line values and `export` prefixes behave exactly as before — a grep-based filter can't promise that. Nothing executes between the source and the restore.

The reserved list deliberately omits `UID`/`PPID`/`BASHOPTS` (readonly — bash already refuses) and `LINENO`/`RANDOM`/`SECONDS` (dynamic — they change between snapshot and comparison, so guarding them fires on *every* load and trains everyone to ignore the warning). The first draft included both and failed its own test.

## Fix 2 — the timeout message

`run_setup_step` asserted egress as the cause and printed an egress probe. Egress was perfect — **30MB at 13MB/s** — and that message sent two people to the network, the proxy and `SETUP_TIMEOUT` for an afternoon while the real cause sat in `.env`.

It now says how to *find* the stalled command (`bash -x`, read the last `+` line) rather than guessing, lists the causes that have actually occurred, and notes that a fast `index.json` says nothing about a 30MB tarball.

## Verified

12 new shell tests: the real `bad.env`, the `nvm_find_up` walk terminating, `HOME`/`PATH` protection, an introduced reserved name ending up **unset** rather than empty, and silence on a clean file.

Full suite green — 573 node tests, all shell suites. The existing `sandcat-setup-timeout` guard caught my new help text embedding a literal unbounded `exec -T agent bash -c`; the example now bounds it the way the real steps do, which is better advice anyway.
